### PR TITLE
Introduce 'given' stage for running the same query on multiple inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5811,7 +5811,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=810e94e12961e4408ee9433d010fd68691783973#810e94e12961e4408ee9433d010fd68691783973"
+source = "git+https://github.com/typedb/typedb-protocol?rev=bb9c513d4dcff269feb88015dcf99354ad378657#bb9c513d4dcff269feb88015dcf99354ad378657"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -429,10 +429,10 @@ dependencies = [
  "base64",
  "bytes 1.11.1",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -464,7 +464,7 @@ dependencies = [
  "async-trait",
  "bytes 1.11.1",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -488,7 +488,7 @@ dependencies = [
  "fastrand 2.4.1",
  "futures-util",
  "headers",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -509,12 +509,12 @@ dependencies = [
  "arc-swap",
  "bytes 1.11.1",
  "fs-err",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
@@ -558,7 +558,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -566,7 +566,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -578,9 +578,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -654,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecount"
@@ -723,14 +723,14 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1363,15 +1363,15 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1421,9 +1421,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -1914,7 +1914,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata",
- "regex-syntax 0.8.10",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -1961,16 +1961,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes 1.11.1",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.1",
+ "http 1.4.2",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -2016,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -2047,7 +2047,7 @@ dependencies = [
  "base64",
  "bytes 1.11.1",
  "headers-core",
- "http 1.4.1",
+ "http 1.4.2",
  "httpdate",
  "mime",
  "sha1",
@@ -2059,7 +2059,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.1",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -2153,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes 1.11.1",
  "itoa",
@@ -2179,7 +2179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes 1.11.1",
- "http 1.4.1",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -2190,7 +2190,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes 1.11.1",
  "futures-core",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -2268,16 +2268,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes 1.11.1",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.1",
+ "h2 0.4.14",
+ "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -2311,10 +2311,10 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.1",
- "hyper 1.9.0",
+ "http 1.4.2",
+ "hyper 1.10.1",
  "hyper-util",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -2327,7 +2327,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2344,14 +2344,14 @@ dependencies = [
  "bytes 1.11.1",
  "futures-channel",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2498,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -2530,7 +2530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2684,13 +2684,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2766,9 +2765,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2816,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 dependencies = [
  "value-bag",
 ]
@@ -2901,9 +2900,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -2937,9 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2972,7 +2971,7 @@ dependencies = [
  "bytes 1.11.1",
  "encoding_rs",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "httparse",
  "memchr",
  "mime",
@@ -3012,7 +3011,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3020,11 +3019,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3081,9 +3080,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-format"
@@ -3128,7 +3127,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -3149,7 +3148,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -3160,7 +3159,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -3193,7 +3192,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3211,7 +3210,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -3224,7 +3223,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3235,7 +3234,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -3247,7 +3246,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -3326,13 +3325,13 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
 dependencies = [
  "android_system_properties",
  "log",
- "nix 0.30.1",
+ "nix 0.31.3",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -3538,18 +3537,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3845,8 +3844,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.39",
- "socket2 0.6.3",
+ "rustls 0.23.40",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3865,7 +3864,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3883,7 +3882,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4067,7 +4066,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4092,14 +4091,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.10",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -4110,7 +4109,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.10",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -4121,9 +4120,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "remove_dir_all"
@@ -4145,10 +4144,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
@@ -4156,7 +4155,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4216,9 +4215,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.3"
+version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835a57a69104632d64deb0df2e09a69945cd7a6eab4070fc9b1d7e50cf6c3edc"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
 dependencies = [
  "libc",
  "rtoolbox",
@@ -4276,7 +4275,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4289,7 +4288,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -4312,9 +4311,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -4340,9 +4339,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
@@ -4403,7 +4402,7 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -4508,7 +4507,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -4521,7 +4520,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4552,7 +4551,7 @@ checksum = "3a7332159e544e34db06b251b1eda5e546bd90285c3f58d9c8ff8450b484e0da"
 dependencies = [
  "httpdate",
  "reqwest",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
@@ -4708,9 +4707,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -4728,9 +4727,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4774,7 +4773,7 @@ dependencies = [
  "executor",
  "function",
  "futures",
- "http 1.4.1",
+ "http 1.4.2",
  "hyper 0.14.32",
  "ir",
  "itertools 0.14.0",
@@ -4889,6 +4888,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4912,9 +4917,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -4984,9 +4989,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5072,9 +5077,9 @@ dependencies = [
 
 [[package]]
 name = "str_stack"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
 
 [[package]]
 name = "streamer"
@@ -5466,7 +5471,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5499,7 +5504,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -5562,17 +5567,17 @@ dependencies = [
  "axum",
  "base64",
  "bytes 1.11.1",
- "h2 0.4.13",
- "http 1.4.1",
+ "h2 0.4.14",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs 0.8.4",
  "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
@@ -5651,10 +5656,10 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes 1.11.1",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
  "tower 0.5.3",
@@ -5765,7 +5770,7 @@ dependencies = [
  "byteorder",
  "bytes 1.11.1",
  "data-encoding",
- "http 1.4.1",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.8.6",
@@ -5806,7 +5811,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=9a45ab625534a01afe5ecf89acaa06cecc92cafb#9a45ab625534a01afe5ecf89acaa06cecc92cafb"
+source = "git+https://github.com/typedb/typedb-protocol?rev=810e94e12961e4408ee9433d010fd68691783973#810e94e12961e4408ee9433d010fd68691783973"
 dependencies = [
  "prost",
  "tonic",
@@ -5861,14 +5866,14 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?tag=3.11.0#01bee6696be8de416ca59ac7660a446583a29306"
+source = "git+https://github.com/typedb/typeql?rev=e16626a2129c554436195384a9fda3a3ea36fa2f#e16626a2129c554436195384a9fda3a3ea36fa2f"
 dependencies = [
  "chrono",
  "itertools 0.14.0",
@@ -5921,9 +5926,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -5952,7 +5957,7 @@ dependencies = [
  "base64",
  "log",
  "once_cell",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.11",
@@ -6007,9 +6012,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6093,9 +6098,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6106,9 +6111,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6116,9 +6121,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6126,9 +6131,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6139,9 +6144,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
@@ -6174,7 +6179,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -6182,9 +6187,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6656,7 +6661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -6732,9 +6737,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6755,18 +6760,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6775,9 +6780,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5811,7 +5811,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=bb9c513d4dcff269feb88015dcf99354ad378657#bb9c513d4dcff269feb88015dcf99354ad378657"
+source = "git+https://github.com/typedb/typedb-protocol?rev=3a39f0b94fd7ea316ba5a4f74d44d5afc454cedf#3a39f0b94fd7ea316ba5a4f74d44d5afc454cedf"
 dependencies = [
  "prost",
  "tonic",
@@ -5873,7 +5873,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=e16626a2129c554436195384a9fda3a3ea36fa2f#e16626a2129c554436195384a9fda3a3ea36fa2f"
+source = "git+https://github.com/typedb/typeql?rev=405c5383a35277acc40bb0921ffd2e8eb1b1b00d#405c5383a35277acc40bb0921ffd2e8eb1b1b00d"
 dependencies = [
  "chrono",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,8 +222,8 @@ features = {}
 
 		[workspace.dependencies.typeql]
 			features = []
+			rev = "e16626a2129c554436195384a9fda3a3ea36fa2f"
 			git = "https://github.com/typedb/typeql"
-			tag = "3.11.0"
 			default-features = false
 
 		[workspace.dependencies.cache]
@@ -493,7 +493,7 @@ features = {}
 
 		[workspace.dependencies.typedb-protocol]
 			features = []
-			rev = "9a45ab625534a01afe5ecf89acaa06cecc92cafb"
+			rev = "810e94e12961e4408ee9433d010fd68691783973"
 			git = "https://github.com/typedb/typedb-protocol"
 			default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -493,7 +493,7 @@ features = {}
 
 		[workspace.dependencies.typedb-protocol]
 			features = []
-			rev = "810e94e12961e4408ee9433d010fd68691783973"
+			rev = "bb9c513d4dcff269feb88015dcf99354ad378657"
 			git = "https://github.com/typedb/typedb-protocol"
 			default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,7 +222,7 @@ features = {}
 
 		[workspace.dependencies.typeql]
 			features = []
-			rev = "e16626a2129c554436195384a9fda3a3ea36fa2f"
+			rev = "405c5383a35277acc40bb0921ffd2e8eb1b1b00d"
 			git = "https://github.com/typedb/typeql"
 			default-features = false
 
@@ -493,7 +493,7 @@ features = {}
 
 		[workspace.dependencies.typedb-protocol]
 			features = []
-			rev = "bb9c513d4dcff269feb88015dcf99354ad378657"
+			rev = "3a39f0b94fd7ea316ba5a4f74d44d5afc454cedf"
 			git = "https://github.com/typedb/typedb-protocol"
 			default-features = false
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -106,12 +106,12 @@ workspace_refs = use_repo_rule("@typedb_bazel_distribution//common/workspace_ref
 workspace_refs(
     name = "typedb_workspace_refs",
     workspace_commit_dict = {
-#        "typeql+": "a1fae91ebd68ed2d7b2eb5035c1287c3bc66789b",
-        "typedb_protocol+": "9a45ab625534a01afe5ecf89acaa06cecc92cafb",
+        "typeql+": "e16626a2129c554436195384a9fda3a3ea36fa2f",
+        "typedb_protocol+": "810e94e12961e4408ee9433d010fd68691783973",
     },
     workspace_tag_dict = {
-        "typeql+": "3.11.0",
-#        "typedb_protocol+": "3.11.0",
+#        "typeql+": "3.11.0-rc0",
+#        "typedb_protocol+": "3.11.0-rc0",
     },
 )
 
@@ -159,20 +159,20 @@ git_override(
 bazel_dep(name = "typeql", version = "0.0.0")
 git_override(
     module_name = "typeql",
-    remote = "https://github.com/typedb/typeql",
-    tag = "3.11.0",
+    remote = "https://github.com/krishnangovindraj/typeql",
+    commit = "e16626a2129c554436195384a9fda3a3ea36fa2f",
 )
 
 bazel_dep(name = "typedb_protocol", version = "0.0.0")
 git_override(
     module_name = "typedb_protocol",
-    remote = "https://github.com/typedb/typedb-protocol",
-    commit = "9a45ab625534a01afe5ecf89acaa06cecc92cafb",
+    remote = "https://github.com/krishnangovindraj/typedb-protocol",
+    commit = "4e8b1179560de715c903099ff1721839fabe984e",
 )
 
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "353cc2cb845287c3eee2ef8ef8ba5321bde49a9d",
+    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+    commit = "d96430563804855ef6cb1049fc660970bc4e2cee",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -174,5 +174,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "d96430563804855ef6cb1049fc660970bc4e2cee",
+    commit = "858af82700791fbd88b6f3bd0ed648f767b2ef31",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -107,7 +107,7 @@ workspace_refs(
     name = "typedb_workspace_refs",
     workspace_commit_dict = {
         "typeql+": "e16626a2129c554436195384a9fda3a3ea36fa2f",
-        "typedb_protocol+": "810e94e12961e4408ee9433d010fd68691783973",
+        "typedb_protocol+": "bb9c513d4dcff269feb88015dcf99354ad378657",
     },
     workspace_tag_dict = {
 #        "typeql+": "3.11.0-rc0",
@@ -167,7 +167,7 @@ bazel_dep(name = "typedb_protocol", version = "0.0.0")
 git_override(
     module_name = "typedb_protocol",
     remote = "https://github.com/krishnangovindraj/typedb-protocol",
-    commit = "4e8b1179560de715c903099ff1721839fabe984e",
+    commit = "bb9c513d4dcff269feb88015dcf99354ad378657",
 )
 
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -174,5 +174,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "858af82700791fbd88b6f3bd0ed648f767b2ef31",
+    commit = "76771f3c64e674e437515f96e6f1813524592820",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -174,5 +174,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "ace384ce53bdca85f8f500eb093c214fdcda3d59",
+    commit = "0cad5eb587bbfe56873a8098a637ad7dc0bf47bf",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -174,5 +174,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "76771f3c64e674e437515f96e6f1813524592820",
+    commit = "cdac9be68cf5844377509e815e0cdf8286f1c168",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -106,8 +106,8 @@ workspace_refs = use_repo_rule("@typedb_bazel_distribution//common/workspace_ref
 workspace_refs(
     name = "typedb_workspace_refs",
     workspace_commit_dict = {
-        "typeql+": "e16626a2129c554436195384a9fda3a3ea36fa2f",
-        "typedb_protocol+": "bb9c513d4dcff269feb88015dcf99354ad378657",
+        "typeql+": "405c5383a35277acc40bb0921ffd2e8eb1b1b00d",
+        "typedb_protocol+": "3a39f0b94fd7ea316ba5a4f74d44d5afc454cedf",
     },
     workspace_tag_dict = {
 #        "typeql+": "3.11.0-rc0",
@@ -159,20 +159,20 @@ git_override(
 bazel_dep(name = "typeql", version = "0.0.0")
 git_override(
     module_name = "typeql",
-    remote = "https://github.com/krishnangovindraj/typeql",
-    commit = "e16626a2129c554436195384a9fda3a3ea36fa2f",
+    remote = "https://github.com/typedb/typeql",
+    commit = "405c5383a35277acc40bb0921ffd2e8eb1b1b00d",
 )
 
 bazel_dep(name = "typedb_protocol", version = "0.0.0")
 git_override(
     module_name = "typedb_protocol",
-    remote = "https://github.com/krishnangovindraj/typedb-protocol",
-    commit = "bb9c513d4dcff269feb88015dcf99354ad378657",
+    remote = "https://github.com/typedb/typedb-protocol",
+    commit = "3a39f0b94fd7ea316ba5a4f74d44d5afc454cedf",
 )
 
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "0cad5eb587bbfe56873a8098a637ad7dc0bf47bf",
+    remote = "https://github.com/typedb/typedb-behaviour",
+    commit = "a6cc06acd204c1e000abe3646ca2e115583b5ce4",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -174,5 +174,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "cdac9be68cf5844377509e815e0cdf8286f1c168",
+    commit = "690e05d5dcd31bae9933ff0cf2349bcf6fab6486",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -174,5 +174,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "690e05d5dcd31bae9933ff0cf2349bcf6fab6486",
+    commit = "ace384ce53bdca85f8f500eb093c214fdcda3d59",
 )

--- a/common/bytes/util.rs
+++ b/common/bytes/util.rs
@@ -91,6 +91,10 @@ impl<'a> HexBytesFormatter<'a> {
         Self(Cow::Borrowed(bytes))
     }
 
+    pub fn into_owned(self) -> HexBytesFormatter<'static> {
+        HexBytesFormatter::owned(self.0.into_owned())
+    }
+
     pub fn format_iid(&self) -> String {
         const PREFIX: &'static str = "0x";
         let mut result = String::with_capacity(PREFIX.len() + self.0.len() * 2);

--- a/compiler/annotation/mod.rs
+++ b/compiler/annotation/mod.rs
@@ -119,6 +119,13 @@ typedb_error!(
             variable: String,
             source_span: Option<Span>,
         ),
+        CouldNotResolveGivenRowDeclaredType(
+            18,
+            "An error occurred when trying to resolve the type of the given rows at index: {index}.",
+            index: usize,
+            source_span: Option<Span>,
+            typedb_source: TypeInferenceError
+        ),
     }
 );
 

--- a/compiler/annotation/pipeline.rs
+++ b/compiler/annotation/pipeline.rs
@@ -20,7 +20,7 @@ use ir::{
         conjunction::Conjunction,
         constraint::{Constraint, ExpressionBinding},
         nested_pattern::NestedPattern,
-        variable_category::VariableCategory,
+        variable_category::{VariableCategory, VariableOptionality},
     },
     pipeline::{
         ParameterRegistry, VariableRegistry,
@@ -30,7 +30,7 @@ use ir::{
         modifier::{Distinct, Limit, Offset, Require, Select, Sort},
         reduce::{AssignedReduction, Reduce, Reducer},
     },
-    translation::pipeline::TranslatedStage,
+    translation::pipeline::{TranslatedGiven, TranslatedStage},
 };
 use storage::snapshot::ReadableSnapshot;
 use typeql::common::Span;
@@ -45,8 +45,9 @@ use crate::{
         },
         fetch::{AnnotatedFetch, annotate_fetch},
         function::{
-            AnnotatedFunctionSignaturesImpl, AnnotatedPreambleFunctions, AnnotatedSchemaFunctions,
-            FunctionParameterAnnotation, annotate_preamble_functions,
+            AnnotatedFunctionSignatures, AnnotatedFunctionSignaturesImpl, AnnotatedPreambleFunctions,
+            AnnotatedSchemaFunctions, FunctionParameterAnnotation, annotate_preamble_functions,
+            get_annotations_from_labels_vec,
         },
         match_inference::infer_types_for_block,
         type_annotations::{BlockAnnotations, ConstraintTypeAnnotations, TypeAnnotations},
@@ -56,8 +57,15 @@ use crate::{
     executable::{reduce::ReduceInstruction, update},
 };
 
+pub struct AnnotatedGiven {
+    pub variables: Vec<Variable>,
+    pub expected_types: Vec<FunctionParameterAnnotation>,
+    pub optionality: Vec<VariableOptionality>,
+}
+
 pub struct AnnotatedPipeline {
     pub annotated_preamble: AnnotatedPreambleFunctions,
+    pub annotated_given: Option<AnnotatedGiven>,
     pub annotated_stages: Vec<AnnotatedStage>,
     pub annotated_fetch: Option<AnnotatedFetch>,
 }
@@ -110,6 +118,7 @@ pub fn annotate_preamble_and_pipeline(
     variable_registry: &mut VariableRegistry,
     parameters: &ParameterRegistry,
     translated_preamble: Vec<Function>,
+    translated_given: Option<TranslatedGiven>,
     translated_stages: Vec<TranslatedStage>,
     translated_fetch: Option<FetchObject>,
 ) -> Result<AnnotatedPipeline, AnnotationError> {
@@ -125,12 +134,46 @@ pub fn annotate_preamble_and_pipeline(
         variable_registry,
         parameters,
     );
-    let input_annotations = RunningVariableAnnotations::empty();
+    let annotated_given = annotate_given_stage(&mut ctx, translated_given)?;
+    let input_annotations = if let Some(given) = &annotated_given {
+        RunningVariableAnnotations::from_iterator(
+            given.variables.iter().copied().zip(given.expected_types.iter().cloned()),
+        )
+    } else {
+        RunningVariableAnnotations::empty()
+    };
     let (annotated_stages, output_annotations) =
         annotate_pipeline_stages(&mut ctx, translated_stages, input_annotations, None)?;
     let annotated_fetch =
         translated_fetch.map(|fetch| annotate_fetch(&mut ctx, fetch, &output_annotations)).transpose()?;
-    Ok(AnnotatedPipeline { annotated_stages, annotated_fetch, annotated_preamble })
+    Ok(AnnotatedPipeline { annotated_given, annotated_stages, annotated_fetch, annotated_preamble })
+}
+
+fn annotate_given_stage(
+    ctx: &mut PipelineAnnotationContext<'_, impl ReadableSnapshot>,
+    translated_given: Option<TranslatedGiven>,
+) -> Result<Option<AnnotatedGiven>, AnnotationError> {
+    let Some(TranslatedGiven { variables, labels, .. }) = translated_given else {
+        return Ok(None);
+    };
+    let expected_types = get_annotations_from_labels_vec(&ctx.to_parts_mut().0, &labels).map_err(
+        |(index, source_span, typedb_source)| AnnotationError::CouldNotResolveGivenRowDeclaredType {
+            index,
+            source_span,
+            typedb_source,
+        },
+    )?;
+    let optionality = variables
+        .iter()
+        .map(|&variable| {
+            if ctx.variable_registry.is_variable_optional(variable) {
+                VariableOptionality::Optional
+            } else {
+                VariableOptionality::Required
+            }
+        })
+        .collect();
+    Ok(Some(AnnotatedGiven { variables, expected_types, optionality }))
 }
 
 pub(crate) fn annotate_pipeline_stages(

--- a/compiler/annotation/type_annotations.rs
+++ b/compiler/annotation/type_annotations.rs
@@ -70,6 +70,16 @@ impl TypeAnnotations {
         TypeAnnotations { vertex: variables, constraints, value_type_annotations: None }
     }
 
+    pub fn new_with_value_annotations(
+        variables: BTreeMap<Vertex<Variable>, Arc<BTreeSet<Type>>>,
+        constraints: HashMap<Constraint<Variable>, ConstraintTypeAnnotations>,
+        value_type_annotations: BTreeMap<Vertex<Variable>, ExpressionValueType>,
+    ) -> Self {
+        let mut this = Self::new(variables, constraints);
+        this.value_type_annotations = Some(value_type_annotations);
+        this
+    }
+
     pub fn vertex_annotations(&self) -> &BTreeMap<Vertex<Variable>, Arc<BTreeSet<Type>>> {
         &self.vertex
     }

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -144,7 +144,7 @@ fn compile_some(
                 available_functions,
                 &stages,
                 Some(fetch),
-                &input_variables,
+                &input_variables.iter().cloned().collect::<Vec<_>>(),
             )
             .map_err(|err| FetchCompilationError::SubFetchCompilation { typedb_source: Box::new(err) })?;
             let input_position_remapping = input_variables

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -13,16 +13,20 @@ use std::{
 use answer::{Type, variable::Variable};
 use concept::thing::statistics::Statistics;
 use ir::{
-    pattern::{Pattern, Vertex, conjunction::Conjunction, nested_pattern::NestedPattern},
+    pattern::{
+        Pattern, Vertex, conjunction::Conjunction, nested_pattern::NestedPattern,
+        variable_category::VariableOptionality,
+    },
     pipeline::{VariableRegistry, function_signature::FunctionID, reduce::AssignedReduction},
 };
+use itertools::Itertools;
 
 use crate::{
-    VariablePosition,
+    ExecutorVariable, VariablePosition,
     annotation::{
         fetch::{AnnotatedFetch, AnnotatedFetchObject, AnnotatedFetchSome},
-        function::{AnnotatedPreambleFunctions, AnnotatedSchemaFunctions},
-        pipeline::AnnotatedStage,
+        function::{AnnotatedPreambleFunctions, AnnotatedSchemaFunctions, FunctionParameterAnnotation},
+        pipeline::{AnnotatedGiven, AnnotatedStage},
     },
     executable::{
         ExecutableCompilationError,
@@ -30,10 +34,11 @@ use crate::{
         fetch::executable::{ExecutableFetch, compile_fetch},
         function::{ExecutableFunctionRegistry, FunctionCallCostProvider, executable::compile_functions},
         insert::{self, executable::InsertExecutable},
-        match_::planner::conjunction_executable::ConjunctionExecutable,
+        match_::{instructions::CheckInstruction, planner::conjunction_executable::ConjunctionExecutable},
         modifiers::{
             DistinctExecutable, LimitExecutable, OffsetExecutable, RequireExecutable, SelectExecutable, SortExecutable,
         },
+        next_executable_id,
         put::PutExecutable,
         reduce::{ReduceExecutable, ReduceRowsExecutable},
         update::executable::UpdateExecutable,
@@ -76,6 +81,7 @@ impl<'a> IntoIterator for &'a TypePopulations {
 #[derive(Debug, Clone)]
 pub struct ExecutablePipeline {
     pub executable_functions: ExecutableFunctionRegistry,
+    pub executable_given: Option<Arc<GivenExecutable>>,
     pub executable_stages: Vec<ExecutableStage>,
     pub executable_fetch: Option<Arc<ExecutableFetch>>,
     pub pipeline_structure: Arc<ParametrisedPipelineStructure>,
@@ -144,9 +150,9 @@ pub fn compile_pipeline_and_functions(
     variable_registry: &VariableRegistry,
     annotated_schema_functions: &AnnotatedSchemaFunctions,
     annotated_preamble: AnnotatedPreambleFunctions,
+    annotated_given: Option<AnnotatedGiven>,
     annotated_stages: Vec<AnnotatedStage>,
     annotated_fetch: Option<AnnotatedFetch>,
-    input_variables: &HashSet<Variable>,
     pipeline_structure: Arc<ParametrisedPipelineStructure>,
 ) -> Result<ExecutablePipeline, ExecutableCompilationError> {
     // TODO: we could cache compiled schema functions so we dont have to re-compile with every query here
@@ -176,18 +182,30 @@ pub fn compile_pipeline_and_functions(
 
     let schema_and_preamble_functions: ExecutableFunctionRegistry =
         ExecutableFunctionRegistry::new(arced_executable_schema_functions, executable_preamble_functions);
+    let executable_given = annotated_given.map(|given| {
+        Arc::new(GivenExecutable::new(next_executable_id(), given.variables, given.expected_types, given.optionality))
+    });
     let (_input_positions, executable_stages, executable_fetch, type_populations) = compile_stages_and_fetch(
         statistics,
         variable_registry,
         &schema_and_preamble_functions,
         &annotated_stages,
         annotated_fetch,
-        input_variables,
+        executable_given.as_ref().map_or(&[], |given| given.variables()),
     )?;
+    debug_assert!(
+        executable_given
+            .as_ref()
+            .map_or(&Vec::new(), |given| &given.variables)
+            .iter()
+            .enumerate()
+            .all(|(i, v)| { _input_positions.get(v) == Some(&VariablePosition::new(i as u32)) })
+    );
     debug_assert!(!executable_stages.is_empty());
     Ok(ExecutablePipeline {
         pipeline_structure,
         executable_functions: schema_and_preamble_functions,
+        executable_given,
         executable_stages,
         executable_fetch,
         type_populations,
@@ -200,7 +218,7 @@ pub fn compile_stages_and_fetch(
     available_functions: &ExecutableFunctionRegistry,
     annotated_stages: &[AnnotatedStage],
     annotated_fetch: Option<AnnotatedFetch>,
-    input_variables: &HashSet<Variable>,
+    input_variables: &[Variable],
 ) -> Result<
     (HashMap<Variable, VariablePosition>, Vec<ExecutableStage>, Option<Arc<ExecutableFetch>>, TypePopulations),
     ExecutableCompilationError,
@@ -581,5 +599,41 @@ fn find_referenced_functions_in_fetch(
                 }
             }
         })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GivenExecutable {
+    pub executable_id: u64,
+    variables: Vec<Variable>,
+    expected_types: Vec<FunctionParameterAnnotation>,
+    optionality: Vec<VariableOptionality>,
+}
+
+impl GivenExecutable {
+    pub(crate) fn new(
+        executable_id: u64,
+        variables: Vec<Variable>,
+        expected_types: Vec<FunctionParameterAnnotation>,
+        optionality: Vec<VariableOptionality>,
+    ) -> Self {
+        debug_assert!(variables.len() == expected_types.len() && variables.len() == optionality.len());
+        Self { executable_id, variables, expected_types, optionality }
+    }
+
+    pub fn row_mapping(&self) -> HashMap<Variable, VariablePosition> {
+        self.variables.iter().cloned().enumerate().map(|(i, v)| (v, VariablePosition::new(i as u32))).collect()
+    }
+
+    pub fn variables(&self) -> &[Variable] {
+        &self.variables
+    }
+
+    pub fn expected_types(&self) -> &[FunctionParameterAnnotation] {
+        &self.expected_types
+    }
+
+    pub fn optionality(&self) -> &[VariableOptionality] {
+        &self.optionality
     }
 }

--- a/compiler/query_structure.rs
+++ b/compiler/query_structure.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize, Serializer};
 
 use crate::annotation::{
     function::{AnnotatedFunction, AnnotatedFunctionReturn},
-    pipeline::{AnnotatedPipeline, AnnotatedStage},
+    pipeline::{AnnotatedGiven, AnnotatedPipeline, AnnotatedStage},
     type_annotations::{BlockAnnotations, TypeAnnotations},
 };
 
@@ -96,6 +96,7 @@ pub fn extract_query_structure_from(
 ) -> QueryStructure {
     let parametrised_pipeline = extract_pipeline_structure_from(
         variable_registry,
+        annotated_pipeline.annotated_given.as_ref(),
         annotated_pipeline.annotated_stages.as_slice(),
         source_query,
     );
@@ -111,7 +112,7 @@ pub fn extract_query_structure_from(
 
 pub fn extract_function_structure_from(function: &AnnotatedFunction, source_query: &str) -> FunctionStructure {
     let parametrised_pipeline =
-        extract_pipeline_structure_from(&function.variable_registry, function.stages.as_slice(), source_query);
+        extract_pipeline_structure_from(&function.variable_registry, None, function.stages.as_slice(), source_query);
     let body = Arc::new(parametrised_pipeline)
         .with_parameters(Arc::new(function.parameter_registry.clone()), function.variable_registry.variable_names());
     let arguments = function.arguments.iter().map_into().collect();
@@ -121,11 +122,13 @@ pub fn extract_function_structure_from(function: &AnnotatedFunction, source_quer
 
 pub fn extract_pipeline_structure_from(
     variable_registry: &VariableRegistry,
+    annotated_given: Option<&AnnotatedGiven>,
     annotated_stages: &[AnnotatedStage],
     source_query: &str,
 ) -> ParametrisedPipelineStructure {
     let branch_ids_allocated = variable_registry.branch_ids_allocated();
     let mut builder = ParametrisedQueryStructureBuilder::new(source_query, branch_ids_allocated);
+    builder.may_add_given(annotated_given);
     annotated_stages.into_iter().enumerate().for_each(|(index, stage)| builder.add_stage(stage, StageIndex(index)));
     let output_variables = annotated_stages
         .iter()
@@ -176,10 +179,12 @@ pub struct PipelineVariableAnnotationAndModifier {
 }
 
 pub type ConjunctionAnnotations = BTreeMap<StructureVariableId, PipelineVariableAnnotationAndModifier>;
+pub type GivenStructureAnnotations = BTreeMap<StructureVariableId, PipelineVariableAnnotationAndModifier>;
 pub type PipelineStructureAnnotations = Vec<ConjunctionAnnotations>;
 
 #[derive(Debug, Clone)]
 pub struct ParametrisedPipelineStructure {
+    pub given: Option<QueryStructureGiven>,
     pub stages: Vec<QueryStructureStage>,
     pub conjunctions: Vec<QueryStructureConjunction>,
     pub output_variables: Vec<StructureVariableId>,
@@ -207,7 +212,7 @@ impl ParametrisedPipelineStructure {
                 | QueryStructureStage::Put { block }
                 | QueryStructureStage::Update { block } => Some(block),
 
-                QueryStructureStage::Select { .. }
+                | QueryStructureStage::Select { .. }
                 | QueryStructureStage::Delete { .. } // Deleted edges are deleted.
                 | QueryStructureStage::Sort { .. }
                 | QueryStructureStage::Offset { .. }
@@ -223,6 +228,12 @@ impl ParametrisedPipelineStructure {
     pub fn resolve_conjunction_id(&self, stage_index: StageIndex, scope_id: ScopeId) -> QueryStructureConjunctionID {
         self.scope_to_conjunction_id.get(&(stage_index, scope_id)).unwrap().clone()
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "tag")]
+pub struct QueryStructureGiven {
+    pub variables: Vec<StructureVariableId>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -307,6 +318,7 @@ impl<'a> ParametrisedQueryStructureBuilder<'a> {
         Self {
             source_query,
             pipeline_structure: ParametrisedPipelineStructure {
+                given: None,
                 stages: Vec::new(),
                 conjunctions,
                 output_variables: Vec::new(),
@@ -315,6 +327,12 @@ impl<'a> ParametrisedQueryStructureBuilder<'a> {
                 scope_to_conjunction_id: HashMap::new(),
             },
         }
+    }
+
+    pub fn may_add_given(&mut self, given: Option<&AnnotatedGiven>) {
+        self.pipeline_structure.given = given.map(|given| QueryStructureGiven {
+            variables: given.variables.iter().map(StructureVariableId::from).collect(),
+        });
     }
 
     pub fn add_stage(&mut self, stage: &AnnotatedStage, stage_index: StageIndex) {

--- a/concept/error.rs
+++ b/concept/error.rs
@@ -6,6 +6,7 @@
 
 use std::{fmt, sync::Arc};
 
+use bytes::util::HexBytesFormatter;
 use encoding::{
     error::EncodingError,
     value::{label::Label, value_type::ValueType},
@@ -99,5 +100,8 @@ typedb_error! {
         MissingDatetimeTzTimezone(6, "Invalid format of 'datetime_tz': missing the 'timezone' part."),
         InvalidDatetimeTzName(7, "Invalid format of 'datetime_tz': timezone provided has name '{name}', which is not an officially recognized timezone.", name: String),
         InvalidDatetimeTzOffset(8, "Invalid format of 'datetime_tz': timezone provided has numerical offset '{offset_seconds}', which is not recognised as a valid value for offset in seconds.", offset_seconds: i32),
+        CouldNotDecodeIIDAsEntity(9, "The iid '{iid}' could not be decoded to an entity", iid: HexBytesFormatter<'static>),
+        CouldNotDecodeIIDAsRelation(10, "The iid '{iid}' could not be decoded to a relation", iid: HexBytesFormatter<'static>),
+        CouldNotDecodeIIDAsAttribute(11, "The iid '{iid}' could not be decoded to an attribute", iid: HexBytesFormatter<'static>),
     }
 }

--- a/database/query.rs
+++ b/database/query.rs
@@ -17,7 +17,10 @@ use function::function_manager::FunctionManager;
 use ir::pipeline::ParameterRegistry;
 use itertools::{Either, Itertools};
 use options::QueryOptions;
-use query::{error::QueryError, query_manager::QueryManager};
+use query::{
+    error::QueryError,
+    query_manager::{GivenRows, QueryManager},
+};
 use storage::{durability_client::WALClient, snapshot::WritableSnapshot};
 use tracing::{Level, event};
 use typeql::query::SchemaQuery;
@@ -73,6 +76,7 @@ pub fn execute_write_query_in_schema(
     transaction: TransactionSchema<WALClient>,
     query_options: QueryOptions,
     pipeline: typeql::query::Pipeline,
+    given_rows: Option<GivenRows>,
     source_query: String,
     interrupt: ExecutionInterrupt,
 ) -> (TransactionSchema<WALClient>, WriteQueryResult) {
@@ -94,7 +98,8 @@ pub fn execute_write_query_in_schema(
         &function_manager,
         &query_manager,
         query_options,
-        &pipeline,
+        pipeline,
+        given_rows,
         &source_query,
         interrupt,
     );
@@ -117,6 +122,7 @@ pub fn execute_write_query_in_write(
     transaction: TransactionWrite<WALClient>,
     query_options: QueryOptions,
     pipeline: typeql::query::Pipeline,
+    given_rows: Option<GivenRows>,
     source_query: String,
     interrupt: ExecutionInterrupt,
 ) -> (TransactionWrite<WALClient>, WriteQueryResult) {
@@ -138,7 +144,8 @@ pub fn execute_write_query_in_write(
         &function_manager,
         &query_manager,
         query_options,
-        &pipeline,
+        pipeline,
+        given_rows,
         &source_query,
         interrupt,
     );
@@ -164,7 +171,8 @@ pub(crate) fn execute_write_query_in<Snapshot: WritableSnapshot + 'static>(
     function_manager: &FunctionManager,
     query_manager: &QueryManager,
     query_options: QueryOptions,
-    pipeline: &typeql::query::Pipeline,
+    pipeline: typeql::query::Pipeline,
+    given_rows: Option<GivenRows>,
     source_query: &str,
     interrupt: ExecutionInterrupt,
 ) -> (Snapshot, WriteQueryResult) {
@@ -174,7 +182,8 @@ pub(crate) fn execute_write_query_in<Snapshot: WritableSnapshot + 'static>(
         type_manager,
         thing_manager,
         function_manager,
-        pipeline,
+        &pipeline,
+        given_rows,
         source_query,
     );
     let pipeline = match result {

--- a/database/query.rs
+++ b/database/query.rs
@@ -17,14 +17,11 @@ use function::function_manager::FunctionManager;
 use ir::pipeline::ParameterRegistry;
 use itertools::{Either, Itertools};
 use options::QueryOptions;
-use query::{
-    error::QueryError,
-    given_rows::GivenRows,
-    query_manager::QueryManager,
-};
+use query::{error::QueryError, given_rows::GivenRows, query_manager::QueryManager};
 use storage::{durability_client::WALClient, snapshot::WritableSnapshot};
 use tracing::{Level, event};
 use typeql::query::SchemaQuery;
+
 use crate::{
     transaction::{TransactionSchema, TransactionWrite},
     with_transaction_parts,

--- a/database/query.rs
+++ b/database/query.rs
@@ -19,12 +19,12 @@ use itertools::{Either, Itertools};
 use options::QueryOptions;
 use query::{
     error::QueryError,
-    query_manager::{GivenRows, QueryManager},
+    given_rows::GivenRows,
+    query_manager::QueryManager,
 };
 use storage::{durability_client::WALClient, snapshot::WritableSnapshot};
 use tracing::{Level, event};
 use typeql::query::SchemaQuery;
-
 use crate::{
     transaction::{TransactionSchema, TransactionWrite},
     with_transaction_parts,
@@ -76,7 +76,7 @@ pub fn execute_write_query_in_schema(
     transaction: TransactionSchema<WALClient>,
     query_options: QueryOptions,
     pipeline: typeql::query::Pipeline,
-    given_rows: Option<GivenRows>,
+    given_rows: Option<impl GivenRows>,
     source_query: String,
     interrupt: ExecutionInterrupt,
 ) -> (TransactionSchema<WALClient>, WriteQueryResult) {
@@ -122,7 +122,7 @@ pub fn execute_write_query_in_write(
     transaction: TransactionWrite<WALClient>,
     query_options: QueryOptions,
     pipeline: typeql::query::Pipeline,
-    given_rows: Option<GivenRows>,
+    given_rows: Option<impl GivenRows>,
     source_query: String,
     interrupt: ExecutionInterrupt,
 ) -> (TransactionWrite<WALClient>, WriteQueryResult) {
@@ -172,7 +172,7 @@ pub(crate) fn execute_write_query_in<Snapshot: WritableSnapshot + 'static>(
     query_manager: &QueryManager,
     query_options: QueryOptions,
     pipeline: typeql::query::Pipeline,
-    given_rows: Option<GivenRows>,
+    given_rows: Option<impl GivenRows>,
     source_query: &str,
     interrupt: ExecutionInterrupt,
 ) -> (Snapshot, WriteQueryResult) {

--- a/database/tests/BUILD
+++ b/database/tests/BUILD
@@ -55,6 +55,7 @@ rust_test(
         "//database",
         "//diagnostics",
         "//executor",
+        "//query",
         "//storage",
         "//util/test:test_utils",
 
@@ -73,6 +74,7 @@ rust_test(
         "//diagnostics",
         "//encoding",
         "//executor",
+        "//query",
         "//storage",
         "//util/test:test_utils",
 

--- a/database/tests/statistics_synchronization.rs
+++ b/database/tests/statistics_synchronization.rs
@@ -21,6 +21,7 @@ use database::{
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 use executor::ExecutionInterrupt;
 use options::{QueryOptions, TransactionOptions};
+use query::given_rows::GivenRowsSimple;
 use storage::durability_client::WALClient;
 use test_utils::{create_tmp_storage_dir, init_logging};
 
@@ -96,7 +97,7 @@ fn run_insert_batch(database: &Arc<Database<WALClient>>, batch_id: usize) {
             tx,
             QueryOptions::default_grpc(),
             pipeline,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
             ExecutionInterrupt::new_uninterruptible(),
         );

--- a/database/tests/statistics_synchronization.rs
+++ b/database/tests/statistics_synchronization.rs
@@ -96,6 +96,7 @@ fn run_insert_batch(database: &Arc<Database<WALClient>>, batch_id: usize) {
             tx,
             QueryOptions::default_grpc(),
             pipeline,
+            None,
             query_str,
             ExecutionInterrupt::new_uninterruptible(),
         );

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -16,6 +16,7 @@ use diagnostics::diagnostics_manager::DiagnosticsManager;
 use encoding::graph::thing::vertex_attribute::StringAttributeID;
 use executor::ExecutionInterrupt;
 use options::{QueryOptions, TransactionOptions};
+use query::given_rows::GivenRowsSimple;
 use storage::{
     StorageCommitError, durability_client::WALClient, isolation_manager::IsolationConflict, snapshot::SnapshotError,
 };
@@ -58,7 +59,7 @@ fn run_write(tx: TransactionWrite<WALClient>, query: &str) -> TransactionWrite<W
         tx,
         QueryOptions::default_grpc(),
         pipeline,
-        None,
+        None::<GivenRowsSimple>,
         query.to_string(),
         ExecutionInterrupt::new_uninterruptible(),
     );

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -58,6 +58,7 @@ fn run_write(tx: TransactionWrite<WALClient>, query: &str) -> TransactionWrite<W
         tx,
         QueryOptions::default_grpc(),
         pipeline,
+        None,
         query.to_string(),
         ExecutionInterrupt::new_uninterruptible(),
     );

--- a/encoding/graph/thing/vertex_object.rs
+++ b/encoding/graph/thing/vertex_object.rs
@@ -74,6 +74,14 @@ impl ObjectVertex {
         Self::LENGTH
     }
 
+    pub fn is_entity(&self) -> bool {
+        self.prefix == Prefix::VertexEntity
+    }
+
+    pub fn is_relation(&self) -> bool {
+        self.prefix == Prefix::VertexRelation
+    }
+
     const fn range_object_id() -> Range<usize> {
         Self::RANGE_TYPE_ID.end..Self::RANGE_TYPE_ID.end + ObjectID::LENGTH
     }

--- a/executor/batch.rs
+++ b/executor/batch.rs
@@ -192,7 +192,7 @@ pub struct Batch {
 }
 
 impl Batch {
-    pub(crate) fn new(width: u32, capacity: usize) -> Self {
+    pub fn new(width: u32, capacity: usize) -> Self {
         let size = width as usize * capacity;
         Batch {
             width,
@@ -200,6 +200,16 @@ impl Batch {
             multiplicities: Vec::with_capacity(capacity),
             provenance: Vec::with_capacity(capacity),
         }
+    }
+
+    pub fn new_single_empty_row() -> Batch {
+        let mut this = Self::new(0, 1);
+        this.append_row(MaybeOwnedRow::empty());
+        this
+    }
+
+    pub fn width(&self) -> u32 {
+        self.width
     }
 
     pub fn len(&self) -> usize {
@@ -227,7 +237,7 @@ impl Batch {
         self.append(|mut appended| appended.copy_from_row(row))
     }
 
-    pub(crate) fn append<T>(&mut self, writer: impl FnOnce(Row<'_>) -> T) -> T {
+    pub fn append<T>(&mut self, writer: impl FnOnce(Row<'_>) -> T) -> T {
         self.data.resize(self.data.len() + self.width as usize, VariableValue::None);
         self.multiplicities.push(1);
         self.provenance.push(Provenance::INITIAL);

--- a/executor/pipeline/fetch.rs
+++ b/executor/pipeline/fetch.rs
@@ -31,7 +31,7 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     ExecutionInterrupt, Provenance,
-    batch::FixedBatch,
+    batch::{Batch, FixedBatch},
     document::{ConceptDocument, DocumentLeaf, DocumentList, DocumentMap, DocumentNode},
     error::ReadExecutionError,
     pipeline::{
@@ -353,41 +353,26 @@ fn execute_list_subfetch(
     executable_subfetch: &ExecutableFetchListSubFetch,
 ) -> Result<DocumentNode, FetchExecutionError> {
     let ExecutableFetchListSubFetch { input_position_mapping, variable_registry, stages, fetch } = executable_subfetch;
-
-    let pipeline = if input_position_mapping.is_empty() {
-        Pipeline::build_read_pipeline(
-            snapshot,
-            thing_manager,
-            variable_registry.variable_names(),
-            None,
-            functions_registry,
-            stages,
-            Some(fetch.clone()),
-            parameters,
-            None,
-            query_profile,
-        )
-    } else {
-        let max_position = input_position_mapping.values().max().map(|pos| pos.as_usize()).unwrap();
-        let mut initial_row = vec![VariableValue::None; max_position + 1];
+    let width = input_position_mapping.values().max().map(|pos| pos.as_usize() as u32 + 1).unwrap_or(0);
+    let mut initial_batch = Batch::new(width, 1);
+    initial_batch.append(|mut write_to| {
         input_position_mapping.iter().for_each(|(parent_row_position, local_row_position)| {
-            initial_row[local_row_position.as_usize()] =
-                row[parent_row_position.as_usize()].as_reference().into_owned();
+            write_to.set(*local_row_position, row[parent_row_position.as_usize()].as_reference().into_owned());
         });
-        let initial_row = MaybeOwnedRow::new_owned(initial_row, row.multiplicity(), Provenance::INITIAL);
-        Pipeline::build_read_pipeline(
-            snapshot,
-            thing_manager,
-            variable_registry.variable_names(),
-            None,
-            functions_registry,
-            stages,
-            Some(fetch.clone()),
-            parameters,
-            Some(initial_row),
-            query_profile,
-        )
-    }
+    });
+    let pipeline = Pipeline::build_read_pipeline(
+        snapshot,
+        thing_manager,
+        variable_registry.variable_names(),
+        None,
+        functions_registry,
+        None,
+        stages,
+        Some(fetch.clone()),
+        parameters,
+        initial_batch,
+        query_profile,
+    )
     .map_err(|typedb_source| FetchExecutionError::Pipeline { typedb_source })?;
 
     let (iterator, _context) = pipeline

--- a/executor/pipeline/given.rs
+++ b/executor/pipeline/given.rs
@@ -1,0 +1,173 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+use std::{marker::PhantomData, sync::Arc};
+
+use answer::variable_value::VariableValue;
+use compiler::{annotation::function::FunctionParameterAnnotation, executable::pipeline::GivenExecutable};
+use concept::{ConceptStatus, error::ConceptReadError, thing::ThingAPI};
+use encoding::value::ValueEncodable;
+use error::needs_update_when_feature_is_implemented;
+use ir::pattern::variable_category::VariableOptionality;
+use lending_iterator::LendingIterator;
+use resource::profile::{StageProfile, StepProfile, StorageCounters};
+use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
+
+use crate::{
+    ExecutionInterrupt,
+    batch::{Batch, BatchRowIterator},
+    pipeline::{
+        PipelineExecutionError, StageIterator,
+        initial::InitialIterator,
+        stage::{ExecutionContext, StageAPI},
+    },
+    row::MaybeOwnedRow,
+};
+
+pub struct GivenStageExecutor<InputIterator> {
+    executable: Arc<GivenExecutable>,
+    _input_iterator: PhantomData<InputIterator>,
+}
+
+impl<InputIterator> GivenStageExecutor<InputIterator> {
+    pub fn new(executable: Arc<GivenExecutable>) -> Self {
+        Self { executable, _input_iterator: PhantomData }
+    }
+}
+
+impl<InputIterator, Snapshot> StageAPI<Snapshot> for GivenStageExecutor<InputIterator>
+where
+    InputIterator: StageIterator,
+    Snapshot: ReadableSnapshot + 'static,
+{
+    type InputIterator = InputIterator;
+    type OutputIterator = GivenStageIterator<Snapshot, InputIterator>;
+
+    fn into_iterator(
+        self,
+        input_iterator: Self::InputIterator,
+        context: ExecutionContext<Snapshot>,
+        interrupt: ExecutionInterrupt,
+    ) -> Result<
+        (Self::OutputIterator, ExecutionContext<Snapshot>),
+        (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
+    > {
+        Ok((GivenStageIterator::new(context.clone(), self.executable, input_iterator), context))
+    }
+}
+
+pub struct GivenStageIterator<Snapshot: ReadableSnapshot + 'static, InputIterator: StageIterator> {
+    context: ExecutionContext<Snapshot>,
+    executable: Arc<GivenExecutable>,
+    source_iterator: InputIterator,
+    row_counter: usize,
+    profile: Arc<StepProfile>,
+}
+
+impl<Snapshot: ReadableSnapshot + 'static, InputIterator: StageIterator> GivenStageIterator<Snapshot, InputIterator> {
+    pub(crate) fn new(
+        context: ExecutionContext<Snapshot>,
+        executable: Arc<GivenExecutable>,
+        source_iterator: InputIterator,
+    ) -> Self {
+        let stage_profile = context.profile.profile_stage(|| "Given".to_owned(), executable.executable_id);
+        let pattern_profile = stage_profile.create_or_get_pattern(|| "Given".to_owned());
+        let profile = pattern_profile.extend_or_get_step(0, || "Given validation".to_owned());
+        Self { context, executable, source_iterator, row_counter: 0, profile }
+    }
+}
+
+impl<Snapshot, InputIterator> LendingIterator for GivenStageIterator<Snapshot, InputIterator>
+where
+    Snapshot: ReadableSnapshot + 'static,
+    InputIterator: StageIterator,
+{
+    type Item<'a> = Result<MaybeOwnedRow<'a>, Box<PipelineExecutionError>>;
+
+    fn next(&mut self) -> Option<Self::Item<'_>> {
+        let expected_types = self.executable.expected_types();
+        let optionality = self.executable.optionality();
+        let row_index = self.row_counter;
+        self.row_counter += 1;
+        Some(self.source_iterator.next()?.and_then(|row| {
+            debug_assert!(row.row().len() == expected_types.len());
+            row.iter().enumerate().try_for_each(|(column_index, entry)| {
+                if !row_entry_satisfies_optionality(optionality[column_index], entry) {
+                    Err(Box::new(PipelineExecutionError::GivenValueDidNotSatisfyDeclaredOptionality {
+                        row_index,
+                        column_index,
+                    }))
+                } else if !row_entry_satisfies_types(&expected_types[column_index], optionality[column_index], entry) {
+                    Err(Box::new(PipelineExecutionError::GivenValueDidNotSatisfyDeclaredType {
+                        row_index,
+                        column_index,
+                    }))
+                } else if !row_entry_exists(&self.context, self.profile.storage_counters(), entry)? {
+                    Err(Box::new(PipelineExecutionError::GivenConceptDoesNotExist { row_index, column_index }))
+                } else {
+                    Ok(())
+                }
+            })?;
+            Ok(row)
+        }))
+    }
+}
+
+impl<Snapshot, InputIterator> StageIterator for GivenStageIterator<Snapshot, InputIterator>
+where
+    Snapshot: ReadableSnapshot + 'static,
+    InputIterator: StageIterator,
+{
+}
+
+fn row_entry_satisfies_optionality(optionality: VariableOptionality, entry: &VariableValue<'_>) -> bool {
+    !(optionality == VariableOptionality::Required && entry == &VariableValue::None)
+}
+fn row_entry_satisfies_types(
+    expected_type: &FunctionParameterAnnotation,
+    optionality: VariableOptionality,
+    entry: &VariableValue<'_>,
+) -> bool {
+    match (entry, expected_type) {
+        (VariableValue::Value(value), FunctionParameterAnnotation::Value(value_type)) => {
+            *value_type == value.value_type()
+        }
+        (VariableValue::Thing(thing), FunctionParameterAnnotation::Concept(types)) => types.contains(&thing.type_()),
+        (VariableValue::None, _) => optionality == VariableOptionality::Optional,
+        (_, FunctionParameterAnnotation::AnyConcept) => unreachable!("Unexpected"),
+        (VariableValue::Value(_), _)
+        | (VariableValue::Thing(_), _)
+        | (VariableValue::ValueList(_), _)
+        | (VariableValue::ThingList(_), _)
+        | (VariableValue::Type(_), _) => false,
+    }
+}
+
+fn row_entry_exists(
+    context: &ExecutionContext<impl ReadableSnapshot>,
+    storage_counters: StorageCounters,
+    entry: &VariableValue<'_>,
+) -> Result<bool, Box<PipelineExecutionError>> {
+    match entry {
+        VariableValue::Thing(thing) => match thing {
+            answer::Thing::Entity(entity) => {
+                context.thing_manager.instance_exists(&*context.snapshot, entity, storage_counters)
+            }
+            answer::Thing::Relation(relation) => {
+                context.thing_manager.instance_exists(&*context.snapshot, relation, storage_counters)
+            }
+            answer::Thing::Attribute(attribute) => {
+                context.thing_manager.instance_exists(&*context.snapshot, attribute, storage_counters)
+            }
+        }
+        .map_err(|typedb_source| Box::new(PipelineExecutionError::ConceptRead { typedb_source })),
+        VariableValue::ThingList(_) => {
+            needs_update_when_feature_is_implemented!(Lists);
+            unreachable!("Unimplemented feature: Lists");
+        }
+        VariableValue::Value(_) | VariableValue::ValueList(_) | VariableValue::None => Ok(true),
+        VariableValue::Type(_) => unreachable!("Types in given rows"),
+    }
+}

--- a/executor/pipeline/initial.rs
+++ b/executor/pipeline/initial.rs
@@ -3,26 +3,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+
 use lending_iterator::LendingIterator;
 
 use crate::{
-    batch::{FixedBatch, FixedBatchRowIterator},
-    pipeline::{PipelineExecutionError, StageIterator},
+    ExecutionInterrupt, Provenance,
+    batch::{Batch, BatchRowIterator, FixedBatch, FixedBatchRowIterator},
+    pipeline::{
+        PipelineExecutionError, StageIterator,
+        stage::{ExecutionContext, StageAPI},
+    },
     row::MaybeOwnedRow,
 };
 
 pub struct InitialStage {
-    initial_batch: FixedBatch,
+    initial_batch: Batch,
 }
 
 impl InitialStage {
-    pub fn new_empty() -> Self {
-        Self { initial_batch: FixedBatch::SINGLE_EMPTY_ROW }
-    }
-
-    pub fn new_with(initial_row: MaybeOwnedRow<'_>) -> Self {
-        let batch = FixedBatch::from(initial_row);
-        Self { initial_batch: batch }
+    pub fn new(initial_batch: Batch) -> Self {
+        Self { initial_batch }
     }
 
     pub(crate) fn into_iterator(self) -> InitialIterator {
@@ -31,12 +31,12 @@ impl InitialStage {
 }
 
 pub struct InitialIterator {
-    iterator: Box<FixedBatchRowIterator>,
+    iterator: Box<BatchRowIterator>,
 }
 
 impl InitialIterator {
-    pub(crate) fn new(batch: FixedBatch) -> Self {
-        Self { iterator: Box::new(FixedBatchRowIterator::new(Ok(batch))) }
+    pub(crate) fn new(batch: Batch) -> Self {
+        Self { iterator: Box::new(batch.into_iterator()) }
     }
 }
 
@@ -44,9 +44,7 @@ impl LendingIterator for InitialIterator {
     type Item<'a> = Result<MaybeOwnedRow<'a>, Box<PipelineExecutionError>>;
 
     fn next(&mut self) -> Option<Self::Item<'_>> {
-        self.iterator.next().map(|result| {
-            result.map_err(|err| Box::new(PipelineExecutionError::ReadPatternExecution { typedb_source: err.clone() }))
-        })
+        self.iterator.next().map(|row| Ok(row))
     }
 }
 

--- a/executor/pipeline/mod.rs
+++ b/executor/pipeline/mod.rs
@@ -19,6 +19,7 @@ use crate::{
 
 pub mod delete;
 pub mod fetch;
+mod given;
 pub mod initial;
 pub mod insert;
 pub mod match_;
@@ -77,5 +78,23 @@ typedb_error! {
         WriteError(6, "Error executing write operation.", typedb_source: Box<WriteError>),
         ReadPatternExecution(7, "Error executing a read pattern.", typedb_source: ReadExecutionError),
         FetchError(8, "Error executing fetch operation.", typedb_source: FetchExecutionError),
+        GivenValueDidNotSatisfyDeclaredType(
+            9,
+            "The given value at row '{row_index}' and column '{column_index}' does not not satisfy the declared type",
+            row_index: usize,
+            column_index: usize,
+        ),
+        GivenValueDidNotSatisfyDeclaredOptionality(
+            10,
+            "The given value at row '{row_index}' and column '{column_index}' was None, but the variable was not declared optional.",
+            row_index: usize,
+            column_index: usize,
+        ),
+        GivenConceptDoesNotExist(
+            11,
+            "The given instance at row '{row_index}' and column '{column_index}' does not exist in the database",
+            row_index: usize,
+            column_index: usize,
+        ),
     }
 }

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -106,13 +106,13 @@ impl<Snapshot: ReadableSnapshot + 'static> Pipeline<Snapshot, ReadPipelineStage<
         executable_stages: &[ExecutableStage],
         executable_fetch: Option<Arc<ExecutableFetch>>,
         parameters: Arc<ParameterRegistry>,
-        given_rows: Batch,
+        given_batch: Batch,
         query_profile: Arc<QueryProfile>,
     ) -> Result<Self, Box<PipelineError>> {
         let output_variable_positions = executable_stages.last().unwrap().output_row_mapping();
         let context = ExecutionContext::new_with_profile(snapshot, thing_manager, parameters.clone(), query_profile);
 
-        let initial_iterator = InitialStage::new(given_rows);
+        let initial_iterator = InitialStage::new(given_batch);
         let initial_iterator = ReadStageIterator::Initial(Box::new(initial_iterator.into_iterator()));
         let mut stages = if let Some(given) = executable_given {
             let mut stages = Vec::with_capacity(executable_stages.len() + 1);
@@ -248,14 +248,14 @@ impl<Snapshot: WritableSnapshot + 'static> Pipeline<Snapshot, WritePipelineStage
         executable_stages: Vec<ExecutableStage>,
         executable_fetch: Option<Arc<ExecutableFetch>>,
         parameters: Arc<ParameterRegistry>,
-        given_rows: Batch,
+        given_batch: Batch,
         query_profile: Arc<QueryProfile>,
     ) -> Self {
         let output_variable_positions = executable_stages.last().unwrap().output_row_mapping();
         let context =
             ExecutionContext::new_with_profile(Arc::new(snapshot), thing_manager, parameters.clone(), query_profile);
 
-        let initial_iterator = WriteStageIterator::Initial(Box::new(InitialIterator::new(given_rows)));
+        let initial_iterator = WriteStageIterator::Initial(Box::new(InitialIterator::new(given_batch)));
         let mut stages = if let Some(given) = executable_given {
             let mut stages = Vec::with_capacity(executable_stages.len() + 1);
             stages.push(WritePipelineStage::Given(Box::new(GivenStageExecutor::new(given))));

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -9,7 +9,11 @@ use std::{collections::HashMap, sync::Arc};
 use answer::variable::Variable;
 use compiler::{
     VariablePosition,
-    executable::{fetch::executable::ExecutableFetch, function::ExecutableFunctionRegistry, pipeline::ExecutableStage},
+    executable::{
+        fetch::executable::ExecutableFetch,
+        function::ExecutableFunctionRegistry,
+        pipeline::{ExecutableStage, GivenExecutable},
+    },
     query_structure::{ParametrisedPipelineStructure, PipelineStructure},
 };
 use concept::thing::thing_manager::ThingManager;
@@ -20,11 +24,13 @@ use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
     ExecutionInterrupt,
+    batch::Batch,
     document::ConceptDocument,
     pipeline::{
         PipelineExecutionError,
         delete::DeleteStageExecutor,
         fetch::FetchStageExecutor,
+        given::GivenStageExecutor,
         initial::{InitialIterator, InitialStage},
         insert::InsertStageExecutor,
         match_::MatchStageExecutor,
@@ -96,21 +102,25 @@ impl<Snapshot: ReadableSnapshot + 'static> Pipeline<Snapshot, ReadPipelineStage<
         variable_names: &HashMap<Variable, String>,
         pipeline_structure: Option<Arc<ParametrisedPipelineStructure>>,
         executable_functions: Arc<ExecutableFunctionRegistry>,
+        executable_given: Option<Arc<GivenExecutable>>,
         executable_stages: &[ExecutableStage],
         executable_fetch: Option<Arc<ExecutableFetch>>,
         parameters: Arc<ParameterRegistry>,
-        input: Option<MaybeOwnedRow<'_>>,
+        given_rows: Batch,
         query_profile: Arc<QueryProfile>,
     ) -> Result<Self, Box<PipelineError>> {
         let output_variable_positions = executable_stages.last().unwrap().output_row_mapping();
         let context = ExecutionContext::new_with_profile(snapshot, thing_manager, parameters.clone(), query_profile);
 
-        let initial_iterator =
-            input.map(|row| InitialStage::new_with(row)).unwrap_or_else(|| InitialStage::new_empty());
+        let initial_iterator = InitialStage::new(given_rows);
         let initial_iterator = ReadStageIterator::Initial(Box::new(initial_iterator.into_iterator()));
-
-        let mut stages: Vec<ReadPipelineStage<Snapshot>> = Vec::with_capacity(executable_stages.len());
-
+        let mut stages = if let Some(given) = executable_given {
+            let mut stages = Vec::with_capacity(executable_stages.len() + 1);
+            stages.push(ReadPipelineStage::Given(Box::new(GivenStageExecutor::new(given))));
+            stages
+        } else {
+            Vec::with_capacity(executable_stages.len())
+        };
         for executable_stage in executable_stages {
             match executable_stage {
                 ExecutableStage::Match(conjunction_executable) => {
@@ -234,19 +244,26 @@ impl<Snapshot: WritableSnapshot + 'static> Pipeline<Snapshot, WritePipelineStage
         pipeline_structure: Option<Arc<ParametrisedPipelineStructure>>,
         thing_manager: Arc<ThingManager>,
         executable_functions: Arc<ExecutableFunctionRegistry>,
+        executable_given: Option<Arc<GivenExecutable>>,
         executable_stages: Vec<ExecutableStage>,
         executable_fetch: Option<Arc<ExecutableFetch>>,
         parameters: Arc<ParameterRegistry>,
+        given_rows: Batch,
         query_profile: Arc<QueryProfile>,
     ) -> Self {
         let output_variable_positions = executable_stages.last().unwrap().output_row_mapping();
         let context =
             ExecutionContext::new_with_profile(Arc::new(snapshot), thing_manager, parameters.clone(), query_profile);
 
-        let initial_iterator =
-            WriteStageIterator::Initial(Box::new(InitialIterator::new(crate::batch::FixedBatch::SINGLE_EMPTY_ROW)));
+        let initial_iterator = WriteStageIterator::Initial(Box::new(InitialIterator::new(given_rows)));
+        let mut stages = if let Some(given) = executable_given {
+            let mut stages = Vec::with_capacity(executable_stages.len() + 1);
+            stages.push(WritePipelineStage::Given(Box::new(GivenStageExecutor::new(given))));
+            stages
+        } else {
+            Vec::with_capacity(executable_stages.len())
+        };
 
-        let mut stages = Vec::with_capacity(executable_stages.len());
         for executable_stage in executable_stages {
             match executable_stage {
                 ExecutableStage::Match(conjunction_executable) => {

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -17,6 +17,7 @@ use crate::{
     pipeline::{
         PipelineExecutionError, WrittenRowsIterator,
         delete::DeleteStageExecutor,
+        given::{GivenStageExecutor, GivenStageIterator},
         initial::InitialIterator,
         insert::InsertStageExecutor,
         match_::{MatchStageExecutor, MatchStageIterator},
@@ -137,6 +138,7 @@ pub trait StageIterator:
 }
 
 pub enum ReadPipelineStage<Snapshot: ReadableSnapshot + 'static> {
+    Given(Box<GivenStageExecutor<ReadStageIterator<Snapshot>>>),
     Match(Box<MatchStageExecutor<ReadStageIterator<Snapshot>>>),
     Select(Box<SelectStageExecutor<ReadStageIterator<Snapshot>>>),
     Sort(Box<SortStageExecutor<ReadStageIterator<Snapshot>>>),
@@ -149,6 +151,7 @@ pub enum ReadPipelineStage<Snapshot: ReadableSnapshot + 'static> {
 
 pub enum ReadStageIterator<Snapshot: ReadableSnapshot + 'static> {
     Initial(Box<InitialIterator>),
+    Given(Box<GivenStageIterator<Snapshot, ReadStageIterator<Snapshot>>>),
     Match(Box<MatchStageIterator<Snapshot, ReadStageIterator<Snapshot>>>),
     Sort(SortStageIterator),
     Distinct(Box<DistinctStageIterator<ReadStageIterator<Snapshot>>>),
@@ -173,6 +176,10 @@ impl<Snapshot: ReadableSnapshot + 'static> StageAPI<Snapshot> for ReadPipelineSt
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
         match self {
+            ReadPipelineStage::Given(stage) => {
+                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                Ok((ReadStageIterator::Given(Box::new(iterator)), snapshot))
+            }
             ReadPipelineStage::Match(stage) => {
                 let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
                 Ok((ReadStageIterator::Match(Box::new(iterator)), snapshot))
@@ -215,6 +222,7 @@ impl<Snapshot: ReadableSnapshot + 'static> LendingIterator for ReadStageIterator
     fn next(&mut self) -> Option<Self::Item<'_>> {
         match self {
             ReadStageIterator::Initial(iterator) => iterator.next(),
+            ReadStageIterator::Given(iterator) => iterator.next(),
             ReadStageIterator::Match(iterator) => iterator.next(),
             ReadStageIterator::Sort(iterator) => iterator.next(),
             ReadStageIterator::Distinct(iterator) => iterator.next(),
@@ -231,6 +239,7 @@ impl<Snapshot: ReadableSnapshot + 'static> StageIterator for ReadStageIterator<S
     fn collect_owned(self) -> Result<Batch, Box<PipelineExecutionError>> {
         match self {
             ReadStageIterator::Initial(iterator) => iterator.collect_owned(),
+            ReadStageIterator::Given(iterator) => iterator.collect_owned(),
             ReadStageIterator::Match(iterator) => iterator.collect_owned(),
             ReadStageIterator::Sort(iterator) => iterator.collect_owned(),
             ReadStageIterator::Distinct(iterator) => iterator.collect_owned(),
@@ -244,6 +253,7 @@ impl<Snapshot: ReadableSnapshot + 'static> StageIterator for ReadStageIterator<S
 }
 
 pub enum WritePipelineStage<Snapshot: WritableSnapshot + 'static> {
+    Given(Box<GivenStageExecutor<WriteStageIterator<Snapshot>>>),
     Match(Box<MatchStageExecutor<WriteStageIterator<Snapshot>>>),
     Insert(Box<InsertStageExecutor<WriteStageIterator<Snapshot>>>),
     Update(Box<UpdateStageExecutor<WriteStageIterator<Snapshot>>>),
@@ -272,6 +282,10 @@ impl<Snapshot: WritableSnapshot + 'static> StageAPI<Snapshot> for WritePipelineS
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
         match self {
+            WritePipelineStage::Given(stage) => {
+                let (iterator, context) = stage.into_iterator(input_iterator, context, interrupt)?;
+                Ok((WriteStageIterator::Given(Box::new(iterator)), context))
+            }
             WritePipelineStage::Match(stage) => {
                 let (iterator, context) = stage.into_iterator(input_iterator, context, interrupt)?;
                 Ok((WriteStageIterator::Match(Box::new(iterator)), context))
@@ -326,6 +340,7 @@ impl<Snapshot: WritableSnapshot + 'static> StageAPI<Snapshot> for WritePipelineS
 
 pub enum WriteStageIterator<Snapshot: WritableSnapshot + 'static> {
     Initial(Box<InitialIterator>),
+    Given(Box<GivenStageIterator<Snapshot, WriteStageIterator<Snapshot>>>),
     Match(Box<MatchStageIterator<Snapshot, WriteStageIterator<Snapshot>>>),
     Write(WrittenRowsIterator),
     Sort(SortStageIterator),
@@ -343,6 +358,7 @@ impl<Snapshot: WritableSnapshot + 'static> LendingIterator for WriteStageIterato
     fn next(&mut self) -> Option<Self::Item<'_>> {
         match self {
             WriteStageIterator::Initial(iterator) => iterator.next(),
+            WriteStageIterator::Given(iterator) => iterator.next(),
             WriteStageIterator::Match(iterator) => iterator.next(),
             WriteStageIterator::Write(iterator) => iterator.next(),
             WriteStageIterator::Sort(iterator) => iterator.next(),
@@ -360,6 +376,7 @@ impl<Snapshot: WritableSnapshot + 'static> StageIterator for WriteStageIterator<
     fn collect_owned(self) -> Result<Batch, Box<PipelineExecutionError>> {
         match self {
             WriteStageIterator::Initial(iterator) => iterator.collect_owned(),
+            WriteStageIterator::Given(iterator) => iterator.collect_owned(),
             WriteStageIterator::Match(iterator) => iterator.collect_owned(),
             WriteStageIterator::Write(iterator) => iterator.collect_owned(),
             WriteStageIterator::Sort(iterator) => iterator.collect_owned(),

--- a/executor/row.rs
+++ b/executor/row.rs
@@ -42,7 +42,7 @@ impl<'a> Row<'a> {
         self.row[position.as_usize()] = VariableValue::None;
     }
 
-    pub(crate) fn set(&mut self, position: VariablePosition, value: VariableValue<'static>) {
+    pub fn set(&mut self, position: VariablePosition, value: VariableValue<'static>) {
         debug_assert!(
             *self.get(position) == VariableValue::None || *self.get(position) == value,
             "{} != {}",

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -79,6 +79,7 @@ fn setup(
             thing_manager.clone(),
             &FunctionManager::default(),
             &query,
+            None,
             data,
         )
         .unwrap();

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -34,7 +34,7 @@ use ir::{
 };
 use itertools::Itertools;
 use lending_iterator::LendingIterator;
-use query::query_manager::QueryManager;
+use query::{given_rows::GivenRowsSimple, query_manager::QueryManager};
 use resource::profile::{CommitProfile, QueryProfile};
 use storage::{
     MVCCStorage,
@@ -79,7 +79,7 @@ fn setup(
             thing_manager.clone(),
             &FunctionManager::default(),
             &query,
-            None,
+            None::<GivenRowsSimple>,
             data,
         )
         .unwrap();

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -125,6 +125,7 @@ fn run_read_query(
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
+            None,
             query,
         )
         .unwrap();
@@ -160,6 +161,7 @@ fn run_write_query(
             context.thing_manager.clone(),
             &context.function_manager,
             &query_as_pipeline,
+            None,
             query,
         )
         .unwrap();

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -18,7 +18,7 @@ use executor::{
 use function::function_manager::FunctionManager;
 use itertools::Either;
 use lending_iterator::LendingIterator;
-use query::{query_cache::QueryCache, query_manager::QueryManager};
+use query::{given_rows::GivenRowsSimple, query_cache::QueryCache, query_manager::QueryManager};
 use resource::profile::CommitProfile;
 use storage::{MVCCStorage, durability_client::WALClient, snapshot::CommittableSnapshot};
 use test_utils::TempDir;
@@ -125,7 +125,7 @@ fn run_read_query(
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
-            None,
+            None::<GivenRowsSimple>,
             query,
         )
         .unwrap();
@@ -161,7 +161,7 @@ fn run_write_query(
             context.thing_manager.clone(),
             &context.function_manager,
             &query_as_pipeline,
-            None,
+            None::<GivenRowsSimple>,
             query,
         )
         .unwrap();

--- a/executor/tests/pipelines.rs
+++ b/executor/tests/pipelines.rs
@@ -78,6 +78,7 @@ fn test_insert() {
             context.thing_manager.clone(),
             &context.function_manager,
             &query,
+            None,
             query_str,
         )
         .unwrap();
@@ -119,6 +120,7 @@ fn test_insert_insert() {
             context.thing_manager.clone(),
             &context.function_manager,
             &query,
+            None,
             query_str,
         )
         .unwrap();
@@ -156,6 +158,7 @@ fn test_match() {
             context.thing_manager.clone(),
             &context.function_manager,
             &query,
+            None,
             query_str,
         )
         .unwrap();
@@ -177,6 +180,7 @@ fn test_match() {
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
+            None,
             query,
         )
         .unwrap();
@@ -195,6 +199,7 @@ fn test_match() {
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
+            None,
             query,
         )
         .unwrap();
@@ -223,6 +228,7 @@ fn test_match_match() {
             context.thing_manager.clone(),
             &context.function_manager,
             &query,
+            None,
             query_str,
         )
         .unwrap();
@@ -247,6 +253,7 @@ fn test_match_match() {
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
+            None,
             query,
         )
         .unwrap();
@@ -265,6 +272,7 @@ fn test_match_match() {
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
+            None,
             query,
         )
         .unwrap();
@@ -288,6 +296,7 @@ fn test_match_delete_has() {
             context.thing_manager.clone(),
             &context.function_manager,
             &insert_query,
+            None,
             insert_query_str,
         )
         .unwrap();
@@ -325,6 +334,7 @@ fn test_match_delete_has() {
             context.thing_manager.clone(),
             &context.function_manager,
             &delete_query,
+            None,
             delete_query_str,
         )
         .unwrap();
@@ -367,6 +377,7 @@ fn test_insert_match_insert() {
             context.thing_manager.clone(),
             &context.function_manager,
             &query,
+            None,
             query_str,
         )
         .unwrap();
@@ -396,6 +407,7 @@ fn test_insert_match_insert() {
             context.thing_manager.clone(),
             &context.function_manager,
             &query,
+            None,
             query_str,
         )
         .unwrap();
@@ -428,6 +440,7 @@ fn test_match_sort() {
             context.thing_manager.clone(),
             &context.function_manager,
             &insert_query,
+            None,
             insert_query_str,
         )
         .unwrap();
@@ -450,6 +463,7 @@ fn test_match_sort() {
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
+            None,
             query,
         )
         .unwrap();
@@ -491,6 +505,7 @@ fn test_select() {
             context.thing_manager.clone(),
             &context.function_manager,
             &insert_query,
+            None,
             insert_query_str,
         )
         .unwrap();
@@ -514,6 +529,7 @@ fn test_select() {
                 context.thing_manager.clone(),
                 &context.function_manager,
                 &match_,
+                None,
                 query,
             )
             .unwrap();
@@ -533,6 +549,7 @@ fn test_select() {
                 context.thing_manager.clone(),
                 &context.function_manager,
                 &match_,
+                None,
                 query,
             )
             .unwrap();
@@ -558,6 +575,7 @@ fn test_require() {
             context.thing_manager.clone(),
             &context.function_manager,
             &insert_query,
+            None,
             insert_query_str,
         )
         .unwrap();
@@ -581,6 +599,7 @@ fn test_require() {
                 context.thing_manager.clone(),
                 &context.function_manager,
                 &match_,
+                None,
                 query,
             )
             .unwrap();

--- a/executor/tests/pipelines.rs
+++ b/executor/tests/pipelines.rs
@@ -17,7 +17,7 @@ use executor::{
 };
 use function::function_manager::FunctionManager;
 use lending_iterator::LendingIterator;
-use query::{query_cache::QueryCache, query_manager::QueryManager};
+use query::{given_rows::GivenRowsSimple, query_cache::QueryCache, query_manager::QueryManager};
 use resource::profile::{CommitProfile, StorageCounters};
 use storage::{MVCCStorage, durability_client::WALClient, snapshot::CommittableSnapshot};
 use test_utils::{TempDir, assert_matches};
@@ -78,7 +78,7 @@ fn test_insert() {
             context.thing_manager.clone(),
             &context.function_manager,
             &query,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
         )
         .unwrap();
@@ -120,7 +120,7 @@ fn test_insert_insert() {
             context.thing_manager.clone(),
             &context.function_manager,
             &query,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
         )
         .unwrap();
@@ -158,7 +158,7 @@ fn test_match() {
             context.thing_manager.clone(),
             &context.function_manager,
             &query,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
         )
         .unwrap();
@@ -180,7 +180,7 @@ fn test_match() {
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
-            None,
+            None::<GivenRowsSimple>,
             query,
         )
         .unwrap();
@@ -199,7 +199,7 @@ fn test_match() {
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
-            None,
+            None::<GivenRowsSimple>,
             query,
         )
         .unwrap();
@@ -228,7 +228,7 @@ fn test_match_match() {
             context.thing_manager.clone(),
             &context.function_manager,
             &query,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
         )
         .unwrap();
@@ -253,7 +253,7 @@ fn test_match_match() {
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
-            None,
+            None::<GivenRowsSimple>,
             query,
         )
         .unwrap();
@@ -272,7 +272,7 @@ fn test_match_match() {
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
-            None,
+            None::<GivenRowsSimple>,
             query,
         )
         .unwrap();
@@ -296,7 +296,7 @@ fn test_match_delete_has() {
             context.thing_manager.clone(),
             &context.function_manager,
             &insert_query,
-            None,
+            None::<GivenRowsSimple>,
             insert_query_str,
         )
         .unwrap();
@@ -334,7 +334,7 @@ fn test_match_delete_has() {
             context.thing_manager.clone(),
             &context.function_manager,
             &delete_query,
-            None,
+            None::<GivenRowsSimple>,
             delete_query_str,
         )
         .unwrap();
@@ -377,7 +377,7 @@ fn test_insert_match_insert() {
             context.thing_manager.clone(),
             &context.function_manager,
             &query,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
         )
         .unwrap();
@@ -407,7 +407,7 @@ fn test_insert_match_insert() {
             context.thing_manager.clone(),
             &context.function_manager,
             &query,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
         )
         .unwrap();
@@ -440,7 +440,7 @@ fn test_match_sort() {
             context.thing_manager.clone(),
             &context.function_manager,
             &insert_query,
-            None,
+            None::<GivenRowsSimple>,
             insert_query_str,
         )
         .unwrap();
@@ -463,7 +463,7 @@ fn test_match_sort() {
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
-            None,
+            None::<GivenRowsSimple>,
             query,
         )
         .unwrap();
@@ -505,7 +505,7 @@ fn test_select() {
             context.thing_manager.clone(),
             &context.function_manager,
             &insert_query,
-            None,
+            None::<GivenRowsSimple>,
             insert_query_str,
         )
         .unwrap();
@@ -529,7 +529,7 @@ fn test_select() {
                 context.thing_manager.clone(),
                 &context.function_manager,
                 &match_,
-                None,
+                None::<GivenRowsSimple>,
                 query,
             )
             .unwrap();
@@ -549,7 +549,7 @@ fn test_select() {
                 context.thing_manager.clone(),
                 &context.function_manager,
                 &match_,
-                None,
+                None::<GivenRowsSimple>,
                 query,
             )
             .unwrap();
@@ -575,7 +575,7 @@ fn test_require() {
             context.thing_manager.clone(),
             &context.function_manager,
             &insert_query,
-            None,
+            None::<GivenRowsSimple>,
             insert_query_str,
         )
         .unwrap();
@@ -599,7 +599,7 @@ fn test_require() {
                 context.thing_manager.clone(),
                 &context.function_manager,
                 &match_,
-                None,
+                None::<GivenRowsSimple>,
                 query,
             )
             .unwrap();

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -308,6 +308,11 @@ typedb_error! {
             "Optionals are not allowed in negations as this can never return a meaningful result.",
             // source_span: Option<Span>,
         ),
+        NonInitialGiven(
+            54,
+            "Given clauses must be the first clause in a query pipeline.",
+            source_span: Option<Span>,
+        ),
         InternalNotAValueBuiltin(
             100,
             "Attempted to translate function '{token}' as a builtin value function.",

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -315,16 +315,17 @@ impl VariableRegistry {
         self.variable_source_spans.get(&variable).cloned()
     }
 
-    pub(crate) fn register_function_argument(
+    pub(crate) fn register_input_variable(
         &mut self,
         name: &str,
         category: VariableCategory,
+        optionality: VariableOptionality,
         source_span: Option<Span>,
     ) -> Result<Variable, Box<RepresentationError>> {
         let variable = self.register_variable_named(name.to_owned(), source_span)?;
-        self.set_variable_category(variable, category, VariableCategorySource::Argument)
+        self.set_variable_category(variable, category, VariableCategorySource::ArgumentOrGiven)
             .expect("Expected a newly created variable");
-        self.set_variable_is_optional(variable, false);
+        self.set_variable_is_optional(variable, optionality == VariableOptionality::Optional);
         Ok(variable)
     }
 
@@ -366,7 +367,7 @@ impl fmt::Display for VariableRegistry {
 pub enum VariableCategorySource {
     Constraint(Constraint<Variable>),
     Reduce(Reducer),
-    Argument,
+    ArgumentOrGiven,
     Delete,
     Variable(Variable),
 }

--- a/ir/translation/constraints.rs
+++ b/ir/translation/constraints.rs
@@ -5,10 +5,8 @@
  */
 
 use answer::variable::Variable;
-use bytes::byte_array::ByteArray;
-use encoding::{graph::thing::THING_VERTEX_MAX_LENGTH, value::label::Label};
+use encoding::value::label::Label;
 use error::UnimplementedFeature;
-use itertools::Itertools;
 use typeql::{
     ScopedLabel, TypeRef, TypeRefAny,
     common::{Span, Spanned},
@@ -33,6 +31,7 @@ use crate::{
     translation::{
         expression::{add_typeql_expression, add_user_defined_function_call, build_expression},
         literal::translate_literal,
+        parse_iid,
         tokens::{checked_identifier, translate_value_type},
     },
 };
@@ -431,35 +430,15 @@ fn add_typeql_isa(
     Ok(())
 }
 
-fn parse_iid(mut iid: &str) -> ByteArray<THING_VERTEX_MAX_LENGTH> {
-    fn from_hex(c: u8) -> u8 {
-        // relying on the fact that typeql ensures only hex digits
-        match c {
-            b'0'..=b'9' => c - b'0',
-            b'a'..=b'f' => c - b'a' + 10,
-            b'A'..=b'F' => c - b'A' + 10,
-            _ => unreachable!(),
-        }
-    }
-
-    iid = &iid["0x".len()..];
-
-    let mut bytes = [0u8; THING_VERTEX_MAX_LENGTH];
-    for (i, (hi, lo)) in iid.bytes().tuples().enumerate() {
-        bytes[i] = (from_hex(hi) << 4) + from_hex(lo);
-    }
-    let len = iid.as_bytes().len() / 2;
-    ByteArray::inline(bytes, len)
-}
-
 fn add_typeql_iid(
     constraints: &mut ConstraintsBuilder<'_, '_>,
     thing: Variable,
     iid: &typeql::statement::thing::Iid,
 ) -> Result<(), Box<RepresentationError>> {
-    let iid_parameter = constraints
-        .parameters()
-        .register_iid(parse_iid(&iid.iid), iid.span().expect("Parser did not provide IID text range"));
+    let iid_parameter = constraints.parameters().register_iid(
+        parse_iid(iid.iid.as_str()).expect("Valid IID"),
+        iid.span().expect("Parser did not provide IID text range"),
+    );
     constraints.add_iid(thing, iid_parameter, iid.span())?;
     Ok(())
 }

--- a/ir/translation/fetch.rs
+++ b/ir/translation/fetch.rs
@@ -155,9 +155,10 @@ fn translate_fetch_list(
         FetchStream::SubQueryFetch(stages) => {
             // clone context, since we don't want the inline function to affect the parent context
             let mut local_context = parent_context.clone();
-            let (translated_stages, subfetch) =
+            let (_translated_given, translated_stages, subfetch) =
                 translate_pipeline_stages(function_index, &mut local_context, value_parameters, stages)
                     .map_err(|err| FetchRepresentationError::SubFetchRepresentation { typedb_source: err })?;
+            debug_assert!(_translated_given.is_none());
             if let Some(subfetch) = subfetch {
                 let input_variables = find_sub_fetch_inputs(parent_context, &translated_stages, &subfetch);
                 Ok(FetchSome::ListSubFetch(FetchListSubFetch {

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -8,9 +8,9 @@ use answer::variable::Variable;
 use error::needs_update_when_feature_is_implemented;
 use itertools::Itertools;
 use typeql::{
-    common::Spanned,
+    common::{Span, Spanned},
     schema::definable::function::{
-        FunctionBlock, Output, ReturnReduction, ReturnSingle, ReturnStatement, ReturnStream,
+        Argument, FunctionBlock, Output, ReturnReduction, ReturnSingle, ReturnStatement, ReturnStream,
     },
     type_::{NamedType, NamedTypeAny},
 };
@@ -71,22 +71,8 @@ pub fn translate_function_from(
     };
 
     let argument_labels = signature.args.iter().map(|arg| arg.type_.clone()).collect();
-    let args_sources_categories = signature
-        .args
-        .iter()
-        .map(|arg| {
-            let name = arg
-                .var
-                .name()
-                .ok_or(FunctionRepresentationError::NonAnonymousVariableExpected { source_span: arg.var.span() })?
-                .to_owned();
-            Ok::<_, FunctionRepresentationError>((
-                name,
-                arg.var.span(),
-                named_type_any_to_category_and_optionality(&arg.type_),
-            ))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let args_sources_categories =
+        signature.args.iter().map(|arg| function_argument_name_and_category(arg)).collect::<Result<Vec<_>, _>>()?;
 
     let (mut context, arguments) = PipelineTranslationContext::new_function_pipeline(args_sources_categories)
         .map_err(|typedb_source| FunctionRepresentationError::BlockDefinition { typedb_source })?;
@@ -94,6 +80,7 @@ pub fn translate_function_from(
     let body = translate_function_block(function_index, &mut context, &mut value_parameters, block)?;
 
     // Check for unused arguments
+    debug_assert!(arguments.iter().all(|&arg| context.variable_registry.get_variable_name(arg).is_some()));
     for (index, &arg) in arguments.iter().enumerate() {
         if !body.stages.iter().any(|stage| {
             if let TranslatedStage::Match { block, .. } = stage {
@@ -103,8 +90,10 @@ pub fn translate_function_from(
                 false
             }
         }) {
-            let argument_variable =
-                context.variable_registry.get_variable_name(arg).expect("Argument names were validated earlier");
+            let argument_variable = context
+                .variable_registry
+                .get_variable_name(arg)
+                .expect(format!("Argument names were validated earlier. Signature {signature:?}.").as_str());
             return Err(Box::new(FunctionRepresentationError::FunctionArgumentUnused {
                 variable: argument_variable.clone(),
                 source_span: signature.args[index].span,
@@ -158,17 +147,29 @@ pub fn translate_function_from(
     ))
 }
 
+pub(crate) fn function_argument_name_and_category(
+    arg: &Argument,
+) -> Result<(String, Option<Span>, (VariableCategory, VariableOptionality)), FunctionRepresentationError> {
+    let name = arg
+        .var
+        .name()
+        .ok_or(FunctionRepresentationError::NonAnonymousVariableExpected { source_span: arg.var.span() })?
+        .to_owned();
+    Ok::<_, FunctionRepresentationError>((name, arg.var.span(), named_type_any_to_category_and_optionality(&arg.type_)))
+}
+
 pub(crate) fn translate_function_block(
     function_index: &impl FunctionSignatureIndex,
     context: &mut PipelineTranslationContext,
     value_parameters: &mut ParameterRegistry,
     function_block: &FunctionBlock,
 ) -> Result<FunctionBody, Box<FunctionRepresentationError>> {
-    let (stages, fetch) = translate_pipeline_stages(function_index, context, value_parameters, &function_block.stages)
-        .map_err(|typedb_source| FunctionRepresentationError::BlockDefinition { typedb_source })?;
-
+    let (_translated_given, stages, fetch) =
+        translate_pipeline_stages(function_index, context, value_parameters, &function_block.stages)
+            .map_err(|typedb_source| FunctionRepresentationError::BlockDefinition { typedb_source })?;
+    debug_assert!(_translated_given.is_none());
     let has_illegal_stages = stages.iter().any(|stage| match stage {
-        TranslatedStage::Insert { .. }
+        | TranslatedStage::Insert { .. }
         | TranslatedStage::Update { .. }
         | TranslatedStage::Put { .. }
         | TranslatedStage::Delete { .. } => true,

--- a/ir/translation/literal.rs
+++ b/ir/translation/literal.rs
@@ -27,7 +27,7 @@ use typeql::{
 
 use crate::LiteralParseError;
 
-pub(crate) fn translate_literal(literal: &Literal) -> Result<Value<'static>, LiteralParseError> {
+pub fn translate_literal(literal: &Literal) -> Result<Value<'static>, LiteralParseError> {
     Value::from_typeql_literal(&literal.inner, literal.span())
 }
 

--- a/ir/translation/mod.rs
+++ b/ir/translation/mod.rs
@@ -4,9 +4,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::HashMap;
+use std::{collections::HashMap, io::Read};
 
 use answer::variable::Variable;
+use bytes::byte_array::ByteArray;
+use encoding::graph::thing::THING_VERTEX_MAX_LENGTH;
+use itertools::Itertools;
 use typeql::common::Span;
 
 use crate::{
@@ -49,16 +52,24 @@ impl PipelineTranslationContext {
     pub fn new_function_pipeline(
         input_variables: Vec<(String, Option<Span>, (VariableCategory, VariableOptionality))>,
     ) -> Result<(Self, Vec<Variable>), Box<RepresentationError>> {
-        let mut last_stage_visible_variables = HashMap::new();
-        let mut variable_registry = VariableRegistry::new();
+        debug_assert!(input_variables.iter().all(|(_, _, (_, opt))| VariableOptionality::Required == *opt));
         let mut variables = Vec::with_capacity(input_variables.len());
-        for (name, source_span, (category, _optionality)) in input_variables {
-            let variable = variable_registry.register_function_argument(name.as_str(), category, source_span)?;
-            last_stage_visible_variables.insert(name.clone(), variable);
-            variables.push(variable);
+        let mut this = Self::new();
+        for input_variable in input_variables {
+            variables.push(this.register_input_variable(input_variable)?);
         }
-        let this = Self { variable_registry, last_stage_visible_variables };
         Ok((this, variables))
+    }
+
+    pub(crate) fn register_input_variable(
+        &mut self,
+        input_variable: (String, Option<Span>, (VariableCategory, VariableOptionality)),
+    ) -> Result<Variable, Box<RepresentationError>> {
+        let (name, source_span, (category, optionality)) = input_variable;
+        let variable =
+            self.variable_registry.register_input_variable(name.as_str(), category, optionality, source_span)?;
+        self.last_stage_visible_variables.insert(name.clone(), variable);
+        Ok(variable)
     }
 
     pub fn new_block_builder_context<'a>(
@@ -115,3 +126,24 @@ macro_rules! verify_variable_available {
     };
 }
 pub(super) use verify_variable_available;
+
+pub fn parse_iid(iid: &str) -> Result<ByteArray<THING_VERTEX_MAX_LENGTH>, ()> {
+    fn from_hex(c: u8) -> Result<u8, ()> {
+        // relying on the fact that typeql ensures only hex digits
+        match c {
+            b'0'..=b'9' => Ok(c - b'0'),
+            b'a'..=b'f' => Ok(c - b'a' + 10),
+            b'A'..=b'F' => Ok(c - b'A' + 10),
+            _ => Err(()),
+        }
+    }
+
+    let iid = &iid["0x".len()..];
+
+    let mut bytes = [0u8; THING_VERTEX_MAX_LENGTH];
+    for (i, (hi, lo)) in iid.bytes().tuples().enumerate() {
+        bytes[i] = (from_hex(hi)? << 4) + from_hex(lo)?;
+    }
+    let len = iid.as_bytes().len() / 2;
+    Ok(ByteArray::inline(bytes, len))
+}

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -11,16 +11,16 @@ use std::{
 };
 
 use answer::variable::Variable;
-use primitive::either::Either;
 use structural_equality::StructuralEquality;
 use typeql::{
     common::{Span, Spanned},
     query::stage::{Operator as TypeQLOperator, Stage as TypeQLStage, Stage},
+    type_::NamedTypeAny,
 };
 
 use crate::{
     RepresentationError,
-    pattern::Pattern,
+    pattern::{Pattern, variable_category::VariableCategory},
     pipeline::{
         ParameterRegistry, VariableRegistry,
         block::{Block, BlockBuilder},
@@ -33,7 +33,7 @@ use crate::{
     translation::{
         PipelineTranslationContext,
         fetch::translate_fetch,
-        function::translate_typeql_function,
+        function::{function_argument_name_and_category, translate_typeql_function},
         match_::translate_match,
         modifiers::{
             translate_distinct, translate_limit, translate_offset, translate_require, translate_select, translate_sort,
@@ -46,6 +46,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct TranslatedPipeline {
     pub translated_preamble: Vec<Function>,
+    pub translated_given: Option<TranslatedGiven>,
     pub translated_stages: Vec<TranslatedStage>,
     pub translated_fetch: Option<FetchObject>,
     pub variable_registry: VariableRegistry,
@@ -57,11 +58,13 @@ impl TranslatedPipeline {
         translation_context: PipelineTranslationContext,
         value_parameters: ParameterRegistry,
         translated_preamble: Vec<Function>,
+        translated_given: Option<TranslatedGiven>,
         translated_stages: Vec<TranslatedStage>,
         translated_fetch: Option<FetchObject>,
     ) -> Self {
         TranslatedPipeline {
             translated_preamble,
+            translated_given: translated_given,
             translated_stages,
             translated_fetch,
             variable_registry: translation_context.variable_registry,
@@ -176,7 +179,7 @@ pub fn translate_pipeline(
 
     let mut translation_context = PipelineTranslationContext::new();
     let mut value_parameters = ParameterRegistry::new();
-    let (translated_stages, translated_fetch) = translate_pipeline_stages(
+    let (translated_given, translated_stages, translated_fetch) = translate_pipeline_stages(
         all_function_signatures,
         &mut translation_context,
         &mut value_parameters,
@@ -187,6 +190,7 @@ pub fn translate_pipeline(
         translation_context,
         value_parameters,
         translated_preamble,
+        translated_given,
         translated_stages,
         translated_fetch,
     ))
@@ -197,22 +201,32 @@ pub(crate) fn translate_pipeline_stages(
     translation_context: &mut PipelineTranslationContext,
     value_parameters: &mut ParameterRegistry,
     stages: &[Stage],
-) -> Result<(Vec<TranslatedStage>, Option<FetchObject>), Box<RepresentationError>> {
+) -> Result<(Option<TranslatedGiven>, Vec<TranslatedStage>, Option<FetchObject>), Box<RepresentationError>> {
     let mut translated_stages: Vec<TranslatedStage> = Vec::with_capacity(stages.len());
+    let mut translated_given = None;
+    let mut translated_fetch = None;
+
     for (i, stage) in stages.iter().enumerate() {
         let translated = translate_stage(translation_context, value_parameters, all_function_signatures, stage)?;
         match translated {
-            Either::First(stage) => translated_stages.push(stage),
-            Either::Second(fetch) => {
+            TranslatedPipelinePart::Stage(stage) => translated_stages.push(stage),
+            TranslatedPipelinePart::Given(given) => {
+                if i != 0 {
+                    return Err(Box::new(RepresentationError::NonInitialGiven { source_span: stage.span() }));
+                } else {
+                    translated_given = Some(given);
+                }
+            }
+            TranslatedPipelinePart::Fetch(fetch) => {
                 if i != stages.len() - 1 {
                     return Err(Box::new(RepresentationError::NonTerminalFetch { source_span: stage.span() }));
                 } else {
-                    return Ok((translated_stages, Some(fetch)));
+                    translated_fetch = Some(fetch)
                 }
             }
         }
     }
-    Ok((translated_stages, None))
+    Ok((translated_given, translated_stages, translated_fetch))
 }
 
 fn translate_stage(
@@ -220,48 +234,98 @@ fn translate_stage(
     value_parameters: &mut ParameterRegistry,
     all_function_signatures: &impl FunctionSignatureIndex,
     typeql_stage: &TypeQLStage,
-) -> Result<Either<TranslatedStage, FetchObject>, Box<RepresentationError>> {
+) -> Result<TranslatedPipelinePart, Box<RepresentationError>> {
     match typeql_stage {
+        TypeQLStage::Given(given) => {
+            translate_given_stage(translation_context, given).map(TranslatedPipelinePart::Given)
+        }
         TypeQLStage::Match(match_) => {
             translate_match(translation_context, value_parameters, all_function_signatures, match_).and_then(
                 |builder| {
-                    Ok(Either::First(TranslatedStage::Match { block: builder.finish()?, source_span: match_.span() }))
+                    Ok(TranslatedPipelinePart::Stage(TranslatedStage::Match {
+                        block: builder.finish()?,
+                        source_span: match_.span(),
+                    }))
                 },
             )
         }
         TypeQLStage::Insert(insert) => translate_insert(translation_context, value_parameters, insert)
-            .map(|block| Either::First(TranslatedStage::Insert { block, source_span: insert.span() })),
+            .map(|block| TranslatedPipelinePart::Stage(TranslatedStage::Insert { block, source_span: insert.span() })),
         TypeQLStage::Update(update) => translate_update(translation_context, value_parameters, update)
-            .map(|block| Either::First(TranslatedStage::Update { block, source_span: update.span() })),
+            .map(|block| TranslatedPipelinePart::Stage(TranslatedStage::Update { block, source_span: update.span() })),
         TypeQLStage::Put(put) => translate_put(translation_context, value_parameters, put)
-            .map(|block| Either::First(TranslatedStage::Put { block, source_span: put.span() })),
+            .map(|block| TranslatedPipelinePart::Stage(TranslatedStage::Put { block, source_span: put.span() })),
         TypeQLStage::Delete(delete) => {
             translate_delete(translation_context, value_parameters, delete).map(|(block, deleted_variables)| {
-                Either::First(TranslatedStage::Delete { block, deleted_variables, source_span: delete.span() })
+                TranslatedPipelinePart::Stage(TranslatedStage::Delete {
+                    block,
+                    deleted_variables,
+                    source_span: delete.span(),
+                })
             })
         }
         TypeQLStage::Fetch(fetch) => {
             translate_fetch(translation_context, value_parameters, all_function_signatures, fetch)
-                .map(Either::Second)
+                .map(TranslatedPipelinePart::Fetch)
                 .map_err(|err| Box::new(RepresentationError::FetchRepresentation { typedb_source: err }))
         }
         TypeQLStage::Operator(modifier) => match modifier {
             TypeQLOperator::Select(select) => translate_select(translation_context, select)
-                .map(|filter| Either::First(TranslatedStage::Select(filter))),
-            TypeQLOperator::Sort(sort) => {
-                translate_sort(translation_context, sort).map(|sort| Either::First(TranslatedStage::Sort(sort)))
-            }
+                .map(|filter| TranslatedPipelinePart::Stage(TranslatedStage::Select(filter))),
+            TypeQLOperator::Sort(sort) => translate_sort(translation_context, sort)
+                .map(|sort| TranslatedPipelinePart::Stage(TranslatedStage::Sort(sort))),
             TypeQLOperator::Offset(offset) => translate_offset(translation_context, offset)
-                .map(|offset| Either::First(TranslatedStage::Offset(offset))),
-            TypeQLOperator::Limit(limit) => {
-                translate_limit(translation_context, limit).map(|limit| Either::First(TranslatedStage::Limit(limit)))
-            }
+                .map(|offset| TranslatedPipelinePart::Stage(TranslatedStage::Offset(offset))),
+            TypeQLOperator::Limit(limit) => translate_limit(translation_context, limit)
+                .map(|limit| TranslatedPipelinePart::Stage(TranslatedStage::Limit(limit))),
             TypeQLOperator::Reduce(reduce) => translate_reduce(translation_context, reduce)
-                .map(|reduce| Either::First(TranslatedStage::Reduce(reduce))),
+                .map(|reduce| TranslatedPipelinePart::Stage(TranslatedStage::Reduce(reduce))),
             TypeQLOperator::Require(require) => translate_require(translation_context, require)
-                .map(|require| Either::First(TranslatedStage::Require(require))),
+                .map(|require| TranslatedPipelinePart::Stage(TranslatedStage::Require(require))),
             TypeQLOperator::Distinct(distinct) => translate_distinct(translation_context, distinct)
-                .map(|distinct| Either::First(TranslatedStage::Distinct(distinct))),
+                .map(|distinct| TranslatedPipelinePart::Stage(TranslatedStage::Distinct(distinct))),
         },
     }
+}
+
+fn translate_given_stage(
+    context: &mut PipelineTranslationContext,
+    typeql_given: &typeql::query::pipeline::stage::Given,
+) -> Result<TranslatedGiven, Box<RepresentationError>> {
+    let mut variables = Vec::with_capacity(typeql_given.variables.len());
+    let mut labels = Vec::with_capacity(typeql_given.variables.len());
+    typeql_given.variables.iter().try_for_each(|arg| {
+        let all_info = function_argument_name_and_category(arg)
+            .map_err(|typedb_source| Box::new(RepresentationError::FunctionRepresentation { typedb_source }))?;
+        variables.push(context.register_input_variable(all_info)?);
+        labels.push(arg.type_.clone());
+        Ok::<(), Box<RepresentationError>>(())
+    })?;
+    Ok(TranslatedGiven { variables, labels, span: typeql_given.span() })
+}
+
+#[derive(Debug, Clone)]
+pub struct TranslatedGiven {
+    pub variables: Vec<Variable>,
+    pub labels: Vec<NamedTypeAny>,
+    pub span: Option<Span>,
+}
+
+impl StructuralEquality for TranslatedGiven {
+    fn hash(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.variables.hash_into(&mut hasher);
+        self.labels.hash_into(&mut hasher);
+        hasher.finish()
+    }
+
+    fn equals(&self, other: &Self) -> bool {
+        self.variables.equals(&other.variables) && self.labels.equals(&other.labels)
+    }
+}
+
+enum TranslatedPipelinePart {
+    Given(TranslatedGiven),
+    Stage(TranslatedStage),
+    Fetch(FetchObject),
 }

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -64,7 +64,7 @@ impl TranslatedPipeline {
     ) -> Self {
         TranslatedPipeline {
             translated_preamble,
-            translated_given: translated_given,
+            translated_given,
             translated_stages,
             translated_fetch,
             variable_registry: translation_context.variable_registry,

--- a/query/analyse.rs
+++ b/query/analyse.rs
@@ -15,12 +15,13 @@ use compiler::{
         expression::compiled_expression::ExpressionValueType,
         fetch::{AnnotatedFetchObject, AnnotatedFetchSome},
         function::{AnnotatedFunctionSignature, FunctionParameterAnnotation},
-        pipeline::{AnnotatedPipeline, AnnotatedStage},
+        pipeline::{AnnotatedGiven, AnnotatedPipeline, AnnotatedStage},
         type_annotations::{BlockAnnotations, TypeAnnotations},
     },
     query_structure::{
-        ConjunctionAnnotations, PipelineStructure, PipelineStructureAnnotations, PipelineVariableAnnotation,
-        PipelineVariableAnnotationAndModifier, QueryStructure, StageIndex, StructureVariableId,
+        ConjunctionAnnotations, GivenStructureAnnotations, PipelineStructure, PipelineStructureAnnotations,
+        PipelineVariableAnnotation, PipelineVariableAnnotationAndModifier, QueryStructure, StageIndex,
+        StructureVariableId,
     },
 };
 use concept::{
@@ -29,7 +30,10 @@ use concept::{
 };
 use encoding::value::value_type::ValueType;
 use ir::{
-    pattern::{ParameterID, Scope, Vertex, conjunction::Conjunction, nested_pattern::NestedPattern},
+    pattern::{
+        ParameterID, Scope, Vertex, conjunction::Conjunction, nested_pattern::NestedPattern,
+        variable_category::VariableOptionality,
+    },
     pipeline::{ParameterRegistry, VariableRegistry},
 };
 use itertools::{Either, chain};
@@ -45,6 +49,7 @@ pub struct AnalysedQuery {
 #[derive(Debug)]
 pub struct QueryStructureAnnotations {
     pub preamble: Vec<FunctionStructureAnnotations>,
+    pub given: Option<GivenStructureAnnotations>,
     pub query: PipelineStructureAnnotations,
     pub fetch: Option<FetchStructureAnnotationsFields>,
 }
@@ -59,7 +64,9 @@ impl QueryStructureAnnotations {
         annotated_pipeline: &AnnotatedPipeline,
         query_structure: &QueryStructure,
     ) -> Result<Self, Box<ConceptReadError>> {
-        let AnnotatedPipeline { annotated_stages, annotated_fetch, annotated_preamble } = &annotated_pipeline;
+        let AnnotatedPipeline { annotated_stages, annotated_given, annotated_fetch, annotated_preamble } =
+            &annotated_pipeline;
+        let given = annotated_given.as_ref().map(build_given_annotations);
         let pipeline =
             build_pipeline_annotations(variable_registry, annotated_stages.as_slice(), &query_structure.query);
         let last_stage_annotations = LastStageAnnotations(annotated_stages.as_slice());
@@ -90,7 +97,7 @@ impl QueryStructureAnnotations {
             })
             .collect();
 
-        Ok(Self { preamble, query: pipeline, fetch })
+        Ok(Self { preamble, given, query: pipeline, fetch })
     }
 }
 
@@ -107,6 +114,28 @@ pub enum FetchStructureAnnotations {
 pub struct FunctionStructureAnnotations {
     pub signature: AnnotatedFunctionSignature,
     pub body: PipelineStructureAnnotations,
+}
+
+fn build_given_annotations(given: &AnnotatedGiven) -> GivenStructureAnnotations {
+    given
+        .variables
+        .iter()
+        .zip(given.expected_types.iter().zip(given.optionality.iter()))
+        .map(|(variable, (annotation, optionality))| {
+            let is_optional = *optionality == VariableOptionality::Optional;
+            let annotations = match annotation {
+                FunctionParameterAnnotation::AnyConcept => {
+                    debug_assert!(false, "This should be unreachable");
+                    PipelineVariableAnnotation::Instance(vec![])
+                }
+                FunctionParameterAnnotation::Concept(types) => {
+                    PipelineVariableAnnotation::Instance(types.iter().copied().collect())
+                }
+                FunctionParameterAnnotation::Value(value_type) => PipelineVariableAnnotation::Value(value_type.clone()),
+            };
+            (StructureVariableId::from(variable), PipelineVariableAnnotationAndModifier { is_optional, annotations })
+        })
+        .collect()
 }
 
 pub fn build_pipeline_annotations(
@@ -392,7 +421,7 @@ impl<'a> LastStageAnnotations<'a> {
                     None
                 }
             }
-            | AnnotatedStage::Delete { .. }
+            AnnotatedStage::Delete { .. }
             | AnnotatedStage::Select(_)
             | AnnotatedStage::Sort(_)
             | AnnotatedStage::Offset(_)

--- a/query/benches/bench_insert_queries.rs
+++ b/query/benches/bench_insert_queries.rs
@@ -125,7 +125,15 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
     let function_manager = FunctionManager::new(Arc::new(DefinitionKeyGenerator::new()), None);
 
     let pipeline = query_manager
-        .prepare_write_pipeline(snapshot, type_manager, thing_manager, &function_manager, &typeql_insert, query_str)
+        .prepare_write_pipeline(
+            snapshot,
+            type_manager,
+            thing_manager,
+            &function_manager,
+            &typeql_insert,
+            None,
+            query_str,
+        )
         .map_err(|(snapshot, err)| (err, snapshot))?;
     let outputs = pipeline.rows_positions().unwrap().clone();
     let (iter, ctx) =

--- a/query/benches/bench_insert_queries.rs
+++ b/query/benches/bench_insert_queries.rs
@@ -28,7 +28,7 @@ use executor::{ExecutionInterrupt, pipeline::stage::StageIterator};
 use function::function_manager::FunctionManager;
 use lending_iterator::LendingIterator;
 use pprof::ProfilerGuard;
-use query::{error::QueryError, query_cache::QueryCache, query_manager::QueryManager};
+use query::{error::QueryError, given_rows::GivenRowsSimple, query_cache::QueryCache, query_manager::QueryManager};
 use resource::profile::{CommitProfile, StorageCounters};
 use storage::{
     MVCCStorage,
@@ -131,7 +131,7 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
             thing_manager,
             &function_manager,
             &typeql_insert,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
         )
         .map_err(|(snapshot, err)| (err, snapshot))?;

--- a/query/benches/bench_insert_queries_multithreaded.rs
+++ b/query/benches/bench_insert_queries_multithreaded.rs
@@ -123,7 +123,15 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
     let function_manager = FunctionManager::new(Arc::new(DefinitionKeyGenerator::new()), None);
 
     let pipeline = query_manager
-        .prepare_write_pipeline(snapshot, type_manager, thing_manager, &function_manager, &typeql_insert, query_str)
+        .prepare_write_pipeline(
+            snapshot,
+            type_manager,
+            thing_manager,
+            &function_manager,
+            &typeql_insert,
+            None,
+            query_str,
+        )
         .map_err(|(snapshot, err)| (err, snapshot))?;
     let outputs = pipeline.rows_positions().unwrap().clone();
     let (iter, ctx) =

--- a/query/benches/bench_insert_queries_multithreaded.rs
+++ b/query/benches/bench_insert_queries_multithreaded.rs
@@ -27,7 +27,7 @@ use encoding::{
 use executor::{ExecutionInterrupt, pipeline::stage::StageIterator};
 use function::function_manager::FunctionManager;
 use lending_iterator::LendingIterator;
-use query::{error::QueryError, query_cache::QueryCache, query_manager::QueryManager};
+use query::{error::QueryError, given_rows::GivenRowsSimple, query_cache::QueryCache, query_manager::QueryManager};
 use resource::profile::{CommitProfile, StorageCounters};
 use storage::{
     MVCCStorage,
@@ -129,7 +129,7 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
             thing_manager,
             &function_manager,
             &typeql_insert,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
         )
         .map_err(|(snapshot, err)| (err, snapshot))?;

--- a/query/error.rs
+++ b/query/error.rs
@@ -36,5 +36,13 @@ typedb_error! {
         QueryExecutionClosedEarly(16, "Query execution was closed before it finished, possibly due to transaction close, rollback, commit, or a server-side error (these should be visible in the server logs)."),
         QueryAnalysisFailed(17, "Error while analysing the query.", source_query: String, typedb_source: Box<ConceptReadError>),
         PipelineStagesLimitExceeded(18, "Query pipeline has {actual} stages, which exceeds the maximum allowed {max}.", source_query: String, actual: usize, max: usize),
+        NoGivenRowsProvided(21, "The query contains a given stage, but no given rows were provided."),
+        UnexpectedGivenRowsProvided(22, "The query contains no given stage, but given rows were provided."),
+        GivenRowsWidthDoesNotMatchDeclared(
+            23,
+            "The width of the given rows provided does not match that declared in the query.",
+            declared_width: u32,
+            actual_width: u32,
+        ),
     }
 }

--- a/query/error.rs
+++ b/query/error.rs
@@ -38,8 +38,9 @@ typedb_error! {
         PipelineStagesLimitExceeded(18, "Query pipeline has {actual} stages, which exceeds the maximum allowed {max}.", source_query: String, actual: usize, max: usize),
         NoGivenRowsProvided(21, "The query contains a given stage, but no given rows were provided."),
         UnexpectedGivenRowsProvided(22, "The query contains no given stage, but given rows were provided."),
+        GivenRowsMissingRequiredVariable(23, "The given rows are missing the required variable '{variable}'.", variable: String),
         ErrorDecodingGivenRowEntry(
-            23,
+            24,
             "An error occured while decoding the given rows.",
             typedb_source: Box<GivenRowDecodeError>,
         ),

--- a/query/error.rs
+++ b/query/error.rs
@@ -15,7 +15,7 @@ use executor::pipeline::{PipelineExecutionError, pipeline::PipelineError};
 use function::FunctionError;
 use ir::RepresentationError;
 
-use crate::{define::DefineError, redefine::RedefineError, undefine::UndefineError};
+use crate::{define::DefineError, given_rows::GivenRowDecodeError, redefine::RedefineError, undefine::UndefineError};
 
 typedb_error! {
     pub QueryError(component = "Query execution", prefix = "QEX") {
@@ -38,11 +38,10 @@ typedb_error! {
         PipelineStagesLimitExceeded(18, "Query pipeline has {actual} stages, which exceeds the maximum allowed {max}.", source_query: String, actual: usize, max: usize),
         NoGivenRowsProvided(21, "The query contains a given stage, but no given rows were provided."),
         UnexpectedGivenRowsProvided(22, "The query contains no given stage, but given rows were provided."),
-        GivenRowsVariablesDoesNotMatchDeclared(
+        ErrorDecodingGivenRowEntry(
             23,
-            "The variables of the given rows provided does not match that declared in the query.",
-            declared: Vec<String>,
-            given: Vec<String>,
+            "An error occured while decoding the given rows.",
+            typedb_source: Box<GivenRowDecodeError>,
         ),
     }
 }

--- a/query/error.rs
+++ b/query/error.rs
@@ -38,11 +38,11 @@ typedb_error! {
         PipelineStagesLimitExceeded(18, "Query pipeline has {actual} stages, which exceeds the maximum allowed {max}.", source_query: String, actual: usize, max: usize),
         NoGivenRowsProvided(21, "The query contains a given stage, but no given rows were provided."),
         UnexpectedGivenRowsProvided(22, "The query contains no given stage, but given rows were provided."),
-        GivenRowsWidthDoesNotMatchDeclared(
+        GivenRowsVariablesDoesNotMatchDeclared(
             23,
-            "The width of the given rows provided does not match that declared in the query.",
-            declared_width: u32,
-            actual_width: u32,
+            "The variables of the given rows provided does not match that declared in the query.",
+            declared: Vec<String>,
+            given: Vec<String>,
         ),
     }
 }

--- a/query/given_rows.rs
+++ b/query/given_rows.rs
@@ -14,16 +14,47 @@ use error::typedb_error;
 use executor::batch::Batch;
 use ir::LiteralParseError;
 
-pub trait GivenRows {
+pub trait GivenRows: Sized {
+    type Item;
+    type Row;
     fn variables(&self) -> &[String];
+    fn decode(item: Self::Item) -> Result<GivenRowEntry, GivenRowDecodeError>;
+
+    fn row_count(&self) -> usize;
+    fn rows(self) -> impl Iterator<Item = Self::Row>;
+    fn iter_row(row: Self::Row) -> impl Iterator<Item = Self::Item>;
+
     fn into_batch_mapped(
         self,
         declared_variable_positions: &HashMap<&str, VariablePosition>,
-    ) -> Result<Batch, GivenRowDecodeError>;
-}
+    ) -> Result<Batch, GivenRowDecodeError> {
+        let mapping =
+            self.variables()
+                .iter()
+                .map(|name| {
+                    declared_variable_positions.get(&name.as_str()).copied().ok_or_else(|| {
+                        GivenRowDecodeError::GivenRowsVariableWasNotDeclared { variable: name.to_owned() }
+                    })
+                })
+                .collect::<Result<Vec<VariablePosition>, GivenRowDecodeError>>()?;
 
-pub trait GivenRowsDecoder<T> {
-    fn decode(item: T) -> Result<GivenRowEntry, GivenRowDecodeError>;
+        let width = declared_variable_positions.len() as u32;
+        let mut batch = Batch::new(width, self.row_count());
+        self.rows().into_iter().try_for_each(|row| {
+            batch.append(|mut write_to| {
+                Self::iter_row(row).enumerate().try_for_each(|(column, entry)| {
+                    let value = match Self::decode(entry)? {
+                        GivenRowEntry::None => VariableValue::None,
+                        GivenRowEntry::Thing(thing) => VariableValue::Thing(thing),
+                        GivenRowEntry::Value(value) => VariableValue::Value(value),
+                    };
+                    write_to.set(mapping[column], value);
+                    Ok(())
+                })
+            })
+        })?;
+        Ok(batch)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -31,44 +62,6 @@ pub enum GivenRowEntry {
     None,
     Thing(Thing),
     Value(Value<'static>),
-}
-
-pub fn into_batch_mapped<T, Row, Decoder>(
-    declared_variable_positions: &HashMap<&str, VariablePosition>,
-    variables: Vec<String>,
-    row_count: usize,
-    rows: impl Iterator<Item = Row>,
-) -> Result<Batch, GivenRowDecodeError>
-where
-    Row: IntoIterator<Item = T>,
-    Decoder: GivenRowsDecoder<T>,
-{
-    let mapping = variables
-        .iter()
-        .map(|name| {
-            declared_variable_positions
-                .get(&name.as_str())
-                .copied()
-                .ok_or_else(|| GivenRowDecodeError::GivenRowsVariableWasNotDeclared { variable: name.to_owned() })
-        })
-        .collect::<Result<Vec<VariablePosition>, GivenRowDecodeError>>()?;
-
-    let width = declared_variable_positions.len() as u32;
-    let mut batch = Batch::new(width, row_count);
-    rows.into_iter().try_for_each(|row| {
-        batch.append(|mut write_to| {
-            row.into_iter().enumerate().try_for_each(|(column, entry)| {
-                let value = match Decoder::decode(entry)? {
-                    GivenRowEntry::None => VariableValue::None,
-                    GivenRowEntry::Thing(thing) => VariableValue::Thing(thing),
-                    GivenRowEntry::Value(value) => VariableValue::Value(value),
-                };
-                write_to.set(mapping[column], value);
-                Ok(())
-            })
-        })
-    })?;
-    Ok(batch)
 }
 
 typedb_error! {
@@ -88,26 +81,25 @@ pub struct GivenRowsSimple {
 }
 
 impl GivenRows for GivenRowsSimple {
+    type Item = GivenRowEntry;
+    type Row = Vec<GivenRowEntry>;
     fn variables(&self) -> &[String] {
         self.variables.as_slice()
     }
 
-    fn into_batch_mapped(
-        self,
-        declared_variable_positions: &HashMap<&str, VariablePosition>,
-    ) -> Result<Batch, GivenRowDecodeError> {
-        self::into_batch_mapped::<GivenRowEntry, Vec<GivenRowEntry>, GivenRowsSimpleDecoder>(
-            declared_variable_positions,
-            self.variables,
-            self.rows.len(),
-            self.rows.into_iter(),
-        )
-    }
-}
-
-struct GivenRowsSimpleDecoder {}
-impl GivenRowsDecoder<GivenRowEntry> for GivenRowsSimpleDecoder {
-    fn decode(item: GivenRowEntry) -> Result<GivenRowEntry, GivenRowDecodeError> {
+    fn decode(item: Self::Item) -> Result<GivenRowEntry, GivenRowDecodeError> {
         Ok(item)
+    }
+
+    fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    fn rows(self) -> impl Iterator<Item = Self::Row> {
+        self.rows.into_iter()
+    }
+
+    fn iter_row(row: Self::Row) -> impl Iterator<Item = Self::Item> {
+        row.into_iter()
     }
 }

--- a/query/given_rows.rs
+++ b/query/given_rows.rs
@@ -76,7 +76,7 @@ typedb_error! {
         InvalidIIDFormatForGivenEntry(2, "The provided iid string '{iid}' was invalid.", iid: String),
         ParsingValueFailedForGivenEntry(3, "An error occured while parsing the provided value '{value}'.", value: String, typedb_source: typeql::Error),
         TranslatingValueFailedForGivenEntry(4, "An error occured while translating the provided value '{value}'.", value: String, typedb_source: LiteralParseError),
-        GivenRowsVariableWasNotDeclared(5, "The variable {variable} was not declared in the query.", variable: String),
+        GivenRowsVariableWasNotDeclared(5, "The variable '{variable}' was not declared in the query.", variable: String),
     }
 }
 

--- a/query/given_rows.rs
+++ b/query/given_rows.rs
@@ -15,6 +15,7 @@ use executor::batch::Batch;
 use ir::LiteralParseError;
 
 pub trait GivenRows {
+    fn variables(&self) -> &[String];
     fn into_batch_mapped(
         self,
         declared_variable_positions: &HashMap<&str, VariablePosition>,
@@ -87,6 +88,10 @@ pub struct GivenRowsSimple {
 }
 
 impl GivenRows for GivenRowsSimple {
+    fn variables(&self) -> &[String] {
+        self.variables.as_slice()
+    }
+
     fn into_batch_mapped(
         self,
         declared_variable_positions: &HashMap<&str, VariablePosition>,

--- a/query/given_rows.rs
+++ b/query/given_rows.rs
@@ -5,8 +5,8 @@
  */
 
 use std::collections::HashMap;
-use answer::Thing;
-use answer::variable_value::VariableValue;
+
+use answer::{Thing, variable_value::VariableValue};
 use compiler::VariablePosition;
 use concept::error::ConceptDecodeError;
 use encoding::value::value::Value;
@@ -15,7 +15,10 @@ use executor::batch::Batch;
 use ir::LiteralParseError;
 
 pub trait GivenRows {
-    fn into_batch_mapped(self, declared_variable_positions: &HashMap<&str, VariablePosition>) -> Result<Batch, GivenRowDecodeError>;
+    fn into_batch_mapped(
+        self,
+        declared_variable_positions: &HashMap<&str, VariablePosition>,
+    ) -> Result<Batch, GivenRowDecodeError>;
 }
 
 pub trait GivenRowsDecoder<T> {
@@ -29,16 +32,25 @@ pub enum GivenRowEntry {
     Value(Value<'static>),
 }
 
-pub fn into_batch_mapped<T, Row, Decoder>(declared_variable_positions: &HashMap<&str, VariablePosition>, variables: Vec<String>, row_count: usize, rows: impl Iterator<Item=Row>) -> Result<Batch, GivenRowDecodeError>
+pub fn into_batch_mapped<T, Row, Decoder>(
+    declared_variable_positions: &HashMap<&str, VariablePosition>,
+    variables: Vec<String>,
+    row_count: usize,
+    rows: impl Iterator<Item = Row>,
+) -> Result<Batch, GivenRowDecodeError>
 where
-    Row: IntoIterator<Item=T>,
+    Row: IntoIterator<Item = T>,
     Decoder: GivenRowsDecoder<T>,
 {
-    let mapping = variables.iter().map(|name| {
-        declared_variable_positions.get(&name.as_str()).copied().ok_or_else(|| {
-            GivenRowDecodeError::GivenRowsVariableWasNotDeclared { variable: name.to_owned(), }
+    let mapping = variables
+        .iter()
+        .map(|name| {
+            declared_variable_positions
+                .get(&name.as_str())
+                .copied()
+                .ok_or_else(|| GivenRowDecodeError::GivenRowsVariableWasNotDeclared { variable: name.to_owned() })
         })
-    }).collect::<Result<Vec<VariablePosition>, GivenRowDecodeError>>()?;
+        .collect::<Result<Vec<VariablePosition>, GivenRowDecodeError>>()?;
     // todo!("USE MAPPING");
 
     let width = declared_variable_positions.len() as u32;
@@ -76,17 +88,20 @@ pub struct GivenRowsSimple {
 }
 
 impl GivenRows for GivenRowsSimple {
-    fn into_batch_mapped(self, declared_variable_positions: &HashMap<&str, VariablePosition>) -> Result<Batch, GivenRowDecodeError> {
+    fn into_batch_mapped(
+        self,
+        declared_variable_positions: &HashMap<&str, VariablePosition>,
+    ) -> Result<Batch, GivenRowDecodeError> {
         self::into_batch_mapped::<GivenRowEntry, Vec<GivenRowEntry>, GivenRowsSimpleDecoder>(
             declared_variable_positions,
             self.variables,
             self.rows.len(),
-            self.rows.into_iter()
+            self.rows.into_iter(),
         )
     }
 }
 
-struct GivenRowsSimpleDecoder { }
+struct GivenRowsSimpleDecoder {}
 impl GivenRowsDecoder<GivenRowEntry> for GivenRowsSimpleDecoder {
     fn decode(what: GivenRowEntry) -> Result<GivenRowEntry, GivenRowDecodeError> {
         Ok(what)

--- a/query/given_rows.rs
+++ b/query/given_rows.rs
@@ -103,7 +103,7 @@ typedb_error! {
         TranslatingValueFailedForGivenEntry(4, "An error occured while translating the provided value '{value}'.", value: String, typedb_source: LiteralParseError),
         GivenRowsVariableWasNotDeclared(5, "The variable '{variable}' was not declared in the query.", variable: String),
         ExpectedInstanceReceivedValue(6, "A value was provided where a concept instance was expected."),
-        ValueTypeMismatch(7, "The provided value '{value}' has the JSON type '{actual_type}' and could not be decoded as the value type '{expected_type}'.", expected_type: ValueType, actual_type: String, value: String),
+        ValueTypeMismatch(7, "The provided value '{value}' has type '{actual_type}' and could not be decoded as the value type '{expected_type}'.", expected_type: ValueType, actual_type: String, value: String),
     }
 }
 

--- a/query/given_rows.rs
+++ b/query/given_rows.rs
@@ -51,7 +51,6 @@ where
                 .ok_or_else(|| GivenRowDecodeError::GivenRowsVariableWasNotDeclared { variable: name.to_owned() })
         })
         .collect::<Result<Vec<VariablePosition>, GivenRowDecodeError>>()?;
-    // todo!("USE MAPPING");
 
     let width = declared_variable_positions.len() as u32;
     let mut batch = Batch::new(width, row_count);

--- a/query/given_rows.rs
+++ b/query/given_rows.rs
@@ -7,9 +7,9 @@
 use std::collections::HashMap;
 
 use answer::{Thing, variable_value::VariableValue};
-use compiler::VariablePosition;
+use compiler::{VariablePosition, annotation::function::FunctionParameterAnnotation};
 use concept::error::ConceptDecodeError;
-use encoding::value::value::Value;
+use encoding::value::{value::Value, value_type::ValueType};
 use error::typedb_error;
 use executor::batch::Batch;
 use ir::LiteralParseError;
@@ -18,7 +18,10 @@ pub trait GivenRows: Sized {
     type Item;
     type Row;
     fn variables(&self) -> &[String];
-    fn decode(item: Self::Item) -> Result<GivenRowEntry, GivenRowDecodeError>;
+    fn decode(
+        item: Self::Item,
+        expected_type: &FunctionParameterAnnotation,
+    ) -> Result<GivenRowEntry, GivenRowDecodeError>;
 
     fn row_count(&self) -> usize;
     fn rows(self) -> impl Iterator<Item = Self::Row>;
@@ -27,6 +30,7 @@ pub trait GivenRows: Sized {
     fn into_batch_mapped(
         self,
         declared_variable_positions: &HashMap<&str, VariablePosition>,
+        expected_types: &[FunctionParameterAnnotation],
     ) -> Result<Batch, GivenRowDecodeError> {
         let mapping =
             self.variables()
@@ -43,12 +47,14 @@ pub trait GivenRows: Sized {
         self.rows().into_iter().try_for_each(|row| {
             batch.append(|mut write_to| {
                 Self::iter_row(row).enumerate().try_for_each(|(column, entry)| {
-                    let value = match Self::decode(entry)? {
+                    let target_index = mapping[column];
+                    let expected_type = &expected_types[target_index.as_usize()];
+                    let value = match Self::decode(entry, expected_type)? {
                         GivenRowEntry::None => VariableValue::None,
                         GivenRowEntry::Thing(thing) => VariableValue::Thing(thing),
                         GivenRowEntry::Value(value) => VariableValue::Value(value),
                     };
-                    write_to.set(mapping[column], value);
+                    write_to.set(target_index, value);
                     Ok(())
                 })
             })
@@ -71,6 +77,8 @@ typedb_error! {
         ParsingValueFailedForGivenEntry(3, "An error occured while parsing the provided value '{value}'.", value: String, typedb_source: typeql::Error),
         TranslatingValueFailedForGivenEntry(4, "An error occured while translating the provided value '{value}'.", value: String, typedb_source: LiteralParseError),
         GivenRowsVariableWasNotDeclared(5, "The variable '{variable}' was not declared in the query.", variable: String),
+        ExpectedValueTypeWasNotProvided(6, "A value was provided where it was not expected."),
+        ValueTypeMismatch(7, "The provided value '{value}' has the JSON type '{actual_type}' and could not be decoded as the value type '{expected_type}'.", expected_type: ValueType, actual_type: String, value: String),
     }
 }
 
@@ -87,7 +95,10 @@ impl GivenRows for GivenRowsSimple {
         self.variables.as_slice()
     }
 
-    fn decode(item: Self::Item) -> Result<GivenRowEntry, GivenRowDecodeError> {
+    fn decode(
+        item: Self::Item,
+        expected_type: &FunctionParameterAnnotation,
+    ) -> Result<GivenRowEntry, GivenRowDecodeError> {
         Ok(item)
     }
 

--- a/query/given_rows.rs
+++ b/query/given_rows.rs
@@ -1,0 +1,94 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::HashMap;
+use answer::Thing;
+use answer::variable_value::VariableValue;
+use compiler::VariablePosition;
+use concept::error::ConceptDecodeError;
+use encoding::value::value::Value;
+use error::typedb_error;
+use executor::batch::Batch;
+use ir::LiteralParseError;
+
+pub trait GivenRows {
+    fn into_batch_mapped(self, declared_variable_positions: &HashMap<&str, VariablePosition>) -> Result<Batch, GivenRowDecodeError>;
+}
+
+pub trait GivenRowsDecoder<T> {
+    fn decode(what: T) -> Result<GivenRowEntry, GivenRowDecodeError>;
+}
+
+#[derive(Debug, Clone)]
+pub enum GivenRowEntry {
+    None,
+    Thing(Thing),
+    Value(Value<'static>),
+}
+
+pub fn into_batch_mapped<T, Row, Decoder>(declared_variable_positions: &HashMap<&str, VariablePosition>, variables: Vec<String>, row_count: usize, rows: impl Iterator<Item=Row>) -> Result<Batch, GivenRowDecodeError>
+where
+    Row: IntoIterator<Item=T>,
+    Decoder: GivenRowsDecoder<T>,
+{
+    let mapping = variables.iter().map(|name| {
+        declared_variable_positions.get(&name.as_str()).copied().ok_or_else(|| {
+            GivenRowDecodeError::GivenRowsVariableWasNotDeclared { variable: name.to_owned(), }
+        })
+    }).collect::<Result<Vec<VariablePosition>, GivenRowDecodeError>>()?;
+    // todo!("USE MAPPING");
+
+    let width = declared_variable_positions.len() as u32;
+    let mut batch = Batch::new(width, row_count);
+    rows.into_iter().try_for_each(|row| {
+        batch.append(|mut write_to| {
+            row.into_iter().enumerate().try_for_each(|(column, entry)| {
+                let value = match Decoder::decode(entry)? {
+                    GivenRowEntry::None => VariableValue::None,
+                    GivenRowEntry::Thing(thing) => VariableValue::Thing(thing),
+                    GivenRowEntry::Value(value) => VariableValue::Value(value),
+                };
+                write_to.set(mapping[column], value);
+                Ok(())
+            })
+        })
+    })?;
+    Ok(batch)
+}
+
+typedb_error! {
+    pub GivenRowDecodeError(component = "Decoding given rows", prefix = "GVN") {
+        ConceptDecode(1, "An error occurred while decoding the provided concept.", typedb_source: Box<ConceptDecodeError>),
+        InvalidIIDFormatForGivenEntry(2, "The provided iid string '{iid}' was invalid.", iid: String),
+        ParsingValueFailedForGivenEntry(3, "An error occured while parsing the provided value '{value}'.", value: String, typedb_source: typeql::Error),
+        TranslatingValueFailedForGivenEntry(4, "An error occured while translating the provided value '{value}'.", value: String, typedb_source: LiteralParseError),
+        GivenRowsVariableWasNotDeclared(5, "The variable {variable} was not declared in the query.", variable: String),
+    }
+}
+
+#[derive(Debug)]
+pub struct GivenRowsSimple {
+    pub variables: Vec<String>,
+    pub rows: Vec<Vec<GivenRowEntry>>,
+}
+
+impl GivenRows for GivenRowsSimple {
+    fn into_batch_mapped(self, declared_variable_positions: &HashMap<&str, VariablePosition>) -> Result<Batch, GivenRowDecodeError> {
+        self::into_batch_mapped::<GivenRowEntry, Vec<GivenRowEntry>, GivenRowsSimpleDecoder>(
+            declared_variable_positions,
+            self.variables,
+            self.rows.len(),
+            self.rows.into_iter()
+        )
+    }
+}
+
+struct GivenRowsSimpleDecoder { }
+impl GivenRowsDecoder<GivenRowEntry> for GivenRowsSimpleDecoder {
+    fn decode(what: GivenRowEntry) -> Result<GivenRowEntry, GivenRowDecodeError> {
+        Ok(what)
+    }
+}

--- a/query/given_rows.rs
+++ b/query/given_rows.rs
@@ -23,7 +23,7 @@ pub trait GivenRows {
 }
 
 pub trait GivenRowsDecoder<T> {
-    fn decode(what: T) -> Result<GivenRowEntry, GivenRowDecodeError>;
+    fn decode(item: T) -> Result<GivenRowEntry, GivenRowDecodeError>;
 }
 
 #[derive(Debug, Clone)]
@@ -107,7 +107,7 @@ impl GivenRows for GivenRowsSimple {
 
 struct GivenRowsSimpleDecoder {}
 impl GivenRowsDecoder<GivenRowEntry> for GivenRowsSimpleDecoder {
-    fn decode(what: GivenRowEntry) -> Result<GivenRowEntry, GivenRowDecodeError> {
-        Ok(what)
+    fn decode(item: GivenRowEntry) -> Result<GivenRowEntry, GivenRowDecodeError> {
+        Ok(item)
     }
 }

--- a/query/given_rows.rs
+++ b/query/given_rows.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use answer::{Thing, variable_value::VariableValue};
 use compiler::{VariablePosition, annotation::function::FunctionParameterAnnotation};
 use concept::error::ConceptDecodeError;
-use encoding::value::{value::Value, value_type::ValueType};
+use encoding::value::{ValueEncodable, value::Value, value_type::ValueType};
 use error::typedb_error;
 use executor::batch::Batch;
 use ir::LiteralParseError;
@@ -70,6 +70,31 @@ pub enum GivenRowEntry {
     Value(Value<'static>),
 }
 
+impl GivenRowEntry {
+    pub fn try_cast_value_to(
+        value: Value<'static>,
+        expected_type: &FunctionParameterAnnotation,
+    ) -> Result<Self, GivenRowDecodeError> {
+        let FunctionParameterAnnotation::Value(expected_type) = expected_type else {
+            return Err(GivenRowDecodeError::ExpectedInstanceReceivedValue {});
+        };
+        let make_err = {
+            let actual_type = value.value_type().to_string();
+            let expected_type = expected_type.clone();
+            |value: String| GivenRowDecodeError::ValueTypeMismatch { expected_type, actual_type, value }
+        };
+
+        if value.value_type().is_trivially_castable_to(expected_type.category()) {
+            let cast_result = value.cast(expected_type.category());
+            debug_assert!(cast_result.is_some());
+            let cast_value = cast_result.ok_or_else(|| make_err("<unreachable>".to_owned()))?;
+            Ok(GivenRowEntry::Value(cast_value))
+        } else {
+            Err(make_err(value.to_string()))
+        }
+    }
+}
+
 typedb_error! {
     pub GivenRowDecodeError(component = "Decoding given rows", prefix = "GVN") {
         ConceptDecode(1, "An error occurred while decoding the provided concept.", typedb_source: Box<ConceptDecodeError>),
@@ -77,7 +102,7 @@ typedb_error! {
         ParsingValueFailedForGivenEntry(3, "An error occured while parsing the provided value '{value}'.", value: String, typedb_source: typeql::Error),
         TranslatingValueFailedForGivenEntry(4, "An error occured while translating the provided value '{value}'.", value: String, typedb_source: LiteralParseError),
         GivenRowsVariableWasNotDeclared(5, "The variable '{variable}' was not declared in the query.", variable: String),
-        ExpectedValueTypeWasNotProvided(6, "A value was provided where it was not expected."),
+        ExpectedInstanceReceivedValue(6, "A value was provided where a concept instance was expected."),
         ValueTypeMismatch(7, "The provided value '{value}' has the JSON type '{actual_type}' and could not be decoded as the value type '{expected_type}'.", expected_type: ValueType, actual_type: String, value: String),
     }
 }
@@ -99,7 +124,10 @@ impl GivenRows for GivenRowsSimple {
         item: Self::Item,
         expected_type: &FunctionParameterAnnotation,
     ) -> Result<GivenRowEntry, GivenRowDecodeError> {
-        Ok(item)
+        match item {
+            GivenRowEntry::Value(value) => GivenRowEntry::try_cast_value_to(value, expected_type),
+            other => Ok(other),
+        }
     }
 
     fn row_count(&self) -> usize {

--- a/query/lib.rs
+++ b/query/lib.rs
@@ -12,6 +12,7 @@ mod definable_resolution;
 mod definable_status;
 mod define;
 pub mod error;
+pub mod given_rows;
 pub mod query_cache;
 pub mod query_manager;
 mod redefine;

--- a/query/query_cache.rs
+++ b/query/query_cache.rs
@@ -14,7 +14,7 @@ use compiler::executable::pipeline::ExecutablePipeline;
 use concept::thing::statistics::Statistics;
 use ir::{
     pipeline::{fetch::FetchObject, function::Function},
-    translation::pipeline::TranslatedStage,
+    translation::pipeline::{TranslatedGiven, TranslatedStage},
 };
 use moka::sync::{Cache, CacheBuilder};
 use resource::{
@@ -47,10 +47,11 @@ impl QueryCache {
     pub(crate) fn get(
         &self,
         preamble: Arc<Vec<Function>>,
+        given_rows: Arc<Option<TranslatedGiven>>,
         stages: Arc<Vec<TranslatedStage>>,
         fetch: Arc<Option<FetchObject>>,
     ) -> Option<ExecutablePipeline> {
-        let key = IRQuery::new(preamble.clone(), stages, fetch);
+        let key = IRQuery::new(preamble.clone(), given_rows, stages, fetch);
         self.cache.get(&key).map(|mut found| {
             let replacement = preamble.iter().map(|func| Arc::new(func.parameters.clone())).enumerate();
             found.executable_functions.replace_preamble_parameters(replacement);
@@ -62,11 +63,12 @@ impl QueryCache {
         &self,
         statistics_sequence_number: SequenceNumber,
         preamble: Arc<Vec<Function>>,
+        given_rows: Arc<Option<TranslatedGiven>>,
         stages: Arc<Vec<TranslatedStage>>,
         fetch: Arc<Option<FetchObject>>,
         pipeline: ExecutablePipeline,
     ) {
-        let key = IRQuery::new(preamble, stages, fetch);
+        let key = IRQuery::new(preamble, given_rows, stages, fetch);
         let read_lock = self.validity_requirements.read().unwrap();
         let ValidityRequirements { latest_schema_commit, latest_statistics } = &*read_lock;
         let may_insert = latest_schema_commit
@@ -127,14 +129,20 @@ fn is_pipeline_type_populations_outdated(statistics: &Statistics, pipeline: &Exe
 
 #[derive(Debug)]
 struct IRQuery {
-    preamable: Arc<Vec<Function>>,
+    preamble: Arc<Vec<Function>>,
+    given: Arc<Option<TranslatedGiven>>,
     stages: Arc<Vec<TranslatedStage>>,
     fetch: Arc<Option<FetchObject>>,
 }
 
 impl IRQuery {
-    fn new(preamable: Arc<Vec<Function>>, stages: Arc<Vec<TranslatedStage>>, fetch: Arc<Option<FetchObject>>) -> Self {
-        Self { preamable, stages, fetch }
+    fn new(
+        preamble: Arc<Vec<Function>>,
+        given: Arc<Option<TranslatedGiven>>,
+        stages: Arc<Vec<TranslatedStage>>,
+        fetch: Arc<Option<FetchObject>>,
+    ) -> Self {
+        Self { preamble: preamble, given, stages, fetch }
     }
 }
 
@@ -155,13 +163,17 @@ impl Eq for IRQuery {}
 impl StructuralEquality for IRQuery {
     fn hash(&self) -> u64 {
         let mut hasher = DefaultHasher::new();
-        self.preamable.hash_into(&mut hasher);
+        self.preamble.hash_into(&mut hasher);
+        self.given.hash_into(&mut hasher);
         self.stages.hash_into(&mut hasher);
         self.fetch.hash_into(&mut hasher);
         hasher.finish()
     }
 
     fn equals(&self, other: &Self) -> bool {
-        self.preamable.equals(&other.preamable) && self.stages.equals(&other.stages) && self.fetch.equals(&other.fetch)
+        self.preamble.equals(&other.preamble)
+            && self.given.equals(&other.given)
+            && self.stages.equals(&other.stages)
+            && self.fetch.equals(&other.fetch)
     }
 }

--- a/query/query_cache.rs
+++ b/query/query_cache.rs
@@ -47,11 +47,11 @@ impl QueryCache {
     pub(crate) fn get(
         &self,
         preamble: Arc<Vec<Function>>,
-        given_rows: Arc<Option<TranslatedGiven>>,
+        given: Arc<Option<TranslatedGiven>>,
         stages: Arc<Vec<TranslatedStage>>,
         fetch: Arc<Option<FetchObject>>,
     ) -> Option<ExecutablePipeline> {
-        let key = IRQuery::new(preamble.clone(), given_rows, stages, fetch);
+        let key = IRQuery::new(preamble.clone(), given, stages, fetch);
         self.cache.get(&key).map(|mut found| {
             let replacement = preamble.iter().map(|func| Arc::new(func.parameters.clone())).enumerate();
             found.executable_functions.replace_preamble_parameters(replacement);
@@ -63,12 +63,12 @@ impl QueryCache {
         &self,
         statistics_sequence_number: SequenceNumber,
         preamble: Arc<Vec<Function>>,
-        given_rows: Arc<Option<TranslatedGiven>>,
+        given: Arc<Option<TranslatedGiven>>,
         stages: Arc<Vec<TranslatedStage>>,
         fetch: Arc<Option<FetchObject>>,
         pipeline: ExecutablePipeline,
     ) {
-        let key = IRQuery::new(preamble, given_rows, stages, fetch);
+        let key = IRQuery::new(preamble, given, stages, fetch);
         let read_lock = self.validity_requirements.read().unwrap();
         let ValidityRequirements { latest_schema_commit, latest_statistics } = &*read_lock;
         let may_insert = latest_schema_commit

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -4,9 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashSet, sync::Arc};
-
-use answer::{Concept, variable::Variable, variable_value::VariableValue};
+use std::sync::Arc;
+use std::collections::HashMap;
 use compiler::{
     VariablePosition,
     annotation::{
@@ -22,15 +21,12 @@ use concept::{
     thing::{ThingAPI, thing_manager::ThingManager},
     type_::type_manager::TypeManager,
 };
-use encoding::value::{ValueEncodable, value::Value};
-use error::{UnimplementedFeature, todo_must_implement};
 use executor::{
     batch::Batch,
     pipeline::{
         pipeline::Pipeline,
         stage::{ReadPipelineStage, WritePipelineStage},
     },
-    row::MaybeOwnedRow,
 };
 use function::function_manager::{FunctionManager, ReadThroughFunctionSignatureIndex, validate_no_cycles};
 use ir::{
@@ -50,21 +46,21 @@ use ir::{
 use resource::{
     constants::query::MAX_PIPELINE_STAGES,
     perf_counters::{QUERY_CACHE_HITS, QUERY_CACHE_MISSES},
-    profile::{CompileProfile, QueryProfile, StorageCounters},
+    profile::{CompileProfile, QueryProfile},
 };
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 use tracing::{Level, event};
-use typeql::{Literal, query::SchemaQuery};
-
+use typeql::query::SchemaQuery;
 use crate::{
     analyse::{
-        self, AnalysedQuery, FetchStructureAnnotationsFields, FunctionStructureAnnotations, QueryStructureAnnotations,
+        self, AnalysedQuery, FunctionStructureAnnotations, QueryStructureAnnotations,
     },
     define,
     error::QueryError,
     query_cache::QueryCache,
     redefine, undefine,
 };
+use crate::given_rows::GivenRows;
 
 #[derive(Debug, Clone)]
 pub struct QueryManager {
@@ -141,7 +137,7 @@ impl QueryManager {
         thing_manager: Arc<ThingManager>,
         function_manager: &FunctionManager,
         query: &typeql::query::Pipeline,
-        given_rows: Option<GivenRows>,
+        given_rows: Option<impl GivenRows>,
         source_query: &str,
     ) -> Result<Pipeline<Snapshot, ReadPipelineStage<Snapshot>>, Box<QueryError>> {
         event!(Level::TRACE, "Running read query:\n{}", query);
@@ -151,7 +147,7 @@ impl QueryManager {
         // 1: Translate
         let TranslatedPipeline {
             translated_preamble,
-            translated_given: translated_given,
+            translated_given,
             translated_stages,
             translated_fetch,
             mut variable_registry,
@@ -209,7 +205,7 @@ impl QueryManager {
             pipeline_structure,
             ..
         } = executable_pipeline;
-        let given_rows_batch = validate_given(executable_given.clone(), given_rows, &variable_registry)?;
+        let given_rows_batch = validate_and_decode_given(executable_given.clone(), given_rows, &variable_registry)?;
 
         // 4: Executor
         Pipeline::build_read_pipeline(
@@ -237,7 +233,7 @@ impl QueryManager {
         thing_manager: Arc<ThingManager>,
         function_manager: &FunctionManager,
         query: &typeql::query::Pipeline,
-        given_rows: Option<GivenRows>,
+        given_rows: Option<impl GivenRows>,
         source_query: &str,
     ) -> Result<Pipeline<Snapshot, WritePipelineStage<Snapshot>>, (Snapshot, Box<QueryError>)> {
         event!(Level::TRACE, "Running write query:\n{}", query);
@@ -247,7 +243,7 @@ impl QueryManager {
         // 1: Translate
         let TranslatedPipeline {
             translated_preamble,
-            translated_given: translated_given,
+            translated_given,
             translated_stages,
             translated_fetch,
             mut variable_registry,
@@ -315,7 +311,7 @@ impl QueryManager {
             pipeline_structure,
             ..
         } = executable_pipeline;
-        let given_rows_batch = match validate_given(executable_given.clone(), given_rows, &variable_registry) {
+        let given_rows_batch = match validate_and_decode_given(executable_given.clone(), given_rows, &variable_registry) {
             Ok(given_rows) => given_rows,
             Err(err) => return Err((snapshot, err)),
         };
@@ -352,7 +348,7 @@ impl QueryManager {
         // 1: Translate
         let TranslatedPipeline {
             translated_preamble,
-            translated_given: translated_given,
+            translated_given,
             translated_stages,
             translated_fetch,
             mut variable_registry,
@@ -549,9 +545,9 @@ fn annotate_and_compile_query(
     Ok(executable_pipeline)
 }
 
-fn validate_given(
+fn validate_and_decode_given(
     given_executable: Option<Arc<GivenExecutable>>,
-    given_rows: Option<GivenRows>,
+    given_rows: Option<impl GivenRows>,
     variable_registry: &VariableRegistry,
 ) -> Result<Batch, Box<QueryError>> {
     match (given_executable, given_rows) {
@@ -559,22 +555,12 @@ fn validate_given(
         (Some(_), None) => Err(Box::new(QueryError::NoGivenRowsProvided {})),
         (None, None) => Ok(Batch::new_single_empty_row()),
         (Some(executable), Some(rows)) => {
-            let declared =
-                executable.variables().iter().map(|v| variable_registry.get_variable_name_or_unnamed(*v).to_owned()).collect();
-            if declared != rows.variables {
-                Err(Box::new(QueryError::GivenRowsVariablesDoesNotMatchDeclared {
-                    declared,
-                    given: rows.variables.clone(),
-                }))
-            } else {
-                Ok(rows.batch)
-            }
+            let declared_variable_positions = executable.variables().iter().enumerate().map(|(i, v)| {
+                (variable_registry.get_variable_name_or_unnamed(*v), VariablePosition::new(i as u32))
+            }).collect::<HashMap<_, _>>();
+            rows.into_batch_mapped(&declared_variable_positions).map_err(|decode_error| {
+                Box::new(QueryError::ErrorDecodingGivenRowEntry { typedb_source: Box::new(decode_error) })
+            })
         }
     }
-}
-
-#[derive(Debug)]
-pub struct GivenRows {
-    pub variables: Vec<String>,
-    pub batch: Batch,
 }

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -207,7 +207,7 @@ impl QueryManager {
             pipeline_structure,
             ..
         } = executable_pipeline;
-        let given_rows_batch = validate_and_decode_given(executable_given.clone(), given_rows, &variable_registry)?;
+        let given_batch = validate_and_decode_given(executable_given.clone(), given_rows, &variable_registry)?;
 
         // 4: Executor
         Pipeline::build_read_pipeline(
@@ -220,7 +220,7 @@ impl QueryManager {
             &executable_stages,
             executable_fetch,
             arced_parameters,
-            given_rows_batch,
+            given_batch,
             Arc::new(query_profile),
         )
         .map_err(|typedb_source| {
@@ -313,8 +313,7 @@ impl QueryManager {
             pipeline_structure,
             ..
         } = executable_pipeline;
-        let given_rows_batch = match validate_and_decode_given(executable_given.clone(), given_rows, &variable_registry)
-        {
+        let given_batch = match validate_and_decode_given(executable_given.clone(), given_rows, &variable_registry) {
             Ok(given_rows) => given_rows,
             Err(err) => return Err((snapshot, err)),
         };
@@ -330,7 +329,7 @@ impl QueryManager {
             executable_stages,
             executable_fetch,
             arced_parameters.clone(),
-            given_rows_batch,
+            given_batch,
             Arc::new(query_profile),
         ))
     }

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -4,7 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use compiler::{
     VariablePosition,
@@ -31,7 +34,7 @@ use executor::{
 use function::function_manager::{FunctionManager, ReadThroughFunctionSignatureIndex, validate_no_cycles};
 use ir::{
     LiteralParseError, RepresentationError,
-    pattern::Vertex,
+    pattern::{Vertex, variable_category::VariableOptionality},
     pipeline::{
         ParameterRegistry, VariableRegistry,
         fetch::FetchObject,
@@ -56,7 +59,7 @@ use crate::{
     analyse::{self, AnalysedQuery, FunctionStructureAnnotations, QueryStructureAnnotations},
     define,
     error::QueryError,
-    given_rows::GivenRows,
+    given_rows::{GivenRowDecodeError, GivenRows},
     query_cache::QueryCache,
     redefine, undefine,
 };
@@ -555,12 +558,17 @@ fn validate_and_decode_given(
         (Some(_), None) => Err(Box::new(QueryError::NoGivenRowsProvided {})),
         (None, None) => Ok(Batch::new_single_empty_row()),
         (Some(executable), Some(rows)) => {
-            let declared_variable_positions = executable
-                .variables()
-                .iter()
-                .enumerate()
-                .map(|(i, v)| (variable_registry.get_variable_name_or_unnamed(*v), VariablePosition::new(i as u32)))
-                .collect::<HashMap<_, _>>();
+            let rows_vars: HashSet<&str> = HashSet::from_iter(rows.variables().iter().map(|s| s.as_str()));
+            let mut declared_variable_positions = HashMap::with_capacity(rows_vars.len());
+            for (i, (var_id, opt)) in executable.variables().iter().zip(executable.optionality().iter()).enumerate() {
+                let variable = variable_registry.get_variable_name_or_unnamed(*var_id);
+                if *opt == VariableOptionality::Required && !rows_vars.contains(variable) {
+                    return Err(Box::new(QueryError::GivenRowsMissingRequiredVariable {
+                        variable: variable.to_owned(),
+                    }));
+                }
+                declared_variable_positions.insert(variable, VariablePosition::new(i as u32));
+            }
             rows.into_batch_mapped(&declared_variable_positions).map_err(|decode_error| {
                 Box::new(QueryError::ErrorDecodingGivenRowEntry { typedb_source: Box::new(decode_error) })
             })

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -6,35 +6,55 @@
 
 use std::{collections::HashSet, sync::Arc};
 
+use answer::{Concept, variable::Variable, variable_value::VariableValue};
 use compiler::{
-    annotation::pipeline::{AnnotatedPipeline, annotate_preamble_and_pipeline},
-    executable::pipeline::{ExecutablePipeline, compile_pipeline_and_functions},
+    VariablePosition,
+    annotation::{
+        expression::compiled_expression::ExpressionValueType,
+        function::FunctionParameterAnnotation,
+        pipeline::{AnnotatedPipeline, annotate_preamble_and_pipeline},
+    },
+    executable::pipeline::{ExecutablePipeline, ExecutableStage, GivenExecutable, compile_pipeline_and_functions},
     query_structure::{extract_pipeline_structure_from, extract_query_structure_from},
     transformation::transform::apply_transformations,
 };
-use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
-use executor::pipeline::{
-    pipeline::Pipeline,
-    stage::{ReadPipelineStage, WritePipelineStage},
+use concept::{
+    thing::{ThingAPI, thing_manager::ThingManager},
+    type_::type_manager::TypeManager,
+};
+use encoding::value::{ValueEncodable, value::Value};
+use error::{UnimplementedFeature, todo_must_implement};
+use executor::{
+    batch::Batch,
+    pipeline::{
+        pipeline::Pipeline,
+        stage::{ReadPipelineStage, WritePipelineStage},
+    },
+    row::MaybeOwnedRow,
 };
 use function::function_manager::{FunctionManager, ReadThroughFunctionSignatureIndex, validate_no_cycles};
 use ir::{
+    LiteralParseError, RepresentationError,
+    pattern::Vertex,
     pipeline::{
         ParameterRegistry, VariableRegistry,
         fetch::FetchObject,
         function::Function,
         function_signature::{FunctionID, HashMapFunctionSignatureIndex},
     },
-    translation::pipeline::{TranslatedPipeline, TranslatedStage},
+    translation::{
+        literal::{FromTypeQLLiteral, translate_literal},
+        pipeline::{TranslatedGiven, TranslatedPipeline, TranslatedStage},
+    },
 };
 use resource::{
     constants::query::MAX_PIPELINE_STAGES,
     perf_counters::{QUERY_CACHE_HITS, QUERY_CACHE_MISSES},
-    profile::{CompileProfile, QueryProfile},
+    profile::{CompileProfile, QueryProfile, StorageCounters},
 };
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 use tracing::{Level, event};
-use typeql::query::SchemaQuery;
+use typeql::{Literal, query::SchemaQuery};
 
 use crate::{
     analyse::{
@@ -45,6 +65,8 @@ use crate::{
     query_cache::QueryCache,
     redefine, undefine,
 };
+
+pub type GivenRows = Batch;
 
 #[derive(Debug, Clone)]
 pub struct QueryManager {
@@ -121,6 +143,7 @@ impl QueryManager {
         thing_manager: Arc<ThingManager>,
         function_manager: &FunctionManager,
         query: &typeql::query::Pipeline,
+        given_rows: Option<GivenRows>,
         source_query: &str,
     ) -> Result<Pipeline<Snapshot, ReadPipelineStage<Snapshot>>, Box<QueryError>> {
         event!(Level::TRACE, "Running read query:\n{}", query);
@@ -130,6 +153,7 @@ impl QueryManager {
         // 1: Translate
         let TranslatedPipeline {
             translated_preamble,
+            translated_given: translated_given,
             translated_stages,
             translated_fetch,
             mut variable_registry,
@@ -137,14 +161,13 @@ impl QueryManager {
         } = translate_pipeline(snapshot.as_ref(), function_manager, query, source_query)?;
         compile_profile.translation_finished();
         let arced_preamble = Arc::new(translated_preamble);
+        let arced_given = Arc::new(translated_given);
         let arced_stages = Arc::new(translated_stages);
         let arced_fetch = Arc::new(translated_fetch);
         let arced_parameters = Arc::new(parameters);
-        let executable_pipeline = match self
-            .cache
-            .as_ref()
-            .and_then(|cache| cache.get(arced_preamble.clone(), arced_stages.clone(), arced_fetch.clone()))
-        {
+        let executable_pipeline = match self.cache.as_ref().and_then(|cache| {
+            cache.get(arced_preamble.clone(), arced_given.clone(), arced_stages.clone(), arced_fetch.clone())
+        }) {
             Some(executable_pipeline) => {
                 QUERY_CACHE_HITS.increment();
                 executable_pipeline
@@ -160,12 +183,20 @@ impl QueryManager {
                     &mut variable_registry,
                     arced_parameters.clone(),
                     arced_preamble.clone(),
+                    arced_given.clone(),
                     arced_stages.clone(),
                     arced_fetch.clone(),
                 )?;
                 if let Some(cache) = self.cache.as_ref() {
                     let seq = thing_manager.statistics().sequence_number;
-                    cache.may_insert(seq, arced_preamble, arced_stages, arced_fetch, executable_pipeline.clone())
+                    cache.may_insert(
+                        seq,
+                        arced_preamble,
+                        arced_given,
+                        arced_stages,
+                        arced_fetch,
+                        executable_pipeline.clone(),
+                    )
                 }
                 QUERY_CACHE_MISSES.increment();
                 executable_pipeline
@@ -173,8 +204,14 @@ impl QueryManager {
         };
 
         let ExecutablePipeline {
-            executable_functions, executable_stages, executable_fetch, pipeline_structure, ..
+            executable_functions,
+            executable_given,
+            executable_stages,
+            executable_fetch,
+            pipeline_structure,
+            ..
         } = executable_pipeline;
+        let given_rows = validate_given(executable_given.clone(), given_rows)?;
 
         // 4: Executor
         Pipeline::build_read_pipeline(
@@ -183,10 +220,11 @@ impl QueryManager {
             variable_registry.variable_names(),
             (variable_registry.branch_ids_allocated() < 64).then_some(pipeline_structure),
             Arc::new(executable_functions),
+            executable_given,
             &executable_stages,
             executable_fetch,
             arced_parameters,
-            None,
+            given_rows,
             Arc::new(query_profile),
         )
         .map_err(|typedb_source| {
@@ -201,6 +239,7 @@ impl QueryManager {
         thing_manager: Arc<ThingManager>,
         function_manager: &FunctionManager,
         query: &typeql::query::Pipeline,
+        given_rows: Option<GivenRows>,
         source_query: &str,
     ) -> Result<Pipeline<Snapshot, WritePipelineStage<Snapshot>>, (Snapshot, Box<QueryError>)> {
         event!(Level::TRACE, "Running write query:\n{}", query);
@@ -210,6 +249,7 @@ impl QueryManager {
         // 1: Translate
         let TranslatedPipeline {
             translated_preamble,
+            translated_given: translated_given,
             translated_stages,
             translated_fetch,
             mut variable_registry,
@@ -220,15 +260,14 @@ impl QueryManager {
         };
         compile_profile.translation_finished();
         let arced_preamble = Arc::new(translated_preamble);
+        let arced_given = Arc::new(translated_given);
         let arced_stages = Arc::new(translated_stages);
         let arced_fetch = Arc::new(translated_fetch);
         let arced_parameters = Arc::new(value_parameters);
 
-        let executable_pipeline = match self
-            .cache
-            .as_ref()
-            .and_then(|cache| cache.get(arced_preamble.clone(), arced_stages.clone(), arced_fetch.clone()))
-        {
+        let executable_pipeline = match self.cache.as_ref().and_then(|cache| {
+            cache.get(arced_preamble.clone(), arced_given.clone(), arced_stages.clone(), arced_fetch.clone())
+        }) {
             Some(executable_pipeline) => {
                 QUERY_CACHE_HITS.increment();
                 executable_pipeline
@@ -244,6 +283,7 @@ impl QueryManager {
                     &mut variable_registry,
                     arced_parameters.clone(),
                     arced_preamble.clone(),
+                    arced_given.clone(),
                     arced_stages.clone(),
                     arced_fetch.clone(),
                 );
@@ -253,6 +293,7 @@ impl QueryManager {
                             cache.may_insert(
                                 thing_manager.statistics().sequence_number,
                                 arced_preamble,
+                                arced_given,
                                 arced_stages,
                                 arced_fetch,
                                 executable_pipeline.clone(),
@@ -269,8 +310,17 @@ impl QueryManager {
         };
 
         let ExecutablePipeline {
-            executable_functions, executable_stages, executable_fetch, pipeline_structure, ..
+            executable_functions,
+            executable_given,
+            executable_stages,
+            executable_fetch,
+            pipeline_structure,
+            ..
         } = executable_pipeline;
+        let given_rows = match validate_given(executable_given.clone(), given_rows) {
+            Ok(given_rows) => given_rows,
+            Err(err) => return Err((snapshot, err)),
+        };
 
         // 4: Executor
         Ok(Pipeline::build_write_pipeline(
@@ -279,9 +329,11 @@ impl QueryManager {
             (variable_registry.branch_ids_allocated() < 64).then_some(pipeline_structure),
             thing_manager,
             Arc::new(executable_functions),
+            executable_given,
             executable_stages,
             executable_fetch,
             arced_parameters.clone(),
+            given_rows,
             Arc::new(query_profile),
         ))
     }
@@ -302,6 +354,7 @@ impl QueryManager {
         // 1: Translate
         let TranslatedPipeline {
             translated_preamble,
+            translated_given: translated_given,
             translated_stages,
             translated_fetch,
             mut variable_registry,
@@ -309,6 +362,7 @@ impl QueryManager {
         } = translate_pipeline(snapshot.as_ref(), function_manager, query, source_query)?;
         compile_profile.translation_finished();
         let arced_preamble = Arc::new(translated_preamble);
+        let arced_given = translated_given.map(Arc::new);
         let arced_stages = Arc::new(translated_stages);
         let arced_fetch = Arc::new(translated_fetch);
 
@@ -336,6 +390,7 @@ impl QueryManager {
             &mut variable_registry,
             &parameters,
             (*arced_preamble).clone(),
+            arced_given.map(|given| (*given).clone()),
             (*arced_stages).clone(),
             (*arced_fetch).clone(),
         )
@@ -404,6 +459,7 @@ fn annotate_and_compile_query(
     variable_registry: &mut VariableRegistry,
     arced_parameters: Arc<ParameterRegistry>,
     arced_preamble: Arc<Vec<Function>>,
+    arced_given: Arc<Option<TranslatedGiven>>,
     arced_stages: Arc<Vec<TranslatedStage>>,
     arced_fetch: Arc<Option<FetchObject>>,
 ) -> Result<ExecutablePipeline, Box<QueryError>> {
@@ -436,6 +492,7 @@ fn annotate_and_compile_query(
         variable_registry,
         &arced_parameters,
         (*arced_preamble).clone(),
+        (*arced_given).clone(),
         (*arced_stages).clone(),
         (*arced_fetch).clone(),
     );
@@ -453,6 +510,7 @@ fn annotate_and_compile_query(
     // TODO: We can avoid this for the regular query path when we break studio backwards compatibility
     let pipeline_structure = Arc::new(extract_pipeline_structure_from(
         &variable_registry,
+        annotated_pipeline.annotated_given.as_ref(),
         &annotated_pipeline.annotated_stages,
         source_query,
     ));
@@ -467,7 +525,8 @@ fn annotate_and_compile_query(
         }
     };
 
-    let AnnotatedPipeline { annotated_preamble, annotated_stages, annotated_fetch } = annotated_pipeline;
+    let AnnotatedPipeline { annotated_preamble, annotated_given, annotated_stages, annotated_fetch } =
+        annotated_pipeline;
 
     // 3: Compile
     let executable_pipeline = match compile_pipeline_and_functions(
@@ -475,9 +534,9 @@ fn annotate_and_compile_query(
         &variable_registry,
         &annotated_schema_functions,
         annotated_preamble,
+        annotated_given,
         annotated_stages,
         annotated_fetch,
-        &HashSet::with_capacity(0),
         pipeline_structure,
     ) {
         Ok(executable) => executable,
@@ -490,4 +549,26 @@ fn annotate_and_compile_query(
     };
     compile_profile.compilation_finished();
     Ok(executable_pipeline)
+}
+
+fn validate_given(
+    given_executable: Option<Arc<GivenExecutable>>,
+    given_rows: Option<Batch>,
+) -> Result<Batch, Box<QueryError>> {
+    let expected_width = given_executable.map(|executable| executable.variables().len() as u32);
+    match (expected_width, given_rows) {
+        (None, Some(_)) => Err(Box::new(QueryError::UnexpectedGivenRowsProvided {})),
+        (Some(_), None) => Err(Box::new(QueryError::NoGivenRowsProvided {})),
+        (None, None) => Ok(Batch::new_single_empty_row()),
+        (Some(width), Some(batch)) => {
+            if width != batch.width() {
+                Err(Box::new(QueryError::GivenRowsWidthDoesNotMatchDeclared {
+                    declared_width: width,
+                    actual_width: batch.width(),
+                }))
+            } else {
+                Ok(batch)
+            }
+        }
+    }
 }

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -66,8 +66,6 @@ use crate::{
     redefine, undefine,
 };
 
-pub type GivenRows = Batch;
-
 #[derive(Debug, Clone)]
 pub struct QueryManager {
     cache: Option<Arc<QueryCache>>,
@@ -211,7 +209,7 @@ impl QueryManager {
             pipeline_structure,
             ..
         } = executable_pipeline;
-        let given_rows = validate_given(executable_given.clone(), given_rows)?;
+        let given_rows_batch = validate_given(executable_given.clone(), given_rows, &variable_registry)?;
 
         // 4: Executor
         Pipeline::build_read_pipeline(
@@ -224,7 +222,7 @@ impl QueryManager {
             &executable_stages,
             executable_fetch,
             arced_parameters,
-            given_rows,
+            given_rows_batch,
             Arc::new(query_profile),
         )
         .map_err(|typedb_source| {
@@ -317,7 +315,7 @@ impl QueryManager {
             pipeline_structure,
             ..
         } = executable_pipeline;
-        let given_rows = match validate_given(executable_given.clone(), given_rows) {
+        let given_rows_batch = match validate_given(executable_given.clone(), given_rows, &variable_registry) {
             Ok(given_rows) => given_rows,
             Err(err) => return Err((snapshot, err)),
         };
@@ -333,7 +331,7 @@ impl QueryManager {
             executable_stages,
             executable_fetch,
             arced_parameters.clone(),
-            given_rows,
+            given_rows_batch,
             Arc::new(query_profile),
         ))
     }
@@ -553,22 +551,30 @@ fn annotate_and_compile_query(
 
 fn validate_given(
     given_executable: Option<Arc<GivenExecutable>>,
-    given_rows: Option<Batch>,
+    given_rows: Option<GivenRows>,
+    variable_registry: &VariableRegistry,
 ) -> Result<Batch, Box<QueryError>> {
-    let expected_width = given_executable.map(|executable| executable.variables().len() as u32);
-    match (expected_width, given_rows) {
+    match (given_executable, given_rows) {
         (None, Some(_)) => Err(Box::new(QueryError::UnexpectedGivenRowsProvided {})),
         (Some(_), None) => Err(Box::new(QueryError::NoGivenRowsProvided {})),
         (None, None) => Ok(Batch::new_single_empty_row()),
-        (Some(width), Some(batch)) => {
-            if width != batch.width() {
-                Err(Box::new(QueryError::GivenRowsWidthDoesNotMatchDeclared {
-                    declared_width: width,
-                    actual_width: batch.width(),
+        (Some(executable), Some(rows)) => {
+            let declared =
+                executable.variables().iter().map(|v| variable_registry.get_variable_name_or_unnamed(*v).to_owned()).collect();
+            if declared != rows.variables {
+                Err(Box::new(QueryError::GivenRowsVariablesDoesNotMatchDeclared {
+                    declared,
+                    given: rows.variables.clone(),
                 }))
             } else {
-                Ok(batch)
+                Ok(rows.batch)
             }
         }
     }
+}
+
+#[derive(Debug)]
+pub struct GivenRows {
+    pub variables: Vec<String>,
+    pub batch: Batch,
 }

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -4,8 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::Arc;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
+
 use compiler::{
     VariablePosition,
     annotation::{
@@ -51,16 +51,15 @@ use resource::{
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 use tracing::{Level, event};
 use typeql::query::SchemaQuery;
+
 use crate::{
-    analyse::{
-        self, AnalysedQuery, FunctionStructureAnnotations, QueryStructureAnnotations,
-    },
+    analyse::{self, AnalysedQuery, FunctionStructureAnnotations, QueryStructureAnnotations},
     define,
     error::QueryError,
+    given_rows::GivenRows,
     query_cache::QueryCache,
     redefine, undefine,
 };
-use crate::given_rows::GivenRows;
 
 #[derive(Debug, Clone)]
 pub struct QueryManager {
@@ -311,7 +310,8 @@ impl QueryManager {
             pipeline_structure,
             ..
         } = executable_pipeline;
-        let given_rows_batch = match validate_and_decode_given(executable_given.clone(), given_rows, &variable_registry) {
+        let given_rows_batch = match validate_and_decode_given(executable_given.clone(), given_rows, &variable_registry)
+        {
             Ok(given_rows) => given_rows,
             Err(err) => return Err((snapshot, err)),
         };
@@ -555,9 +555,12 @@ fn validate_and_decode_given(
         (Some(_), None) => Err(Box::new(QueryError::NoGivenRowsProvided {})),
         (None, None) => Ok(Batch::new_single_empty_row()),
         (Some(executable), Some(rows)) => {
-            let declared_variable_positions = executable.variables().iter().enumerate().map(|(i, v)| {
-                (variable_registry.get_variable_name_or_unnamed(*v), VariablePosition::new(i as u32))
-            }).collect::<HashMap<_, _>>();
+            let declared_variable_positions = executable
+                .variables()
+                .iter()
+                .enumerate()
+                .map(|(i, v)| (variable_registry.get_variable_name_or_unnamed(*v), VariablePosition::new(i as u32)))
+                .collect::<HashMap<_, _>>();
             rows.into_batch_mapped(&declared_variable_positions).map_err(|decode_error| {
                 Box::new(QueryError::ErrorDecodingGivenRowEntry { typedb_source: Box::new(decode_error) })
             })

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -568,7 +568,7 @@ fn validate_and_decode_given(
                 }
                 declared_variable_positions.insert(variable, VariablePosition::new(i as u32));
             }
-            rows.into_batch_mapped(&declared_variable_positions).map_err(|decode_error| {
+            rows.into_batch_mapped(&declared_variable_positions, executable.expected_types()).map_err(|decode_error| {
                 Box::new(QueryError::ErrorDecodingGivenRowEntry { typedb_source: Box::new(decode_error) })
             })
         }

--- a/query/tests/fetch.rs
+++ b/query/tests/fetch.rs
@@ -50,7 +50,7 @@ fn insert_data(
     let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
     let query = typeql::parse_query(query_string).unwrap().into_structure().into_pipeline();
     let pipeline = query_manager
-        .prepare_write_pipeline(snapshot, type_manager, thing_manager, function_manager, &query, query_string)
+        .prepare_write_pipeline(snapshot, type_manager, thing_manager, function_manager, &query, None, query_string)
         .unwrap();
     let (_iterator, context) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
     let snapshot = Arc::into_inner(context.snapshot).unwrap();
@@ -127,6 +127,7 @@ fetch {
             thing_manager.clone(),
             &function_manager,
             &pipeline,
+            None,
             query_str,
         )
         .unwrap();

--- a/query/tests/fetch.rs
+++ b/query/tests/fetch.rs
@@ -10,7 +10,7 @@ use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManag
 use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
 use executor::ExecutionInterrupt;
 use function::function_manager::FunctionManager;
-use query::{query_cache::QueryCache, query_manager::QueryManager};
+use query::{given_rows::GivenRowsSimple, query_cache::QueryCache, query_manager::QueryManager};
 use resource::profile::CommitProfile;
 use storage::{MVCCStorage, durability_client::WALClient, snapshot::CommittableSnapshot};
 use test_utils_concept::{load_managers, setup_concept_storage};
@@ -50,7 +50,15 @@ fn insert_data(
     let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
     let query = typeql::parse_query(query_string).unwrap().into_structure().into_pipeline();
     let pipeline = query_manager
-        .prepare_write_pipeline(snapshot, type_manager, thing_manager, function_manager, &query, None, query_string)
+        .prepare_write_pipeline(
+            snapshot,
+            type_manager,
+            thing_manager,
+            function_manager,
+            &query,
+            None::<GivenRowsSimple>,
+            query_string,
+        )
         .unwrap();
     let (_iterator, context) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
     let snapshot = Arc::into_inner(context.snapshot).unwrap();
@@ -127,7 +135,7 @@ fetch {
             thing_manager.clone(),
             &function_manager,
             &pipeline,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
         )
         .unwrap();

--- a/query/tests/pipeline_stages_limit.rs
+++ b/query/tests/pipeline_stages_limit.rs
@@ -64,6 +64,7 @@ fn pipeline_at_limit_is_accepted() {
         thing_manager.clone(),
         &function_manager,
         &pipeline,
+        None,
         &query_str,
     );
 
@@ -86,6 +87,7 @@ fn pipeline_over_limit_is_rejected() {
         thing_manager.clone(),
         &function_manager,
         &pipeline,
+        None,
         &query_str,
     );
     let err = match result {

--- a/query/tests/pipeline_stages_limit.rs
+++ b/query/tests/pipeline_stages_limit.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
 use function::function_manager::FunctionManager;
-use query::{error::QueryError, query_manager::QueryManager};
+use query::{error::QueryError, given_rows::GivenRowsSimple, query_manager::QueryManager};
 use resource::{constants::query::MAX_PIPELINE_STAGES, profile::CommitProfile};
 use storage::snapshot::CommittableSnapshot;
 use test_utils::assert_matches;
@@ -64,7 +64,7 @@ fn pipeline_at_limit_is_accepted() {
         thing_manager.clone(),
         &function_manager,
         &pipeline,
-        None,
+        None::<GivenRowsSimple>,
         &query_str,
     );
 
@@ -87,7 +87,7 @@ fn pipeline_over_limit_is_rejected() {
         thing_manager.clone(),
         &function_manager,
         &pipeline,
-        None,
+        None::<GivenRowsSimple>,
         &query_str,
     );
     let err = match result {

--- a/query/tests/query_profile.rs
+++ b/query/tests/query_profile.rs
@@ -57,7 +57,7 @@ fn insert_data(
     let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
     let query = typeql::parse_query(query_string).unwrap().into_structure().into_pipeline();
     let pipeline = query_manager
-        .prepare_write_pipeline(snapshot, type_manager, thing_manager, function_manager, &query, query_string)
+        .prepare_write_pipeline(snapshot, type_manager, thing_manager, function_manager, &query, None, query_string)
         .unwrap();
     let (_iterator, context) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
     let snapshot = Arc::into_inner(context.snapshot).unwrap();
@@ -172,7 +172,15 @@ fn query_profile_tree_structure() {
     let query = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let pipeline = QueryManager::new(Some(Arc::new(QueryCache::new())))
-        .prepare_read_pipeline(snapshot, &type_manager, thing_manager.clone(), &function_manager, &query, query_str)
+        .prepare_read_pipeline(
+            snapshot,
+            &type_manager,
+            thing_manager.clone(),
+            &function_manager,
+            &query,
+            None,
+            query_str,
+        )
         .unwrap();
 
     let (iterator, context) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();

--- a/query/tests/query_profile.rs
+++ b/query/tests/query_profile.rs
@@ -12,7 +12,7 @@ use executor::ExecutionInterrupt;
 use function::function_manager::FunctionManager;
 use itertools::Itertools;
 use lending_iterator::LendingIterator;
-use query::{query_cache::QueryCache, query_manager::QueryManager};
+use query::{given_rows::GivenRowsSimple, query_cache::QueryCache, query_manager::QueryManager};
 use resource::profile::{CommitProfile, PatternProfile, QueryProfile, StageProfile, SubstepProfile};
 use storage::{MVCCStorage, durability_client::WALClient, snapshot::CommittableSnapshot};
 use test_utils::init_logging;
@@ -57,7 +57,15 @@ fn insert_data(
     let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
     let query = typeql::parse_query(query_string).unwrap().into_structure().into_pipeline();
     let pipeline = query_manager
-        .prepare_write_pipeline(snapshot, type_manager, thing_manager, function_manager, &query, None, query_string)
+        .prepare_write_pipeline(
+            snapshot,
+            type_manager,
+            thing_manager,
+            function_manager,
+            &query,
+            None::<GivenRowsSimple>,
+            query_string,
+        )
         .unwrap();
     let (_iterator, context) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
     let snapshot = Arc::into_inner(context.snapshot).unwrap();
@@ -178,7 +186,7 @@ fn query_profile_tree_structure() {
             thing_manager.clone(),
             &function_manager,
             &query,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
         )
         .unwrap();

--- a/query/tests/unimplemented.rs
+++ b/query/tests/unimplemented.rs
@@ -73,6 +73,7 @@ fn run_read_query(
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
+            None,
             query,
         )
         .map_err(|query_error| Either::Left(query_error))?;
@@ -99,6 +100,7 @@ fn run_write_query(
             context.thing_manager.clone(),
             &context.function_manager,
             &query_as_pipeline,
+            None,
             query,
         )
         .unwrap();

--- a/query/tests/unimplemented.rs
+++ b/query/tests/unimplemented.rs
@@ -19,7 +19,7 @@ use function::function_manager::FunctionManager;
 use ir::RepresentationError;
 use itertools::Either;
 use lending_iterator::LendingIterator;
-use query::{error::QueryError, query_cache::QueryCache, query_manager::QueryManager};
+use query::{error::QueryError, given_rows::GivenRowsSimple, query_cache::QueryCache, query_manager::QueryManager};
 use resource::profile::CommitProfile;
 use storage::{MVCCStorage, durability_client::WALClient, snapshot::CommittableSnapshot};
 use test_utils::TempDir;
@@ -73,7 +73,7 @@ fn run_read_query(
             context.thing_manager.clone(),
             &context.function_manager,
             &match_,
-            None,
+            None::<GivenRowsSimple>,
             query,
         )
         .map_err(|query_error| Either::Left(query_error))?;
@@ -100,7 +100,7 @@ fn run_write_query(
             context.thing_manager.clone(),
             &context.function_manager,
             &query_as_pipeline,
-            None,
+            None::<GivenRowsSimple>,
             query,
         )
         .unwrap();

--- a/server/service/grpc/analyze.rs
+++ b/server/service/grpc/analyze.rs
@@ -10,10 +10,10 @@ use answer::{Type, variable::Variable};
 use compiler::{
     annotation::{function::FunctionParameterAnnotation, type_inference::get_type_annotation_from_label},
     query_structure::{
-        ConjunctionAnnotations, FunctionReturnStructure, FunctionStructure, PipelineStructure,
-        PipelineStructureAnnotations, PipelineVariableAnnotation, PipelineVariableAnnotationAndModifier,
-        QueryStructureConjunction, QueryStructureNestedPattern, QueryStructureStage, StructureSortVariable,
-        StructureVariableId,
+        ConjunctionAnnotations, FunctionReturnStructure, FunctionStructure, GivenStructureAnnotations,
+        PipelineStructure, PipelineStructureAnnotations, PipelineVariableAnnotation,
+        PipelineVariableAnnotationAndModifier, QueryStructureConjunction, QueryStructureGiven,
+        QueryStructureNestedPattern, QueryStructureStage, StructureSortVariable, StructureVariableId,
     },
 };
 use concept::{error::ConceptReadError, type_::type_manager::TypeManager};
@@ -75,6 +75,12 @@ pub fn encode_analyzed_query(
     analyzed_query: AnalysedQuery,
 ) -> Result<typedb_protocol::analyze::res::AnalyzedQuery, Box<ConceptReadError>> {
     let AnalysedQuery { structure, annotations, source } = analyzed_query;
+    let given = match (&structure.query.parametrised_structure.given, &annotations.given) {
+        (Some(given_structure), Some(given_annotations)) => {
+            Some(encode_analyzed_given(snapshot, type_manager, given_structure, given_annotations)?)
+        }
+        _ => None,
+    };
     let query = encode_analyzed_pipeline(snapshot, type_manager, &structure.query, &annotations.query)?;
     let preamble = std::iter::zip(structure.preamble.iter(), annotations.preamble.iter())
         .map(|(structure, annotations)| encode_function(snapshot, type_manager, structure, annotations))
@@ -87,7 +93,7 @@ pub fn encode_analyzed_query(
                 .map(|object| analyze_proto::Fetch { node: Some(analyze_proto::fetch::Node::Object(object)) })
         })
         .transpose()?;
-    Ok(typedb_protocol::analyze::res::AnalyzedQuery { source, query: Some(query), preamble, fetch })
+    Ok(typedb_protocol::analyze::res::AnalyzedQuery { source, query: Some(query), preamble, fetch, given })
 }
 
 fn encode_function(
@@ -149,6 +155,17 @@ fn encode_function(
         arguments_annotations,
         return_annotations,
     })
+}
+
+fn encode_analyzed_given(
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    given_structure: &QueryStructureGiven,
+    given_annotations: &GivenStructureAnnotations,
+) -> Result<analyze_proto::AnalyzedGiven, Box<ConceptReadError>> {
+    let variables = given_structure.variables.iter().map(|v| encode_structure_variable(*v)).collect();
+    let variable_annotations = encode_conjunction_annotations(snapshot, type_manager, given_annotations)?;
+    Ok(analyze_proto::AnalyzedGiven { variables, variable_annotations })
 }
 
 pub(crate) fn encode_analyzed_pipeline_for_query(

--- a/server/service/grpc/concept.rs
+++ b/server/service/grpc/concept.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use std::str::FromStr;
+use std::{borrow::Cow, str::FromStr};
 
 use answer::{Thing, Type};
 use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, TimeZone as ChronoTimeZone, Timelike};
@@ -22,6 +22,7 @@ use encoding::value::{
 use error::unimplemented_feature;
 use resource::profile::StorageCounters;
 use storage::snapshot::ReadableSnapshot;
+use typedb_protocol::migration::MigrationValue;
 
 pub(crate) fn encode_thing_concept(
     thing: &Thing,
@@ -217,6 +218,25 @@ pub(crate) fn encode_value(value: Value<'_>) -> typedb_protocol::Value {
         Value::Struct(_struct) => unimplemented_feature!(Structs),
     };
     typedb_protocol::Value { value: Some(value_message) }
+}
+
+pub(crate) fn decode_value(
+    value_proto: typedb_protocol::value::Value,
+) -> Result<Value<'static>, Box<ConceptDecodeError>> {
+    use typedb_protocol::value::Value as ValueProto;
+    let value = match value_proto {
+        ValueProto::Boolean(boolean) => Value::Boolean(boolean),
+        ValueProto::Integer(integer) => Value::Integer(integer),
+        ValueProto::Double(double) => Value::Double(double),
+        ValueProto::Decimal(decimal) => Value::Decimal(decode_decimal(decimal)?),
+        ValueProto::Date(date) => Value::Date(decode_date(date)?),
+        ValueProto::Datetime(date_time) => Value::DateTime(decode_datetime(date_time)?),
+        ValueProto::DatetimeTz(datetime_tz) => Value::DateTimeTZ(decode_datetime_tz(datetime_tz)?),
+        ValueProto::Duration(duration) => Value::Duration(decode_duration(duration)?),
+        ValueProto::String(string) => Value::String(Cow::Owned(string)),
+        ValueProto::Struct(_struct) => unimplemented_feature!(Structs),
+    };
+    Ok(value)
 }
 
 pub(crate) fn encode_decimal(decimal: Decimal) -> typedb_protocol::value::Decimal {

--- a/server/service/grpc/concept.rs
+++ b/server/service/grpc/concept.rs
@@ -22,7 +22,6 @@ use encoding::value::{
 use error::unimplemented_feature;
 use resource::profile::StorageCounters;
 use storage::snapshot::ReadableSnapshot;
-use typedb_protocol::migration::MigrationValue;
 
 pub(crate) fn encode_thing_concept(
     thing: &Thing,

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -1858,6 +1858,10 @@ impl QueueOptions {
 
 pub struct GivenRowsGrpc(typedb_protocol::query::req::GivenRows);
 impl GivenRows for GivenRowsGrpc {
+    fn variables(&self) -> &[String] {
+        self.0.variables.as_slice()
+    }
+
     fn into_batch_mapped(
         self,
         declared_variable_positions: &HashMap<&str, VariablePosition>,

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -1864,9 +1864,10 @@ impl QueueOptions {
 
 fn given_rows_from_proto(
     given_rows: Option<typedb_protocol::query::req::GivenRows>,
-) -> Result<Option<Batch>, ConceptDecodeError> {
+) -> Result<Option<GivenRows>, ConceptDecodeError> {
     use typedb_protocol::{query::req::given_entry::Entry as EntryProto, thing::Thing as ThingProto};
     let Some(given_rows) = given_rows else { return Ok(None) };
+    let variables = given_rows.variables;
     let rows = given_rows.rows;
     let len = rows.len();
     let width = rows.first().map(|row| row.entries.len() as u32).unwrap_or(0);
@@ -1912,5 +1913,5 @@ fn given_rows_from_proto(
             })
         })
     })?;
-    Ok(Some(batch))
+    Ok(Some(GivenRows { variables, batch }))
 }

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -1889,32 +1889,34 @@ impl GivenRows for GivenRowsGrpc {
 
     fn decode(
         item: Self::Item,
-        _expected_type: &FunctionParameterAnnotation,
+        expected_type: &FunctionParameterAnnotation,
     ) -> Result<GivenRowEntry, GivenRowDecodeError> {
         use typedb_protocol::{query::req::given_entry::Entry as EntryProto, thing::Thing as ThingProto};
-        Ok(match item.entry.expect("Missing proto field") {
-            EntryProto::Empty(_) => GivenRowEntry::None,
+        match item.entry.expect("Missing proto field") {
+            EntryProto::Empty(_) => Ok(GivenRowEntry::None),
             EntryProto::Value(value) => {
-                GivenRowEntry::Value(decode_value(value.value.expect("Missing proto field")).unwrap())
+                let decoded_value = decode_value(value.value.expect("Missing proto field"))
+                    .map_err(|typedb_source| GivenRowDecodeError::ConceptDecode { typedb_source })?;
+                GivenRowEntry::try_cast_value_to(decoded_value, expected_type)
             }
             EntryProto::Thing(thing) => match thing.thing.expect("Missing proto field") {
                 ThingProto::Entity(entity) => {
                     let vertex = ObjectVertex::try_decode(entity.iid.as_slice())
                         .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsEntity, entity.iid))?;
-                    GivenRowEntry::Thing(Thing::Entity(Entity::new(vertex)))
+                    Ok(GivenRowEntry::Thing(Thing::Entity(Entity::new(vertex))))
                 }
                 ThingProto::Relation(relation) => {
                     let vertex = ObjectVertex::try_decode(relation.iid.as_slice())
                         .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsRelation, relation.iid))?;
-                    GivenRowEntry::Thing(Thing::Relation(Relation::new(vertex)))
+                    Ok(GivenRowEntry::Thing(Thing::Relation(Relation::new(vertex))))
                 }
                 ThingProto::Attribute(attribute) => {
                     let vertex = AttributeVertex::try_decode(attribute.iid.as_slice())
                         .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsAttribute, attribute.iid))?;
-                    GivenRowEntry::Thing(Thing::Attribute(Attribute::new(vertex)))
+                    Ok(GivenRowEntry::Thing(Thing::Attribute(Attribute::new(vertex))))
                 }
             },
-        })
+        }
     }
 }
 

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -6,6 +6,7 @@
 
 use std::{
     collections::{HashMap, VecDeque},
+    fmt::Formatter,
     ops::{
         ControlFlow,
         ControlFlow::{Break, Continue},
@@ -13,8 +14,8 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use std::fmt::Formatter;
-use answer::{Thing};
+
+use answer::Thing;
 use bytes::util::HexBytesFormatter;
 use compiler::{VariablePosition, query_structure::PipelineStructure};
 use concept::{
@@ -50,7 +51,7 @@ use lending_iterator::LendingIterator;
 use options::QueryOptions;
 use query::{
     error::QueryError,
-    given_rows::{GivenRowDecodeError, GivenRowEntry, GivenRowsDecoder},
+    given_rows::{GivenRowDecodeError, GivenRowEntry, GivenRows, GivenRowsDecoder},
 };
 use resource::profile::{EncodingProfile, QueryProfile, StorageCounters};
 use storage::snapshot::ReadableSnapshot;
@@ -72,7 +73,7 @@ use typedb_protocol::{
 };
 use typeql::{parse_query, query::SchemaQuery};
 use uuid::Uuid;
-use query::given_rows::GivenRows;
+
 use crate::{
     service::{
         TransactionType,
@@ -1857,7 +1858,10 @@ impl QueueOptions {
 
 pub struct GivenRowsGrpc(typedb_protocol::query::req::GivenRows);
 impl GivenRows for GivenRowsGrpc {
-    fn into_batch_mapped(self, declared_variable_positions: &HashMap<&str, VariablePosition>) -> Result<Batch, GivenRowDecodeError> {
+    fn into_batch_mapped(
+        self,
+        declared_variable_positions: &HashMap<&str, VariablePosition>,
+    ) -> Result<Batch, GivenRowDecodeError> {
         query::given_rows::into_batch_mapped::<_, _, GivenRowsDecoderGrpc>(
             declared_variable_positions,
             self.0.variables,
@@ -1884,7 +1888,6 @@ macro_rules! concept_decode_error {
 
 pub struct GivenRowsDecoderGrpc;
 impl GivenRowsDecoder<typedb_protocol::query::req::GivenEntry> for GivenRowsDecoderGrpc {
-
     fn decode(what: typedb_protocol::query::req::GivenEntry) -> Result<GivenRowEntry, GivenRowDecodeError> {
         use typedb_protocol::{query::req::given_entry::Entry as EntryProto, thing::Thing as ThingProto};
         Ok(match what.entry.expect("Missing proto field") {
@@ -1894,21 +1897,18 @@ impl GivenRowsDecoder<typedb_protocol::query::req::GivenEntry> for GivenRowsDeco
             }
             EntryProto::Thing(thing) => match thing.thing.expect("Missing proto field") {
                 ThingProto::Entity(entity) => {
-                    let vertex = ObjectVertex::try_decode(entity.iid.as_slice()).ok_or_else(|| {
-                        concept_decode_error!(CouldNotDecodeIIDAsEntity, entity.iid)
-                    })?;
+                    let vertex = ObjectVertex::try_decode(entity.iid.as_slice())
+                        .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsEntity, entity.iid))?;
                     GivenRowEntry::Thing(Thing::Entity(Entity::new(vertex)))
                 }
                 ThingProto::Relation(relation) => {
-                    let vertex = ObjectVertex::try_decode(relation.iid.as_slice()).ok_or_else(|| {
-                        concept_decode_error!(CouldNotDecodeIIDAsRelation, relation.iid)
-                    })?;
+                    let vertex = ObjectVertex::try_decode(relation.iid.as_slice())
+                        .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsRelation, relation.iid))?;
                     GivenRowEntry::Thing(Thing::Relation(Relation::new(vertex)))
                 }
                 ThingProto::Attribute(attribute) => {
-                    let vertex = AttributeVertex::try_decode(attribute.iid.as_slice()).ok_or_else(|| {
-                        concept_decode_error!(CouldNotDecodeIIDAsAttribute, attribute.iid)
-                    })?;
+                    let vertex = AttributeVertex::try_decode(attribute.iid.as_slice())
+                        .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsAttribute, attribute.iid))?;
                     GivenRowEntry::Thing(Thing::Attribute(Attribute::new(vertex)))
                 }
             },

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -51,7 +51,7 @@ use lending_iterator::LendingIterator;
 use options::QueryOptions;
 use query::{
     error::QueryError,
-    given_rows::{GivenRowDecodeError, GivenRowEntry, GivenRows, GivenRowsDecoder},
+    given_rows::{GivenRowDecodeError, GivenRowEntry, GivenRows},
 };
 use resource::profile::{EncodingProfile, QueryProfile, StorageCounters};
 use storage::snapshot::ReadableSnapshot;
@@ -1856,30 +1856,6 @@ impl QueueOptions {
     }
 }
 
-pub struct GivenRowsGrpc(typedb_protocol::query::req::GivenRows);
-impl GivenRows for GivenRowsGrpc {
-    fn variables(&self) -> &[String] {
-        self.0.variables.as_slice()
-    }
-
-    fn into_batch_mapped(
-        self,
-        declared_variable_positions: &HashMap<&str, VariablePosition>,
-    ) -> Result<Batch, GivenRowDecodeError> {
-        query::given_rows::into_batch_mapped::<_, _, GivenRowsDecoderGrpc>(
-            declared_variable_positions,
-            self.0.variables,
-            self.0.rows.len(),
-            self.0.rows.into_iter().map(|row| row.entries),
-        )
-    }
-}
-impl std::fmt::Debug for GivenRowsGrpc {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "GivenRowsGrpc[omitted]")
-    }
-}
-
 macro_rules! concept_decode_error {
     ($variant:ident, $iid:expr) => {
         GivenRowDecodeError::ConceptDecode {
@@ -1890,9 +1866,28 @@ macro_rules! concept_decode_error {
     };
 }
 
-pub struct GivenRowsDecoderGrpc;
-impl GivenRowsDecoder<typedb_protocol::query::req::GivenEntry> for GivenRowsDecoderGrpc {
-    fn decode(item: typedb_protocol::query::req::GivenEntry) -> Result<GivenRowEntry, GivenRowDecodeError> {
+pub struct GivenRowsGrpc(typedb_protocol::query::req::GivenRows);
+impl GivenRows for GivenRowsGrpc {
+    type Item = typedb_protocol::query::req::GivenEntry;
+    type Row = typedb_protocol::query::req::GivenRow;
+
+    fn variables(&self) -> &[String] {
+        self.0.variables.as_slice()
+    }
+
+    fn row_count(&self) -> usize {
+        self.0.rows.len()
+    }
+
+    fn rows(self) -> impl Iterator<Item = Self::Row> {
+        self.0.rows.into_iter()
+    }
+
+    fn iter_row(row: Self::Row) -> impl Iterator<Item = Self::Item> {
+        row.entries.into_iter()
+    }
+
+    fn decode(item: Self::Item) -> Result<GivenRowEntry, GivenRowDecodeError> {
         use typedb_protocol::{query::req::given_entry::Entry as EntryProto, thing::Thing as ThingProto};
         Ok(match item.entry.expect("Missing proto field") {
             EntryProto::Empty(_) => GivenRowEntry::None,
@@ -1917,5 +1912,11 @@ impl GivenRowsDecoder<typedb_protocol::query::req::GivenEntry> for GivenRowsDeco
                 }
             },
         })
+    }
+}
+
+impl std::fmt::Debug for GivenRowsGrpc {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GivenRowsGrpc[omitted]")
     }
 }

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -5,6 +5,7 @@
  */
 
 use std::{
+    borrow::Cow,
     collections::{HashMap, VecDeque},
     ops::{
         ControlFlow,
@@ -14,15 +15,30 @@ use std::{
     time::Duration,
 };
 
-use compiler::query_structure::PipelineStructure;
-use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
-use database::query::{
-    StreamQueryOutputDescriptor, WriteQueryAnswer, WriteQueryResult, execute_schema_query,
-    execute_write_query_in_schema, execute_write_query_in_write,
+use answer::{Thing, variable_value::VariableValue};
+use bytes::util::HexBytesFormatter;
+use compiler::{VariablePosition, query_structure::PipelineStructure};
+use concept::{
+    error::ConceptDecodeError,
+    thing::{ThingAPI, attribute::Attribute, entity::Entity, relation::Relation, thing_manager::ThingManager},
+    type_::type_manager::TypeManager,
 };
-use diagnostics::metrics::{
-    ActionKind, ClientEndpoint, ReadQueryMetrics, SchemaQueryMetrics, TransactionMetrics, WriteQueryMetrics,
+use database::{
+    database_manager::DatabaseManager,
+    query::{
+        StreamQueryOutputDescriptor, WriteQueryAnswer, WriteQueryResult, execute_schema_query,
+        execute_write_query_in_schema, execute_write_query_in_write,
+    },
+    transaction::{TransactionRead, TransactionSchema, TransactionWrite},
 };
+use diagnostics::{
+    diagnostics_manager::DiagnosticsManager,
+    metrics::{
+        ActionKind, ClientEndpoint, LoadKind, ReadQueryMetrics, SchemaQueryMetrics, TransactionMetrics,
+        WriteQueryMetrics,
+    },
+};
+use encoding::graph::thing::{ThingVertex, vertex_attribute::AttributeVertex, vertex_object::ObjectVertex};
 use executor::{
     ExecutionInterrupt, InterruptType,
     batch::Batch,
@@ -33,7 +49,7 @@ use ir::pipeline::ParameterRegistry;
 use itertools::{Either, Itertools};
 use lending_iterator::LendingIterator;
 use options::QueryOptions;
-use query::error::QueryError;
+use query::{error::QueryError, query_manager::GivenRows};
 use resource::profile::{EncodingProfile, QueryProfile, StorageCounters};
 use storage::snapshot::ReadableSnapshot;
 use tokio::{
@@ -60,6 +76,7 @@ use crate::{
         TransactionType,
         grpc::{
             analyze::{encode_analyzed_pipeline_for_query, encode_analyzed_query},
+            concept::decode_value,
             diagnostics::run_with_diagnostics_async,
             document::encode_document,
             error::{IntoGrpcStatus, IntoProtocolErrorMessage, ProtocolError},
@@ -133,7 +150,7 @@ pub(crate) struct TransactionService {
 
     is_open: bool,
     transaction: Option<Transaction>,
-    query_queue: VecDeque<(Uuid, QueueOptions, typeql::query::Pipeline, String)>,
+    query_queue: VecDeque<(Uuid, QueueOptions, typeql::query::Pipeline, Option<GivenRows>, String)>,
     query_responders: HashMap<Uuid, (JoinHandle<()>, QueryStreamTransmitter)>,
     running_write_query: Option<(Uuid, JoinHandle<(Transaction, WriteQueryResult)>)>,
 
@@ -627,9 +644,11 @@ impl TransactionService {
 
     async fn cancel_queued_read_queries(&mut self, interrupt: InterruptType) -> ControlFlow<(), ()> {
         let mut write_queries = VecDeque::with_capacity(self.query_queue.len());
-        for (req_id, query_options, pipeline, source_query) in self.query_queue.drain(0..self.query_queue.len()) {
+        for (req_id, query_options, pipeline, given_rows, source_query) in
+            self.query_queue.drain(0..self.query_queue.len())
+        {
             if query_options.is_query() && is_write_pipeline(&pipeline) {
-                write_queries.push_back((req_id, query_options, pipeline, source_query));
+                write_queries.push_back((req_id, query_options, pipeline, given_rows, source_query));
             } else {
                 Self::respond_query_response(
                     &self.response_sender,
@@ -689,7 +708,7 @@ impl TransactionService {
 
     async fn cancel_queued_write_queries(&mut self, interrupt: InterruptType) -> ControlFlow<(), ()> {
         let mut read_queries = VecDeque::with_capacity(self.query_queue.len());
-        for (req_id, options, pipeline, source_query) in self.query_queue.drain(0..self.query_queue.len()) {
+        for (req_id, options, pipeline, given_rows, source_query) in self.query_queue.drain(0..self.query_queue.len()) {
             if options.is_query() && is_write_pipeline(&pipeline) {
                 Self::respond_query_response(
                     &self.response_sender,
@@ -700,7 +719,7 @@ impl TransactionService {
                 )
                 .await?;
             } else {
-                read_queries.push_back((req_id, options, pipeline, source_query));
+                read_queries.push_back((req_id, options, pipeline, given_rows, source_query));
             }
         }
         self.query_queue = read_queries;
@@ -710,14 +729,14 @@ impl TransactionService {
     async fn finish_queued_write_queries(&mut self, interrupt: InterruptType) -> Result<(), Status> {
         self.finish_running_write_query_no_transmit(interrupt).await?;
         let requests: Vec<_> = self.query_queue.drain(0..self.query_queue.len()).collect();
-        for (req_id, query_queue_options, pipeline, source_query) in requests.into_iter() {
+        for (req_id, query_queue_options, pipeline, given_rows, source_query) in requests.into_iter() {
             match (query_queue_options, is_write_pipeline(&pipeline)) {
                 (QueueOptions::Query(query_options), true) => {
-                    self.run_write_query(req_id, query_options, pipeline, source_query).await;
+                    self.run_write_query(req_id, query_options, pipeline, given_rows, source_query).await;
                     self.finish_running_write_query_no_transmit(interrupt).await?;
                 }
                 (queue_options, _) => {
-                    self.query_queue.push_back((req_id, queue_options, pipeline, source_query));
+                    self.query_queue.push_back((req_id, queue_options, pipeline, given_rows, source_query));
                 }
             }
         }
@@ -726,19 +745,26 @@ impl TransactionService {
 
     async fn may_accept_from_queue(&mut self) {
         debug_assert!(self.running_write_query.is_none());
-
         // unblock requests until the first write request, which we begin executing if it exists
-        while let Some((req_id, queue_options, query_pipeline, source_query)) = self.query_queue.pop_front() {
+        while let Some((req_id, queue_options, query_pipeline, given_rows, source_query)) = self.query_queue.pop_front()
+        {
             match (queue_options, is_write_pipeline(&query_pipeline)) {
                 (QueueOptions::Analyze, _) => {
+                    debug_assert!(given_rows.is_none());
                     self.run_analyse_query(req_id, query_pipeline, source_query).await;
                 }
                 (QueueOptions::Query(query_options), true) => {
-                    self.run_write_query(req_id, query_options, query_pipeline, source_query).await;
+                    self.run_write_query(req_id, query_options, query_pipeline, given_rows, source_query).await;
                     return;
                 }
                 (QueueOptions::Query(query_options), false) => {
-                    self.run_and_activate_read_transmitter(req_id, query_options, query_pipeline, source_query);
+                    self.run_and_activate_read_transmitter(
+                        req_id,
+                        query_options,
+                        query_pipeline,
+                        given_rows,
+                        source_query,
+                    );
                 }
             }
         }
@@ -764,9 +790,8 @@ impl TransactionService {
                 ImmediateAnalyzeResponse::non_fatal_err(TransactionServiceError::AnalyseQueryExpectsPipeline {});
             return Ok(Self::respond_analyze_response(&self.response_sender, req_id, response).await);
         };
-
         if !self.query_queue.is_empty() || self.running_write_query.is_some() {
-            self.query_queue.push_back((req_id, QueueOptions::Analyze, pipeline, query));
+            self.query_queue.push_back((req_id, QueueOptions::Analyze, pipeline, None, query));
             // queued queries are not handled yet so there will be no query response yet
             Ok(Continue(()))
         } else {
@@ -810,23 +835,45 @@ impl TransactionService {
                 Ok(Self::respond_query_response(&self.response_sender, req_id, response).await)
             }
             typeql::query::QueryStructure::Pipeline(pipeline) => {
+                let given_rows = match given_rows_from_proto(query_req.given) {
+                    Ok(given_rows) => given_rows,
+                    Err(err) => {
+                        let response =
+                            ImmediateQueryResponse::non_fatal_err(TransactionServiceError::DecodingGivenRowsFailed {
+                                typedb_source: err,
+                            });
+                        return Ok(Self::respond_query_response(&self.response_sender, req_id, response).await);
+                    }
+                };
                 #[allow(clippy::collapsible_else_if)]
                 if is_write_pipeline(&pipeline) {
                     if !self.query_queue.is_empty() || self.running_write_query.is_some() {
-                        self.query_queue.push_back((req_id, QueueOptions::Query(query_options), pipeline, query));
+                        self.query_queue.push_back((
+                            req_id,
+                            QueueOptions::Query(query_options),
+                            pipeline,
+                            given_rows,
+                            query,
+                        ));
                         // queued queries are not handled yet so there will be no query response yet
                         Ok(Continue(()))
                     } else {
-                        self.run_write_query(req_id, query_options, pipeline, query).await;
+                        self.run_write_query(req_id, query_options, pipeline, given_rows, query).await;
                         Ok(Continue(()))
                     }
                 } else {
                     if !self.query_queue.is_empty() || self.running_write_query.is_some() {
-                        self.query_queue.push_back((req_id, QueueOptions::Query(query_options), pipeline, query));
+                        self.query_queue.push_back((
+                            req_id,
+                            QueueOptions::Query(query_options),
+                            pipeline,
+                            given_rows,
+                            query,
+                        ));
                         // queued queries are not handled yet so there will be no query response yet
                         Ok(Continue(()))
                     } else {
-                        self.run_and_activate_read_transmitter(req_id, query_options, pipeline, query);
+                        self.run_and_activate_read_transmitter(req_id, query_options, pipeline, given_rows, query);
                         // running read queries have no response on the main loop and will respond asynchronously
                         Ok(Continue(()))
                     }
@@ -910,11 +957,12 @@ impl TransactionService {
         req_id: Uuid,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
+        given_rows: Option<GivenRows>,
         source_query: String,
     ) {
         debug_assert!(self.running_write_query.is_none());
         self.interrupt_and_close_responders(InterruptType::WriteQueryExecution).await;
-        let handle = match self.spawn_blocking_execute_write_query(query_options, pipeline, source_query) {
+        let handle = match self.spawn_blocking_execute_write_query(query_options, pipeline, given_rows, source_query) {
             Ok(handle) => {
                 // running write queries have no valid response yet (until they finish) and will respond asynchronously
                 handle
@@ -955,11 +1003,12 @@ impl TransactionService {
         req_id: Uuid,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
+        given_rows: Option<GivenRows>,
         source_query: String,
     ) {
         let prefetch_size = query_options.prefetch_size;
         let (sender, receiver) = channel(prefetch_size);
-        let worker_handle = self.blocking_read_query_worker(sender, query_options, pipeline, source_query);
+        let worker_handle = self.blocking_read_query_worker(sender, query_options, pipeline, given_rows, source_query);
         let stream_transmitter = QueryStreamTransmitter::start_new(
             self.response_sender.clone(),
             receiver,
@@ -974,6 +1023,7 @@ impl TransactionService {
         &mut self,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
+        given_rows: Option<GivenRows>,
         source_query: String,
     ) -> Result<JoinHandle<(Transaction, WriteQueryResult)>, TransactionServiceError> {
         debug_assert!(self.running_write_query.is_none());
@@ -981,13 +1031,25 @@ impl TransactionService {
         let interrupt = self.query_interrupt_receiver.clone();
         match self.transaction.take() {
             Some(Transaction::Schema(schema_transaction)) => Ok(spawn_blocking(move || {
-                let (transaction, result) =
-                    execute_write_query_in_schema(schema_transaction, query_options, pipeline, source_query, interrupt);
+                let (transaction, result) = execute_write_query_in_schema(
+                    schema_transaction,
+                    query_options,
+                    pipeline,
+                    given_rows,
+                    source_query,
+                    interrupt,
+                );
                 (Transaction::Schema(transaction), result)
             })),
             Some(Transaction::Write(write_transaction)) => Ok(spawn_blocking(move || {
-                let (transaction, result) =
-                    execute_write_query_in_write(write_transaction, query_options, pipeline, source_query, interrupt);
+                let (transaction, result) = execute_write_query_in_write(
+                    write_transaction,
+                    query_options,
+                    pipeline,
+                    given_rows,
+                    source_query,
+                    interrupt,
+                );
                 (Transaction::Write(transaction), result)
             })),
             Some(Transaction::Read(transaction)) => {
@@ -1183,6 +1245,7 @@ impl TransactionService {
         sender: Sender<StreamQueryResponse>,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
+        given_rows: Option<GivenRows>,
         source_query: String,
     ) -> JoinHandle<()> {
         debug_assert!(self.query_queue.is_empty() && self.running_write_query.is_none() && self.transaction.is_some());
@@ -1205,6 +1268,7 @@ impl TransactionService {
                     thing_manager.clone(),
                     &function_manager,
                     &pipeline,
+                    given_rows,
                     &source_query,
                 );
                 let pipeline = unwrap_or_execute_and_return!(pipeline, |err| {
@@ -1796,4 +1860,57 @@ impl QueueOptions {
     fn is_query(&self) -> bool {
         matches!(self, QueueOptions::Query(_))
     }
+}
+
+fn given_rows_from_proto(
+    given_rows: Option<typedb_protocol::query::req::GivenRows>,
+) -> Result<Option<Batch>, ConceptDecodeError> {
+    use typedb_protocol::{query::req::given_entry::Entry as EntryProto, thing::Thing as ThingProto};
+    let Some(given_rows) = given_rows else { return Ok(None) };
+    let rows = given_rows.rows;
+    let len = rows.len();
+    let width = rows.first().map(|row| row.entries.len() as u32).unwrap_or(0);
+    let mut batch = Batch::new(width, len);
+    rows.into_iter().try_for_each(|row| {
+        batch.append(|mut write_to| {
+            row.entries.into_iter().enumerate().try_for_each(|(column, entry)| {
+                let entry = entry.entry.expect("Missing proto file");
+                let value: VariableValue<'static> = match entry {
+                    EntryProto::Empty(_) => VariableValue::None,
+                    EntryProto::Value(value) => {
+                        VariableValue::Value(decode_value(value.value.expect("Missing proto field")).unwrap())
+                    }
+                    EntryProto::Thing(thing) => match thing.thing.expect("Missing proto field") {
+                        ThingProto::Entity(entity) => {
+                            let vertex = ObjectVertex::try_decode(entity.iid.as_slice()).ok_or_else(|| {
+                                ConceptDecodeError::CouldNotDecodeIIDAsEntity {
+                                    iid: HexBytesFormatter::owned(entity.iid),
+                                }
+                            })?;
+                            VariableValue::Thing(Thing::Entity(Entity::new(vertex)))
+                        }
+                        ThingProto::Relation(relation) => {
+                            let vertex = ObjectVertex::try_decode(relation.iid.as_slice()).ok_or_else(|| {
+                                ConceptDecodeError::CouldNotDecodeIIDAsRelation {
+                                    iid: HexBytesFormatter::owned(relation.iid),
+                                }
+                            })?;
+                            VariableValue::Thing(Thing::Relation(Relation::new(vertex)))
+                        }
+                        ThingProto::Attribute(attribute) => {
+                            let vertex = AttributeVertex::try_decode(attribute.iid.as_slice()).ok_or_else(|| {
+                                ConceptDecodeError::CouldNotDecodeIIDAsAttribute {
+                                    iid: HexBytesFormatter::owned(attribute.iid),
+                                }
+                            })?;
+                            VariableValue::Thing(Thing::Attribute(Attribute::new(vertex)))
+                        }
+                    },
+                };
+                write_to.set(VariablePosition::new(column as u32), value);
+                Ok::<_, ConceptDecodeError>(())
+            })
+        })
+    })?;
+    Ok(Some(batch))
 }

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -17,7 +17,7 @@ use std::{
 
 use answer::Thing;
 use bytes::util::HexBytesFormatter;
-use compiler::{VariablePosition, query_structure::PipelineStructure};
+use compiler::{annotation::function::FunctionParameterAnnotation, query_structure::PipelineStructure};
 use concept::{
     error::ConceptDecodeError,
     thing::{ThingAPI, attribute::Attribute, entity::Entity, relation::Relation, thing_manager::ThingManager},
@@ -1887,7 +1887,10 @@ impl GivenRows for GivenRowsGrpc {
         row.entries.into_iter()
     }
 
-    fn decode(item: Self::Item) -> Result<GivenRowEntry, GivenRowDecodeError> {
+    fn decode(
+        item: Self::Item,
+        _expected_type: &FunctionParameterAnnotation,
+    ) -> Result<GivenRowEntry, GivenRowDecodeError> {
         use typedb_protocol::{query::req::given_entry::Entry as EntryProto, thing::Thing as ThingProto};
         Ok(match item.entry.expect("Missing proto field") {
             EntryProto::Empty(_) => GivenRowEntry::None,

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -5,7 +5,6 @@
  */
 
 use std::{
-    borrow::Cow,
     collections::{HashMap, VecDeque},
     ops::{
         ControlFlow,
@@ -14,8 +13,8 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-
-use answer::{Thing, variable_value::VariableValue};
+use std::fmt::Formatter;
+use answer::{Thing};
 use bytes::util::HexBytesFormatter;
 use compiler::{VariablePosition, query_structure::PipelineStructure};
 use concept::{
@@ -49,7 +48,10 @@ use ir::pipeline::ParameterRegistry;
 use itertools::{Either, Itertools};
 use lending_iterator::LendingIterator;
 use options::QueryOptions;
-use query::{error::QueryError, query_manager::GivenRows};
+use query::{
+    error::QueryError,
+    given_rows::{GivenRowDecodeError, GivenRowEntry, GivenRowsDecoder},
+};
 use resource::profile::{EncodingProfile, QueryProfile, StorageCounters};
 use storage::snapshot::ReadableSnapshot;
 use tokio::{
@@ -70,7 +72,7 @@ use typedb_protocol::{
 };
 use typeql::{parse_query, query::SchemaQuery};
 use uuid::Uuid;
-
+use query::given_rows::GivenRows;
 use crate::{
     service::{
         TransactionType,
@@ -150,7 +152,7 @@ pub(crate) struct TransactionService {
 
     is_open: bool,
     transaction: Option<Transaction>,
-    query_queue: VecDeque<(Uuid, QueueOptions, typeql::query::Pipeline, Option<GivenRows>, String)>,
+    query_queue: VecDeque<(Uuid, QueueOptions, typeql::query::Pipeline, Option<GivenRowsGrpc>, String)>,
     query_responders: HashMap<Uuid, (JoinHandle<()>, QueryStreamTransmitter)>,
     running_write_query: Option<(Uuid, JoinHandle<(Transaction, WriteQueryResult)>)>,
 
@@ -835,16 +837,7 @@ impl TransactionService {
                 Ok(Self::respond_query_response(&self.response_sender, req_id, response).await)
             }
             typeql::query::QueryStructure::Pipeline(pipeline) => {
-                let given_rows = match given_rows_from_proto(query_req.given) {
-                    Ok(given_rows) => given_rows,
-                    Err(err) => {
-                        let response =
-                            ImmediateQueryResponse::non_fatal_err(TransactionServiceError::DecodingGivenRowsFailed {
-                                typedb_source: err,
-                            });
-                        return Ok(Self::respond_query_response(&self.response_sender, req_id, response).await);
-                    }
-                };
+                let given_rows = query_req.given.map(GivenRowsGrpc);
                 #[allow(clippy::collapsible_else_if)]
                 if is_write_pipeline(&pipeline) {
                     if !self.query_queue.is_empty() || self.running_write_query.is_some() {
@@ -957,7 +950,7 @@ impl TransactionService {
         req_id: Uuid,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
-        given_rows: Option<GivenRows>,
+        given_rows: Option<GivenRowsGrpc>,
         source_query: String,
     ) {
         debug_assert!(self.running_write_query.is_none());
@@ -1003,7 +996,7 @@ impl TransactionService {
         req_id: Uuid,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
-        given_rows: Option<GivenRows>,
+        given_rows: Option<GivenRowsGrpc>,
         source_query: String,
     ) {
         let prefetch_size = query_options.prefetch_size;
@@ -1023,7 +1016,7 @@ impl TransactionService {
         &mut self,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
-        given_rows: Option<GivenRows>,
+        given_rows: Option<GivenRowsGrpc>,
         source_query: String,
     ) -> Result<JoinHandle<(Transaction, WriteQueryResult)>, TransactionServiceError> {
         debug_assert!(self.running_write_query.is_none());
@@ -1245,7 +1238,7 @@ impl TransactionService {
         sender: Sender<StreamQueryResponse>,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
-        given_rows: Option<GivenRows>,
+        given_rows: Option<GivenRowsGrpc>,
         source_query: String,
     ) -> JoinHandle<()> {
         debug_assert!(self.query_queue.is_empty() && self.running_write_query.is_none() && self.transaction.is_some());
@@ -1862,56 +1855,63 @@ impl QueueOptions {
     }
 }
 
-fn given_rows_from_proto(
-    given_rows: Option<typedb_protocol::query::req::GivenRows>,
-) -> Result<Option<GivenRows>, ConceptDecodeError> {
-    use typedb_protocol::{query::req::given_entry::Entry as EntryProto, thing::Thing as ThingProto};
-    let Some(given_rows) = given_rows else { return Ok(None) };
-    let variables = given_rows.variables;
-    let rows = given_rows.rows;
-    let len = rows.len();
-    let width = rows.first().map(|row| row.entries.len() as u32).unwrap_or(0);
-    let mut batch = Batch::new(width, len);
-    rows.into_iter().try_for_each(|row| {
-        batch.append(|mut write_to| {
-            row.entries.into_iter().enumerate().try_for_each(|(column, entry)| {
-                let entry = entry.entry.expect("Missing proto file");
-                let value: VariableValue<'static> = match entry {
-                    EntryProto::Empty(_) => VariableValue::None,
-                    EntryProto::Value(value) => {
-                        VariableValue::Value(decode_value(value.value.expect("Missing proto field")).unwrap())
-                    }
-                    EntryProto::Thing(thing) => match thing.thing.expect("Missing proto field") {
-                        ThingProto::Entity(entity) => {
-                            let vertex = ObjectVertex::try_decode(entity.iid.as_slice()).ok_or_else(|| {
-                                ConceptDecodeError::CouldNotDecodeIIDAsEntity {
-                                    iid: HexBytesFormatter::owned(entity.iid),
-                                }
-                            })?;
-                            VariableValue::Thing(Thing::Entity(Entity::new(vertex)))
-                        }
-                        ThingProto::Relation(relation) => {
-                            let vertex = ObjectVertex::try_decode(relation.iid.as_slice()).ok_or_else(|| {
-                                ConceptDecodeError::CouldNotDecodeIIDAsRelation {
-                                    iid: HexBytesFormatter::owned(relation.iid),
-                                }
-                            })?;
-                            VariableValue::Thing(Thing::Relation(Relation::new(vertex)))
-                        }
-                        ThingProto::Attribute(attribute) => {
-                            let vertex = AttributeVertex::try_decode(attribute.iid.as_slice()).ok_or_else(|| {
-                                ConceptDecodeError::CouldNotDecodeIIDAsAttribute {
-                                    iid: HexBytesFormatter::owned(attribute.iid),
-                                }
-                            })?;
-                            VariableValue::Thing(Thing::Attribute(Attribute::new(vertex)))
-                        }
-                    },
-                };
-                write_to.set(VariablePosition::new(column as u32), value);
-                Ok::<_, ConceptDecodeError>(())
-            })
+pub struct GivenRowsGrpc(typedb_protocol::query::req::GivenRows);
+impl GivenRows for GivenRowsGrpc {
+    fn into_batch_mapped(self, declared_variable_positions: &HashMap<&str, VariablePosition>) -> Result<Batch, GivenRowDecodeError> {
+        query::given_rows::into_batch_mapped::<_, _, GivenRowsDecoderGrpc>(
+            declared_variable_positions,
+            self.0.variables,
+            self.0.rows.len(),
+            self.0.rows.into_iter().map(|row| row.entries),
+        )
+    }
+}
+impl std::fmt::Debug for GivenRowsGrpc {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GivenRowsGrpc[omitted]")
+    }
+}
+
+macro_rules! concept_decode_error {
+    ($variant:ident, $iid:expr) => {
+        GivenRowDecodeError::ConceptDecode {
+            typedb_source: Box::new(ConceptDecodeError::$variant {
+                iid: HexBytesFormatter::borrowed($iid.as_ref()).into_owned(),
+            }),
+        }
+    };
+}
+
+pub struct GivenRowsDecoderGrpc;
+impl GivenRowsDecoder<typedb_protocol::query::req::GivenEntry> for GivenRowsDecoderGrpc {
+
+    fn decode(what: typedb_protocol::query::req::GivenEntry) -> Result<GivenRowEntry, GivenRowDecodeError> {
+        use typedb_protocol::{query::req::given_entry::Entry as EntryProto, thing::Thing as ThingProto};
+        Ok(match what.entry.expect("Missing proto field") {
+            EntryProto::Empty(_) => GivenRowEntry::None,
+            EntryProto::Value(value) => {
+                GivenRowEntry::Value(decode_value(value.value.expect("Missing proto field")).unwrap())
+            }
+            EntryProto::Thing(thing) => match thing.thing.expect("Missing proto field") {
+                ThingProto::Entity(entity) => {
+                    let vertex = ObjectVertex::try_decode(entity.iid.as_slice()).ok_or_else(|| {
+                        concept_decode_error!(CouldNotDecodeIIDAsEntity, entity.iid)
+                    })?;
+                    GivenRowEntry::Thing(Thing::Entity(Entity::new(vertex)))
+                }
+                ThingProto::Relation(relation) => {
+                    let vertex = ObjectVertex::try_decode(relation.iid.as_slice()).ok_or_else(|| {
+                        concept_decode_error!(CouldNotDecodeIIDAsRelation, relation.iid)
+                    })?;
+                    GivenRowEntry::Thing(Thing::Relation(Relation::new(vertex)))
+                }
+                ThingProto::Attribute(attribute) => {
+                    let vertex = AttributeVertex::try_decode(attribute.iid.as_slice()).ok_or_else(|| {
+                        concept_decode_error!(CouldNotDecodeIIDAsAttribute, attribute.iid)
+                    })?;
+                    GivenRowEntry::Thing(Thing::Attribute(Attribute::new(vertex)))
+                }
+            },
         })
-    })?;
-    Ok(Some(GivenRows { variables, batch }))
+    }
 }

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -1892,9 +1892,9 @@ macro_rules! concept_decode_error {
 
 pub struct GivenRowsDecoderGrpc;
 impl GivenRowsDecoder<typedb_protocol::query::req::GivenEntry> for GivenRowsDecoderGrpc {
-    fn decode(what: typedb_protocol::query::req::GivenEntry) -> Result<GivenRowEntry, GivenRowDecodeError> {
+    fn decode(item: typedb_protocol::query::req::GivenEntry) -> Result<GivenRowEntry, GivenRowDecodeError> {
         use typedb_protocol::{query::req::given_entry::Entry as EntryProto, thing::Thing as ThingProto};
-        Ok(match what.entry.expect("Missing proto field") {
+        Ok(match item.entry.expect("Missing proto field") {
             EntryProto::Empty(_) => GivenRowEntry::None,
             EntryProto::Value(value) => {
                 GivenRowEntry::Value(decode_value(value.value.expect("Missing proto field")).unwrap())

--- a/server/service/http/error.rs
+++ b/server/service/http/error.rs
@@ -5,9 +5,7 @@
  */
 use std::sync::Arc;
 
-use concept::error::ConceptDecodeError;
 use error::{TypeDBError, typedb_error};
-use ir::LiteralParseError;
 
 use crate::{
     authentication::AuthenticationError,
@@ -29,10 +27,6 @@ typedb_error!(
         Transaction(16, "Transaction error.", typedb_source: TransactionServiceError),
         QueryClose(17, "Error while closing single-query transaction.", typedb_source: TransactionServiceError),
         QueryCommit(18, "Error while committing single-query transaction.", typedb_source: TransactionServiceError),
-        ConceptDecode(19, "An error occurred while decoding the provided concept.", typedb_source: Box<ConceptDecodeError>),
-        InvalidIIDFormatForGivenEntry(20, "The provided iid string '{iid}' was invalid.", iid: String),
-        ParsingValueFailedForGivenEntry(21, "An error occured while parsing the provided value '{value}'.", value: String, typedb_source: typeql::Error),
-        TranslatingValueFailedForGivenEntry(22, "An error occured while parsing the provided value '{value}'.", value: String, typedb_source: LiteralParseError),
     }
 );
 
@@ -71,11 +65,7 @@ impl HttpServiceError {
             | HttpServiceError::UnknownVersion { .. }
             | HttpServiceError::MissingPathParameter { .. }
             | HttpServiceError::InvalidPathParameter { .. }
-            | HttpServiceError::Authentication { .. }
-            | HttpServiceError::ConceptDecode { .. }
-            | HttpServiceError::InvalidIIDFormatForGivenEntry { .. }
-            | HttpServiceError::ParsingValueFailedForGivenEntry { .. }
-            | HttpServiceError::TranslatingValueFailedForGivenEntry { .. } => None,
+            | HttpServiceError::Authentication { .. } => None,
         }
     }
 }

--- a/server/service/http/error.rs
+++ b/server/service/http/error.rs
@@ -5,7 +5,9 @@
  */
 use std::sync::Arc;
 
+use concept::error::ConceptDecodeError;
 use error::{TypeDBError, typedb_error};
+use ir::LiteralParseError;
 
 use crate::{
     authentication::AuthenticationError,
@@ -27,6 +29,10 @@ typedb_error!(
         Transaction(16, "Transaction error.", typedb_source: TransactionServiceError),
         QueryClose(17, "Error while closing single-query transaction.", typedb_source: TransactionServiceError),
         QueryCommit(18, "Error while committing single-query transaction.", typedb_source: TransactionServiceError),
+        ConceptDecode(19, "An error occurred while decoding the provided concept.", typedb_source: Box<ConceptDecodeError>),
+        InvalidIIDFormatForGivenEntry(20, "The provided iid string '{iid}' was invalid.", iid: String),
+        ParsingValueFailedForGivenEntry(21, "An error occured while parsing the provided value '{value}'.", value: String, typedb_source: typeql::Error),
+        TranslatingValueFailedForGivenEntry(22, "An error occured while parsing the provided value '{value}'.", value: String, typedb_source: LiteralParseError),
     }
 );
 
@@ -65,7 +71,11 @@ impl HttpServiceError {
             | HttpServiceError::UnknownVersion { .. }
             | HttpServiceError::MissingPathParameter { .. }
             | HttpServiceError::InvalidPathParameter { .. }
-            | HttpServiceError::Authentication { .. } => None,
+            | HttpServiceError::Authentication { .. }
+            | HttpServiceError::ConceptDecode { .. }
+            | HttpServiceError::InvalidIIDFormatForGivenEntry { .. }
+            | HttpServiceError::ParsingValueFailedForGivenEntry { .. }
+            | HttpServiceError::TranslatingValueFailedForGivenEntry { .. } => None,
         }
     }
 }

--- a/server/service/http/message/analyze/annotations.rs
+++ b/server/service/http/message/analyze/annotations.rs
@@ -270,7 +270,7 @@ pub mod bdd {
 use itertools::Itertools;
 
     use super::{ConjunctionAnnotationsResponse, FetchStructureAnnotationsResponse, FunctionReturnAnnotationsResponse, SingleTypeAnnotationResponse, TypeAnnotationResponse, VariableAnnotationsResponse};
-use crate::service::http::message::analyze::structure::{AnalyzedFunctionResponse, AnalyzedPipelineResponse};
+use crate::service::http::message::analyze::structure::{AnalyzedFunctionResponse, AnalyzedGivenResponse, AnalyzedPipelineResponse};
 use crate::service::http::message::analyze::{
     bdd::{
         functor_macros,
@@ -280,6 +280,14 @@ use crate::service::http::message::analyze::{
     structure::StructureConstraint,
     AnalysedQueryResponse,
 };
+
+    pub fn encode_pipeline_given_annotations_as_functor(pipeline: &AnalyzedPipelineResponse, given: &AnalyzedGivenResponse) -> String {
+        let AnalyzedGivenResponse { variable_annotations, .. } = given;
+        encode_functor_impl!(
+            &FunctorContext { pipeline },
+            Given { variable_annotations, }
+        )
+    }
 
     pub fn encode_pipeline_annotations_as_functor(pipeline: &AnalyzedPipelineResponse) -> String {
         PipelineAnnotationsToEncode.encode_as_functor(&FunctorContext { pipeline })

--- a/server/service/http/message/analyze/mod.rs
+++ b/server/service/http/message/analyze/mod.rs
@@ -11,7 +11,10 @@ use http::StatusCode;
 use query::analyse::AnalysedQuery;
 use serde::{Deserialize, Serialize};
 use storage::snapshot::ReadableSnapshot;
-use structure::{AnalyzedFunctionResponse, AnalyzedPipelineResponse, encode_analyzed_pipeline};
+use structure::{
+    AnalyzedFunctionResponse, AnalyzedGivenResponse, AnalyzedPipelineResponse, encode_analyzed_given,
+    encode_analyzed_pipeline,
+};
 
 use crate::service::http::message::body::JsonBody;
 
@@ -35,6 +38,7 @@ pub struct TransactionAnalyzePayload {
 #[serde(rename_all = "camelCase")]
 pub struct AnalysedQueryResponse {
     pub source: String,
+    pub given: Option<AnalyzedGivenResponse>,
     pub query: AnalyzedPipelineResponse,
     pub preamble: Vec<AnalyzedFunctionResponse>,
     pub fetch: Option<FetchStructureAnnotationsResponse>,
@@ -54,6 +58,12 @@ pub fn encode_analyzed_query(
     analysed_query: AnalysedQuery,
 ) -> Result<AnalysedQueryResponse, Box<ConceptReadError>> {
     let AnalysedQuery { source, structure, annotations } = analysed_query;
+    let given = match (&structure.query.parametrised_structure.given, &annotations.given) {
+        (Some(given), Some(given_annotations)) => {
+            Some(encode_analyzed_given(snapshot, type_manager, given, given_annotations)?)
+        }
+        _ => None,
+    };
     let preamble = structure
         .preamble
         .into_iter()
@@ -68,7 +78,7 @@ pub fn encode_analyzed_query(
                 .map(|fields| FetchStructureAnnotationsResponse::Object { possible_fields: fields })
         })
         .transpose()?;
-    Ok(AnalysedQueryResponse { source, query, preamble, fetch })
+    Ok(AnalysedQueryResponse { source, given, query, preamble, fetch })
 }
 
 #[cfg(debug_assertions)]

--- a/server/service/http/message/analyze/structure.rs
+++ b/server/service/http/message/analyze/structure.rs
@@ -11,9 +11,9 @@ use bytes::util::HexBytesFormatter;
 use compiler::{
     annotation::type_inference::get_type_annotation_from_label,
     query_structure::{
-        ConjunctionAnnotations, FunctionReturnStructure, ParametrisedPipelineStructure, PipelineStructure,
-        PipelineStructureAnnotations, QueryStructureConjunction, QueryStructureConjunctionID,
-        QueryStructureNestedPattern, QueryStructureStage, StructureVariableId,
+        ConjunctionAnnotations, FunctionReturnStructure, GivenStructureAnnotations, ParametrisedPipelineStructure,
+        PipelineStructure, PipelineStructureAnnotations, QueryStructureConjunction, QueryStructureConjunctionID,
+        QueryStructureGiven, QueryStructureNestedPattern, QueryStructureStage, StructureVariableId,
     },
 };
 use concept::{error::ConceptReadError, type_::type_manager::TypeManager};
@@ -51,6 +51,13 @@ pub struct AnalyzedPipelineResponse {
     pub(super) stages: Vec<QueryStructureStage>,
     pub(super) variables: HashMap<StructureVariableId, StructureVariableInfo>,
     pub(super) outputs: Vec<StructureVariableId>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnalyzedGivenResponse {
+    pub variables: Vec<StructureVariableId>,
+    pub variable_annotations: HashMap<StructureVariableId, VariableAnnotationsResponse>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -277,6 +284,19 @@ pub fn encode_analyzed_pipeline(
     Ok(AnalyzedPipelineResponse { conjunctions: encoded_conjunctions, outputs, variables, stages: stages.clone() })
 }
 
+pub fn encode_analyzed_given(
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    given: &QueryStructureGiven,
+    annotations: &GivenStructureAnnotations,
+) -> Result<AnalyzedGivenResponse, Box<ConceptReadError>> {
+    let variable_annotations = annotations
+        .iter()
+        .map(|(id, ann)| Ok((*id, encode_variable_type_annotations_and_modifiers(snapshot, type_manager, ann)?)))
+        .collect::<Result<HashMap<_, _>, Box<ConceptReadError>>>()?;
+    Ok(AnalyzedGivenResponse { variables: given.variables.clone(), variable_annotations })
+}
+
 fn record_reducer_variables<'a>(context: &mut PipelineStructureContext<'a, impl ReadableSnapshot>) {
     context.structure.parametrised_structure.stages.iter().for_each(|stage| {
         if let QueryStructureStage::Reduce { reducers, .. } = stage {
@@ -500,8 +520,8 @@ fn encode_role_type_as_vertex(
 #[cfg(debug_assertions)]
 pub mod bdd {
     use compiler::query_structure::{
-        FunctionReturnStructure, QueryStructureConjunctionID, QueryStructureStage, StructureReduceAssign,
-        StructureReducer, StructureSortVariable, StructureVariableId,
+        FunctionReturnStructure, QueryStructureConjunctionID, QueryStructureGiven, QueryStructureStage,
+        StructureReduceAssign, StructureReducer, StructureSortVariable, StructureVariableId,
     };
     use itertools::Itertools;
     use serde_json::Value;
@@ -512,10 +532,17 @@ pub mod bdd {
             functor_macros::{encode_functor_impl, impl_functor_for, impl_functor_for_impl, impl_functor_for_multi},
         },
         structure::{
-            AnalyzedFunctionResponse, AnalyzedPipelineResponse, StructureConstraint, StructureConstraintWithSpan,
-            StructureVertex,
+            AnalyzedFunctionResponse, AnalyzedGivenResponse, AnalyzedPipelineResponse, StructureConstraint,
+            StructureConstraintWithSpan, StructureVertex,
         },
     };
+
+    pub fn encode_pipeline_given_as_functor(
+        pipeline: &AnalyzedPipelineResponse,
+        given: &AnalyzedGivenResponse,
+    ) -> String {
+        given.encode_as_functor(&FunctorContext { pipeline })
+    }
 
     pub fn encode_pipeline_structure_as_functor(pipeline: &AnalyzedPipelineResponse) -> String {
         pipeline.encode_as_functor(&FunctorContext { pipeline })
@@ -530,6 +557,7 @@ pub mod bdd {
     impl_functor_for!(struct StructureReduceAssign { assigned, reducer,  } named ReduceAssign);
     impl_functor_for!(struct StructureReducer { reducer, arguments, } named Reducer);
 
+    impl_functor_for!(struct AnalyzedGivenResponse { variables, } named Given);
     impl_functor_for!(enum QueryStructureStage [
         Match { block, } |
         Insert { block, } |

--- a/server/service/http/message/error.rs
+++ b/server/service/http/message/error.rs
@@ -97,10 +97,6 @@ impl IntoResponse for HttpServiceError {
             },
             HttpServiceError::QueryClose { .. } => StatusCode::BAD_REQUEST,
             HttpServiceError::QueryCommit { .. } => StatusCode::BAD_REQUEST,
-            HttpServiceError::ConceptDecode { .. } => StatusCode::BAD_REQUEST,
-            HttpServiceError::InvalidIIDFormatForGivenEntry { .. } => StatusCode::BAD_REQUEST,
-            HttpServiceError::ParsingValueFailedForGivenEntry { .. } => StatusCode::BAD_REQUEST,
-            HttpServiceError::TranslatingValueFailedForGivenEntry { .. } => StatusCode::BAD_REQUEST,
         };
         (code, JsonBody(encode_error(self))).into_response()
     }

--- a/server/service/http/message/error.rs
+++ b/server/service/http/message/error.rs
@@ -93,9 +93,14 @@ impl IntoResponse for HttpServiceError {
                 TransactionServiceError::TransactionTimeout { .. } => StatusCode::REQUEST_TIMEOUT,
                 TransactionServiceError::InvalidPrefetchSize { .. } => StatusCode::BAD_REQUEST,
                 TransactionServiceError::CannotOpen { .. } => StatusCode::BAD_REQUEST,
+                TransactionServiceError::DecodingGivenRowsFailed { .. } => StatusCode::BAD_REQUEST,
             },
             HttpServiceError::QueryClose { .. } => StatusCode::BAD_REQUEST,
             HttpServiceError::QueryCommit { .. } => StatusCode::BAD_REQUEST,
+            HttpServiceError::ConceptDecode { .. } => StatusCode::BAD_REQUEST,
+            HttpServiceError::InvalidIIDFormatForGivenEntry { .. } => StatusCode::BAD_REQUEST,
+            HttpServiceError::ParsingValueFailedForGivenEntry { .. } => StatusCode::BAD_REQUEST,
+            HttpServiceError::TranslatingValueFailedForGivenEntry { .. } => StatusCode::BAD_REQUEST,
         };
         (code, JsonBody(encode_error(self))).into_response()
     }

--- a/server/service/http/message/query/concept.rs
+++ b/server/service/http/message/query/concept.rs
@@ -18,11 +18,14 @@ use concept::{
 };
 use encoding::value::{ValueEncodable, value::Value, value_type::ValueType};
 use error::unimplemented_feature;
+use ir::translation::literal::FromTypeQLLiteral;
 use resource::profile::StorageCounters;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use storage::snapshot::ReadableSnapshot;
+use typeql::parse_value;
 
+use crate::service::http::error::HttpServiceError;
 // TODO: Should probably be merged with JSON from behaviour/steps/query_answer_context.rs.
 // Now, it's easier to have symmetry between two services, and we don't have the capacity to merge
 // these (BDDs will check if this code is correct)
@@ -44,6 +47,7 @@ pub struct RelationResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "kind", rename = "attribute")]
 pub struct AttributeResponse {
+    pub iid: String,
     pub value: serde_json::Value,
     pub value_type: String,
     pub r#type: Option<AttributeTypeResponse>,
@@ -208,6 +212,7 @@ pub fn encode_attribute(
 ) -> Result<AttributeResponse, Box<ConceptReadError>> {
     let value = attribute.get_value(snapshot, thing_manager, storage_counters)?;
     Ok(AttributeResponse {
+        iid: encode_iid(attribute.iid()),
         value_type: encode_value_value_type(&value),
         value: encode_value_value(value),
         r#type: if include_instance_types {
@@ -329,4 +334,21 @@ pub fn encode_value_type(
         }
     };
     Ok(value_type)
+}
+
+pub fn decode_value(value: ValueResponse) -> Result<Value<'static>, HttpServiceError> {
+    fn decode(to_parse: &str) -> Result<Value<'static>, HttpServiceError> {
+        let parsed = parse_value(to_parse).map_err(|typedb_source| {
+            HttpServiceError::ParsingValueFailedForGivenEntry { value: to_parse.to_owned(), typedb_source }
+        })?;
+        Value::from_typeql_literal(&parsed, None).map_err(|typedb_source| {
+            HttpServiceError::TranslatingValueFailedForGivenEntry { value: to_parse.to_owned(), typedb_source }
+        })
+    }
+    let as_str = value.value.to_string();
+    match value.value_type.as_str() {
+        "decimal" => decode(&format!("{}dec", &as_str[1..as_str.len() - 1])),
+        "date" | "datetime" | "datetime-tz" | "duration" => decode(&as_str[1..as_str.len() - 1]),
+        _ => decode(&as_str),
+    }
 }

--- a/server/service/http/message/query/concept.rs
+++ b/server/service/http/message/query/concept.rs
@@ -17,7 +17,6 @@ use concept::{
     },
 };
 use encoding::value::{ValueEncodable, value::Value, value_type::ValueType};
-
 use error::unimplemented_feature;
 use resource::profile::StorageCounters;
 use serde::{Deserialize, Serialize};

--- a/server/service/http/message/query/concept.rs
+++ b/server/service/http/message/query/concept.rs
@@ -17,15 +17,12 @@ use concept::{
     },
 };
 use encoding::value::{ValueEncodable, value::Value, value_type::ValueType};
+
 use error::unimplemented_feature;
-use ir::translation::literal::FromTypeQLLiteral;
 use resource::profile::StorageCounters;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use storage::snapshot::ReadableSnapshot;
-use typeql::parse_value;
-
-use crate::service::http::error::HttpServiceError;
 // TODO: Should probably be merged with JSON from behaviour/steps/query_answer_context.rs.
 // Now, it's easier to have symmetry between two services, and we don't have the capacity to merge
 // these (BDDs will check if this code is correct)
@@ -334,21 +331,4 @@ pub fn encode_value_type(
         }
     };
     Ok(value_type)
-}
-
-pub fn decode_value(value: ValueResponse) -> Result<Value<'static>, HttpServiceError> {
-    fn decode(to_parse: &str) -> Result<Value<'static>, HttpServiceError> {
-        let parsed = parse_value(to_parse).map_err(|typedb_source| {
-            HttpServiceError::ParsingValueFailedForGivenEntry { value: to_parse.to_owned(), typedb_source }
-        })?;
-        Value::from_typeql_literal(&parsed, None).map_err(|typedb_source| {
-            HttpServiceError::TranslatingValueFailedForGivenEntry { value: to_parse.to_owned(), typedb_source }
-        })
-    }
-    let as_str = value.value.to_string();
-    match value.value_type.as_str() {
-        "decimal" => decode(&format!("{}dec", &as_str[1..as_str.len() - 1])),
-        "date" | "datetime" | "datetime-tz" | "duration" => decode(&as_str[1..as_str.len() - 1]),
-        _ => decode(&as_str),
-    }
 }

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -3,34 +3,36 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
+use std::collections::HashMap;
 use ::concept::{
     error::ConceptDecodeError,
     thing::{ThingAPI, attribute::Attribute, entity::Entity, relation::Relation},
 };
-use answer::{Thing, variable_value::VariableValue};
+use answer::Thing;
 use axum::response::{IntoResponse, Response};
 use bytes::util::HexBytesFormatter;
 use compiler::VariablePosition;
-use encoding::graph::thing::{ThingVertex, vertex_attribute::AttributeVertex, vertex_object::ObjectVertex};
+use encoding::{
+    graph::thing::{ThingVertex, vertex_attribute::AttributeVertex, vertex_object::ObjectVertex},
+    value::value::Value,
+};
 use executor::batch::Batch;
 use ir::translation::parse_iid;
 use options::QueryOptions;
-use query::query_manager::GivenRows;
+use query::given_rows::{GivenRowDecodeError, GivenRowEntry, GivenRows, GivenRowsDecoder};
 use resource::constants::server::{
     DEFAULT_ANSWER_COUNT_LIMIT_HTTP, DEFAULT_INCLUDE_INSTANCE_TYPES, DEFAULT_INCLUDE_STRUCTURE_HTTP,
     DEFAULT_PREFETCH_SIZE,
 };
 use serde::{Deserialize, Serialize};
-
+use ir::translation::literal::FromTypeQLLiteral;
 use crate::service::{
     AnswerType, QueryType,
     http::{
-        error::HttpServiceError,
         message::{
             analyze::structure::AnalyzedPipelineResponse,
             body::JsonBody,
-            query::concept::{AttributeResponse, EntityResponse, RelationResponse, ValueResponse, decode_value},
+            query::concept::{AttributeResponse, EntityResponse, RelationResponse, ValueResponse},
             transaction::TransactionOpenPayload,
         },
         transaction_service::QueryAnswer,
@@ -175,7 +177,7 @@ pub enum GivenEntryPayload {
 
 macro_rules! concept_decode_error {
     ($variant:ident, $iid:ident) => {
-        HttpServiceError::ConceptDecode {
+        GivenRowDecodeError::ConceptDecode {
             typedb_source: Box::new(ConceptDecodeError::$variant {
                 iid: HexBytesFormatter::borrowed($iid.as_ref()).into_owned(),
             }),
@@ -183,58 +185,73 @@ macro_rules! concept_decode_error {
     };
 }
 
-impl TryInto<GivenRows> for GivenRowsPayload {
-    type Error = HttpServiceError;
-    fn try_into(self) -> Result<GivenRows, Self::Error> {
-        let variables = self.variables;
-        let rows = self.rows;
-        let len = rows.len();
-        let width = rows.first().map(|row| row.len() as u32).unwrap_or(0);
-        let mut batch = Batch::new(width, len);
-        rows.into_iter().try_for_each(|row| {
-            batch.append(|mut write_to| {
-                row.into_iter().enumerate().try_for_each(|(column, entry)| {
-                    let value: VariableValue<'static> = match entry {
-                        GivenEntryPayload::Empty => VariableValue::None,
-                        GivenEntryPayload::Value(value) => VariableValue::Value(decode_value(value)?),
-                        GivenEntryPayload::Entity(entity) => {
-                            let iid = parse_iid(entity.iid.as_str()).map_err(|_: ()| {
-                                HttpServiceError::InvalidIIDFormatForGivenEntry { iid: entity.iid.clone().to_owned() }
-                            })?;
-                            let vertex = ObjectVertex::try_decode(&iid)
-                                .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsEntity, iid))?;
-                            if !vertex.is_entity() {
-                                return Err(concept_decode_error!(CouldNotDecodeIIDAsEntity, iid));
-                            }
-                            VariableValue::Thing(Thing::Entity(Entity::new(vertex)))
-                        }
-                        GivenEntryPayload::Relation(relation) => {
-                            let iid = parse_iid(relation.iid.as_str()).map_err(|_: ()| {
-                                HttpServiceError::InvalidIIDFormatForGivenEntry { iid: relation.iid.clone().to_owned() }
-                            })?;
-                            let vertex = ObjectVertex::try_decode(&iid)
-                                .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsRelation, iid))?;
-                            if !vertex.is_relation() {
-                                return Err(concept_decode_error!(CouldNotDecodeIIDAsRelation, iid));
-                            }
-                            VariableValue::Thing(Thing::Relation(Relation::new(vertex)))
-                        }
-                        GivenEntryPayload::Attribute(attribute) => {
-                            let iid = parse_iid(attribute.iid.as_str()).map_err(|_: ()| {
-                                HttpServiceError::InvalidIIDFormatForGivenEntry {
-                                    iid: attribute.iid.clone().to_owned(),
-                                }
-                            })?;
-                            let vertex = AttributeVertex::try_decode(&iid)
-                                .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsAttribute, iid))?;
-                            VariableValue::Thing(Thing::Attribute(Attribute::new(vertex)))
-                        }
-                    };
-                    write_to.set(VariablePosition::new(column as u32), value);
-                    Ok::<_, HttpServiceError>(())
-                })
-            })
+impl GivenRows for GivenRowsPayload {
+    fn into_batch_mapped(self, declared_variable_positions: &HashMap<&str, VariablePosition>) -> Result<Batch, GivenRowDecodeError> {
+        query::given_rows::into_batch_mapped::<_, _, GivenRowsDecoderHttp>(
+            &declared_variable_positions,
+            self.variables,
+            self.rows.len(),
+            self.rows.into_iter(),
+        )
+    }
+}
+
+pub struct GivenRowsDecoderHttp;
+impl GivenRowsDecoder<GivenEntryPayload> for GivenRowsDecoderHttp {
+    fn decode(what: GivenEntryPayload) -> Result<GivenRowEntry, GivenRowDecodeError> {
+        Ok(match what {
+            GivenEntryPayload::Empty => GivenRowEntry::None,
+            GivenEntryPayload::Value(value) => GivenRowEntry::Value(decode_value(value)?),
+            GivenEntryPayload::Entity(entity) => {
+                let iid = parse_iid(entity.iid.as_str()).map_err(|_: ()| {
+                    GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: entity.iid.clone().to_owned() }
+                })?;
+                let vertex = ObjectVertex::try_decode(&iid)
+                    .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsEntity, iid))?;
+                if !vertex.is_entity() {
+                    return Err(concept_decode_error!(CouldNotDecodeIIDAsEntity, iid));
+                }
+                GivenRowEntry::Thing(Thing::Entity(Entity::new(vertex)))
+            }
+            GivenEntryPayload::Relation(relation) => {
+                let iid = parse_iid(relation.iid.as_str()).map_err(|_: ()| {
+                    GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: relation.iid.clone().to_owned() }
+                })?;
+                let vertex = ObjectVertex::try_decode(&iid)
+                    .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsRelation, iid))?;
+                if !vertex.is_relation() {
+                    return Err(concept_decode_error!(CouldNotDecodeIIDAsRelation, iid));
+                }
+                GivenRowEntry::Thing(Thing::Relation(Relation::new(vertex)))
+            }
+            GivenEntryPayload::Attribute(attribute) => {
+                let iid = parse_iid(attribute.iid.as_str()).map_err(|_: ()| {
+                    GivenRowDecodeError::InvalidIIDFormatForGivenEntry {
+                        iid: attribute.iid.clone().to_owned(),
+                    }
+                })?;
+                let vertex = AttributeVertex::try_decode(&iid)
+                    .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsAttribute, iid))?;
+                GivenRowEntry::Thing(Thing::Attribute(Attribute::new(vertex)))
+            }
+        })
+    }
+}
+
+pub fn decode_value(value: ValueResponse) -> Result<Value<'static>, GivenRowDecodeError> {
+
+    fn decode(to_parse: &str) -> Result<Value<'static>, GivenRowDecodeError> {
+        let parsed = typeql::parse_value(to_parse).map_err(|typedb_source| {
+            GivenRowDecodeError::ParsingValueFailedForGivenEntry { value: to_parse.to_owned(), typedb_source }
         })?;
-        Ok(GivenRows { variables, batch })
+        Value::from_typeql_literal(&parsed, None).map_err(|typedb_source| {
+            GivenRowDecodeError::TranslatingValueFailedForGivenEntry { value: to_parse.to_owned(), typedb_source }
+        })
+    }
+    let as_str = value.value.to_string();
+    match value.value_type.as_str() {
+        "decimal" => decode(&format!("{}dec", &as_str[1..as_str.len() - 1])),
+        "date" | "datetime" | "datetime-tz" | "duration" => decode(&as_str[1..as_str.len() - 1]),
+        _ => decode(&as_str),
     }
 }

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use std::borrow::Cow;
 
 use ::concept::{
     error::ConceptDecodeError,
@@ -158,7 +157,10 @@ impl IntoResponse for QueryAnswer {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GivenRowsPayload(pub Vec<Vec<GivenEntryPayload>>);
+pub struct GivenRowsPayload {
+    pub variables: Vec<String>,
+    pub rows: Vec<Vec<GivenEntryPayload>>,
+}
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "kind")]
@@ -184,7 +186,8 @@ macro_rules! concept_decode_error {
 impl TryInto<GivenRows> for GivenRowsPayload {
     type Error = HttpServiceError;
     fn try_into(self) -> Result<GivenRows, Self::Error> {
-        let rows = self.0;
+        let variables = self.variables;
+        let rows = self.rows;
         let len = rows.len();
         let width = rows.first().map(|row| row.len() as u32).unwrap_or(0);
         let mut batch = Batch::new(width, len);
@@ -232,6 +235,6 @@ impl TryInto<GivenRows> for GivenRowsPayload {
                 })
             })
         })?;
-        Ok(batch)
+        Ok(GivenRows { variables, batch })
     }
 }

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -3,21 +3,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use ::concept::{
     error::ConceptDecodeError,
     thing::{ThingAPI, attribute::Attribute, entity::Entity, relation::Relation},
 };
-use answer::Thing;
+use answer::{Thing, Type};
 use axum::response::{IntoResponse, Response};
 use bytes::util::HexBytesFormatter;
-use compiler::VariablePosition;
+use clap::builder::TypedValueParser;
+use compiler::annotation::function::FunctionParameterAnnotation;
 use encoding::{
     graph::thing::{ThingVertex, vertex_attribute::AttributeVertex, vertex_object::ObjectVertex},
-    value::value::Value,
+    value::{ValueEncodable, value::Value, value_type::ValueType},
 };
-use executor::batch::Batch;
 use ir::translation::{literal::FromTypeQLLiteral, parse_iid};
 use options::QueryOptions;
 use query::given_rows::{GivenRowDecodeError, GivenRowEntry, GivenRows};
@@ -26,6 +26,7 @@ use resource::constants::server::{
     DEFAULT_PREFETCH_SIZE,
 };
 use serde::{Deserialize, Serialize};
+use typeql::parse_value;
 
 use crate::service::{
     AnswerType, QueryType,
@@ -164,11 +165,20 @@ pub struct GivenRowsPayload(pub Vec<BTreeMap<String, Option<GivenEntryPayload>>>
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "kind")]
-pub enum GivenEntryPayload {
+pub enum TaggedEntryPayload {
     Entity(EntityResponse),
     Relation(RelationResponse),
     Attribute(AttributeResponse),
     Value(ValueResponse),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum GivenEntryPayload {
+    PlainString(String),
+    PlainNumber(serde_json::Number),
+    PlainBool(bool),
+    Concept(TaggedEntryPayload),
 }
 
 macro_rules! concept_decode_error {
@@ -209,40 +219,79 @@ impl GivenRows for GivenRowsHttp {
         self.variables.as_slice()
     }
 
-    fn decode(item: Self::Item) -> Result<GivenRowEntry, GivenRowDecodeError> {
-        if let Some(what) = item {
-            match what {
-                GivenEntryPayload::Value(value) => Ok(GivenRowEntry::Value(decode_value(value)?)),
-                GivenEntryPayload::Entity(entity) => {
-                    let iid = parse_iid(entity.iid.as_str()).map_err(|_: ()| {
-                        GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: entity.iid.clone().to_owned() }
-                    })?;
-                    let vertex = ObjectVertex::try_decode(&iid)
-                        .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsEntity, iid))?;
-                    if !vertex.is_entity() {
-                        return Err(concept_decode_error!(CouldNotDecodeIIDAsEntity, iid));
+    fn decode(
+        item: Self::Item,
+        expected_type: &FunctionParameterAnnotation,
+    ) -> Result<GivenRowEntry, GivenRowDecodeError> {
+        if let Some(item) = item {
+            match item {
+                GivenEntryPayload::PlainNumber(value) => {
+                    let FunctionParameterAnnotation::Value(expected_type) = expected_type else {
+                        return Err(GivenRowDecodeError::ExpectedValueTypeWasNotProvided {});
+                    };
+                    let decoded_value = match expected_type {
+                        ValueType::Integer => value.as_i64().map(Value::Integer),
+                        ValueType::Double => value.as_f64().map(Value::Double),
+                        _ => None,
                     }
-                    Ok(GivenRowEntry::Thing(Thing::Entity(Entity::new(vertex))))
-                }
-                GivenEntryPayload::Relation(relation) => {
-                    let iid = parse_iid(relation.iid.as_str()).map_err(|_: ()| {
-                        GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: relation.iid.clone().to_owned() }
+                    .ok_or_else(|| GivenRowDecodeError::ValueTypeMismatch {
+                        expected_type: expected_type.clone(),
+                        actual_type: "json::number".to_owned(),
+                        value: value.to_string(),
                     })?;
-                    let vertex = ObjectVertex::try_decode(&iid)
-                        .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsRelation, iid))?;
-                    if !vertex.is_relation() {
-                        return Err(concept_decode_error!(CouldNotDecodeIIDAsRelation, iid));
+                    Ok(GivenRowEntry::Value(decoded_value))
+                }
+                GivenEntryPayload::PlainBool(value) => {
+                    let FunctionParameterAnnotation::Value(expected_type) = expected_type else {
+                        return Err(GivenRowDecodeError::ExpectedValueTypeWasNotProvided {});
+                    };
+                    match expected_type {
+                        ValueType::Boolean => Ok(GivenRowEntry::Value(Value::Boolean(value))),
+                        _ => Err(GivenRowDecodeError::ValueTypeMismatch {
+                            expected_type: expected_type.clone(),
+                            actual_type: "boolean".to_owned(),
+                            value: value.to_string(),
+                        }),
                     }
-                    Ok(GivenRowEntry::Thing(Thing::Relation(Relation::new(vertex))))
                 }
-                GivenEntryPayload::Attribute(attribute) => {
-                    let iid = parse_iid(attribute.iid.as_str()).map_err(|_: ()| {
-                        GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: attribute.iid.clone().to_owned() }
-                    })?;
-                    let vertex = AttributeVertex::try_decode(&iid)
-                        .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsAttribute, iid))?;
-                    Ok(GivenRowEntry::Thing(Thing::Attribute(Attribute::new(vertex))))
-                }
+                GivenEntryPayload::PlainString(value) => match expected_type {
+                    FunctionParameterAnnotation::AnyConcept => unreachable!("Can't be"),
+                    FunctionParameterAnnotation::Concept(expected_type) => decode_string_as_iid(value, expected_type),
+                    FunctionParameterAnnotation::Value(expected_type) => decode_string_as_value(value, expected_type),
+                },
+                GivenEntryPayload::Concept(tagged) => match tagged {
+                    TaggedEntryPayload::Value(value) => Ok(GivenRowEntry::Value(decode_value(value)?)),
+                    TaggedEntryPayload::Entity(entity) => {
+                        let iid = parse_iid(entity.iid.as_str()).map_err(|_: ()| {
+                            GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: entity.iid.clone().to_owned() }
+                        })?;
+                        let vertex = ObjectVertex::try_decode(&iid)
+                            .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsEntity, iid))?;
+                        if !vertex.is_entity() {
+                            return Err(concept_decode_error!(CouldNotDecodeIIDAsEntity, iid));
+                        }
+                        Ok(GivenRowEntry::Thing(Thing::Entity(Entity::new(vertex))))
+                    }
+                    TaggedEntryPayload::Relation(relation) => {
+                        let iid = parse_iid(relation.iid.as_str()).map_err(|_: ()| {
+                            GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: relation.iid.clone().to_owned() }
+                        })?;
+                        let vertex = ObjectVertex::try_decode(&iid)
+                            .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsRelation, iid))?;
+                        if !vertex.is_relation() {
+                            return Err(concept_decode_error!(CouldNotDecodeIIDAsRelation, iid));
+                        }
+                        Ok(GivenRowEntry::Thing(Thing::Relation(Relation::new(vertex))))
+                    }
+                    TaggedEntryPayload::Attribute(attribute) => {
+                        let iid = parse_iid(attribute.iid.as_str()).map_err(|_: ()| {
+                            GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: attribute.iid.clone().to_owned() }
+                        })?;
+                        let vertex = AttributeVertex::try_decode(&iid)
+                            .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsAttribute, iid))?;
+                        Ok(GivenRowEntry::Thing(Thing::Attribute(Attribute::new(vertex))))
+                    }
+                },
             }
         } else {
             Ok(GivenRowEntry::None)
@@ -259,6 +308,56 @@ impl GivenRows for GivenRowsHttp {
 
     fn iter_row(row: Self::Row) -> impl Iterator<Item = Self::Item> {
         row.into_iter()
+    }
+}
+
+fn decode_string_as_iid(iid_string: String, _types: &BTreeSet<Type>) -> Result<GivenRowEntry, GivenRowDecodeError> {
+    let iid = parse_iid(iid_string.as_str())
+        .map_err(|_: ()| GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: iid_string.clone() })?;
+    let prefix = iid_string[0..4].to_lowercase();
+    match prefix.as_str() {
+        "0x1e" => {
+            let vertex =
+                ObjectVertex::try_decode(&*iid).ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsEntity, iid))?;
+            Ok(GivenRowEntry::Thing(Thing::Entity(Entity::new(vertex))))
+        }
+        "0x1f" => {
+            let vertex =
+                ObjectVertex::try_decode(&*iid).ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsEntity, iid))?;
+            Ok(GivenRowEntry::Thing(Thing::Relation(Relation::new(vertex))))
+        }
+        "0x20" => {
+            let vertex = AttributeVertex::try_decode(&*iid)
+                .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsEntity, iid))?;
+            Ok(GivenRowEntry::Thing(Thing::Attribute(Attribute::new(vertex))))
+        }
+        _ => Err(GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: iid_string }),
+    }
+}
+
+fn decode_string_as_value(value: String, expected_type: &ValueType) -> Result<GivenRowEntry, GivenRowDecodeError> {
+    let parsed_value = if expected_type == &ValueType::String {
+        parse_value(format!("\"{value}\"").as_str())
+    } else if expected_type == &ValueType::Decimal && !value.as_str().ends_with("dec") {
+        parse_value(format!("{value}dec").as_str())
+    } else {
+        parse_value(value.as_str())
+    }
+    .map_err(|typedb_source| GivenRowDecodeError::ParsingValueFailedForGivenEntry {
+        value: value.clone(),
+        typedb_source,
+    })?;
+    let translated_value = Value::from_typeql_literal(&parsed_value, None).map_err(|typedb_source| {
+        GivenRowDecodeError::TranslatingValueFailedForGivenEntry { value: value.clone(), typedb_source }
+    })?;
+    if &translated_value.value_type() == expected_type {
+        Ok(GivenRowEntry::Value(translated_value))
+    } else {
+        Err(GivenRowDecodeError::ValueTypeMismatch {
+            expected_type: expected_type.clone(),
+            actual_type: translated_value.value_type().to_string(),
+            value: value.to_string(),
+        })
     }
 }
 

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -185,6 +185,10 @@ macro_rules! concept_decode_error {
 }
 
 impl GivenRows for GivenRowsPayload {
+    fn variables(&self) -> &[String] {
+        self.variables.as_slice()
+    }
+
     fn into_batch_mapped(
         self,
         declared_variable_positions: &HashMap<&str, VariablePosition>,

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -162,14 +162,12 @@ impl IntoResponse for QueryAnswer {
 #[serde(rename_all = "camelCase")]
 pub struct GivenRowsPayload {
     pub variables: Vec<String>,
-    pub rows: Vec<Vec<GivenEntryPayload>>,
+    pub rows: Vec<Vec<Option<GivenEntryPayload>>>,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "kind")]
 pub enum GivenEntryPayload {
-    #[default]
-    Empty,
     Entity(EntityResponse),
     Relation(RelationResponse),
     Attribute(AttributeResponse),
@@ -201,42 +199,45 @@ impl GivenRows for GivenRowsPayload {
 }
 
 pub struct GivenRowsDecoderHttp;
-impl GivenRowsDecoder<GivenEntryPayload> for GivenRowsDecoderHttp {
-    fn decode(what: GivenEntryPayload) -> Result<GivenRowEntry, GivenRowDecodeError> {
-        Ok(match what {
-            GivenEntryPayload::Empty => GivenRowEntry::None,
-            GivenEntryPayload::Value(value) => GivenRowEntry::Value(decode_value(value)?),
-            GivenEntryPayload::Entity(entity) => {
-                let iid = parse_iid(entity.iid.as_str()).map_err(|_: ()| {
-                    GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: entity.iid.clone().to_owned() }
-                })?;
-                let vertex = ObjectVertex::try_decode(&iid)
-                    .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsEntity, iid))?;
-                if !vertex.is_entity() {
-                    return Err(concept_decode_error!(CouldNotDecodeIIDAsEntity, iid));
+impl GivenRowsDecoder<Option<GivenEntryPayload>> for GivenRowsDecoderHttp {
+    fn decode(what: Option<GivenEntryPayload>) -> Result<GivenRowEntry, GivenRowDecodeError> {
+        if let Some(what) = what {
+            match what {
+                GivenEntryPayload::Value(value) => Ok(GivenRowEntry::Value(decode_value(value)?)),
+                GivenEntryPayload::Entity(entity) => {
+                    let iid = parse_iid(entity.iid.as_str()).map_err(|_: ()| {
+                        GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: entity.iid.clone().to_owned() }
+                    })?;
+                    let vertex = ObjectVertex::try_decode(&iid)
+                        .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsEntity, iid))?;
+                    if !vertex.is_entity() {
+                        return Err(concept_decode_error!(CouldNotDecodeIIDAsEntity, iid));
+                    }
+                    Ok(GivenRowEntry::Thing(Thing::Entity(Entity::new(vertex))))
                 }
-                GivenRowEntry::Thing(Thing::Entity(Entity::new(vertex)))
-            }
-            GivenEntryPayload::Relation(relation) => {
-                let iid = parse_iid(relation.iid.as_str()).map_err(|_: ()| {
-                    GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: relation.iid.clone().to_owned() }
-                })?;
-                let vertex = ObjectVertex::try_decode(&iid)
-                    .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsRelation, iid))?;
-                if !vertex.is_relation() {
-                    return Err(concept_decode_error!(CouldNotDecodeIIDAsRelation, iid));
+                GivenEntryPayload::Relation(relation) => {
+                    let iid = parse_iid(relation.iid.as_str()).map_err(|_: ()| {
+                        GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: relation.iid.clone().to_owned() }
+                    })?;
+                    let vertex = ObjectVertex::try_decode(&iid)
+                        .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsRelation, iid))?;
+                    if !vertex.is_relation() {
+                        return Err(concept_decode_error!(CouldNotDecodeIIDAsRelation, iid));
+                    }
+                    Ok(GivenRowEntry::Thing(Thing::Relation(Relation::new(vertex))))
                 }
-                GivenRowEntry::Thing(Thing::Relation(Relation::new(vertex)))
+                GivenEntryPayload::Attribute(attribute) => {
+                    let iid = parse_iid(attribute.iid.as_str()).map_err(|_: ()| {
+                        GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: attribute.iid.clone().to_owned() }
+                    })?;
+                    let vertex = AttributeVertex::try_decode(&iid)
+                        .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsAttribute, iid))?;
+                    Ok(GivenRowEntry::Thing(Thing::Attribute(Attribute::new(vertex))))
+                }
             }
-            GivenEntryPayload::Attribute(attribute) => {
-                let iid = parse_iid(attribute.iid.as_str()).map_err(|_: ()| {
-                    GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: attribute.iid.clone().to_owned() }
-                })?;
-                let vertex = AttributeVertex::try_decode(&iid)
-                    .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsAttribute, iid))?;
-                GivenRowEntry::Thing(Thing::Attribute(Attribute::new(vertex)))
-            }
-        })
+        } else {
+            Ok(GivenRowEntry::None)
+        }
     }
 }
 

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -3,9 +3,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+use std::borrow::Cow;
 
+use ::concept::{
+    error::ConceptDecodeError,
+    thing::{ThingAPI, attribute::Attribute, entity::Entity, relation::Relation},
+};
+use answer::{Thing, variable_value::VariableValue};
 use axum::response::{IntoResponse, Response};
+use bytes::util::HexBytesFormatter;
+use compiler::VariablePosition;
+use encoding::graph::thing::{ThingVertex, vertex_attribute::AttributeVertex, vertex_object::ObjectVertex};
+use executor::batch::Batch;
+use ir::translation::parse_iid;
 use options::QueryOptions;
+use query::query_manager::GivenRows;
 use resource::constants::server::{
     DEFAULT_ANSWER_COUNT_LIMIT_HTTP, DEFAULT_INCLUDE_INSTANCE_TYPES, DEFAULT_INCLUDE_STRUCTURE_HTTP,
     DEFAULT_PREFETCH_SIZE,
@@ -15,7 +27,13 @@ use serde::{Deserialize, Serialize};
 use crate::service::{
     AnswerType, QueryType,
     http::{
-        message::{analyze::structure::AnalyzedPipelineResponse, body::JsonBody, transaction::TransactionOpenPayload},
+        error::HttpServiceError,
+        message::{
+            analyze::structure::AnalyzedPipelineResponse,
+            body::JsonBody,
+            query::concept::{AttributeResponse, EntityResponse, RelationResponse, ValueResponse, decode_value},
+            transaction::TransactionOpenPayload,
+        },
         transaction_service::QueryAnswer,
     },
 };
@@ -57,6 +75,7 @@ impl Into<QueryOptions> for QueryOptionsPayload {
 pub struct TransactionQueryPayload {
     pub query_options: Option<QueryOptionsPayload>,
     pub query: String,
+    pub given_rows: Option<GivenRowsPayload>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -64,6 +83,7 @@ pub struct TransactionQueryPayload {
 pub struct QueryPayload {
     pub query_options: Option<QueryOptionsPayload>,
     pub query: String,
+    pub given_rows: Option<GivenRowsPayload>,
     pub commit: Option<bool>,
 
     #[serde(flatten)]
@@ -133,5 +153,85 @@ impl IntoResponse for QueryAnswer {
             )),
         };
         (code, body).into_response()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GivenRowsPayload(pub Vec<Vec<GivenEntryPayload>>);
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum GivenEntryPayload {
+    #[default]
+    Empty,
+    Entity(EntityResponse),
+    Relation(RelationResponse),
+    Attribute(AttributeResponse),
+    Value(ValueResponse),
+}
+
+macro_rules! concept_decode_error {
+    ($variant:ident, $iid:ident) => {
+        HttpServiceError::ConceptDecode {
+            typedb_source: Box::new(ConceptDecodeError::$variant {
+                iid: HexBytesFormatter::borrowed($iid.as_ref()).into_owned(),
+            }),
+        }
+    };
+}
+
+impl TryInto<GivenRows> for GivenRowsPayload {
+    type Error = HttpServiceError;
+    fn try_into(self) -> Result<GivenRows, Self::Error> {
+        let rows = self.0;
+        let len = rows.len();
+        let width = rows.first().map(|row| row.len() as u32).unwrap_or(0);
+        let mut batch = Batch::new(width, len);
+        rows.into_iter().try_for_each(|row| {
+            batch.append(|mut write_to| {
+                row.into_iter().enumerate().try_for_each(|(column, entry)| {
+                    let value: VariableValue<'static> = match entry {
+                        GivenEntryPayload::Empty => VariableValue::None,
+                        GivenEntryPayload::Value(value) => VariableValue::Value(decode_value(value)?),
+                        GivenEntryPayload::Entity(entity) => {
+                            let iid = parse_iid(entity.iid.as_str()).map_err(|_: ()| {
+                                HttpServiceError::InvalidIIDFormatForGivenEntry { iid: entity.iid.clone().to_owned() }
+                            })?;
+                            let vertex = ObjectVertex::try_decode(&iid)
+                                .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsEntity, iid))?;
+                            if !vertex.is_entity() {
+                                return Err(concept_decode_error!(CouldNotDecodeIIDAsEntity, iid));
+                            }
+                            VariableValue::Thing(Thing::Entity(Entity::new(vertex)))
+                        }
+                        GivenEntryPayload::Relation(relation) => {
+                            let iid = parse_iid(relation.iid.as_str()).map_err(|_: ()| {
+                                HttpServiceError::InvalidIIDFormatForGivenEntry { iid: relation.iid.clone().to_owned() }
+                            })?;
+                            let vertex = ObjectVertex::try_decode(&iid)
+                                .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsRelation, iid))?;
+                            if !vertex.is_relation() {
+                                return Err(concept_decode_error!(CouldNotDecodeIIDAsRelation, iid));
+                            }
+                            VariableValue::Thing(Thing::Relation(Relation::new(vertex)))
+                        }
+                        GivenEntryPayload::Attribute(attribute) => {
+                            let iid = parse_iid(attribute.iid.as_str()).map_err(|_: ()| {
+                                HttpServiceError::InvalidIIDFormatForGivenEntry {
+                                    iid: attribute.iid.clone().to_owned(),
+                                }
+                            })?;
+                            let vertex = AttributeVertex::try_decode(&iid)
+                                .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsAttribute, iid))?;
+                            VariableValue::Thing(Thing::Attribute(Attribute::new(vertex)))
+                        }
+                    };
+                    write_to.set(VariablePosition::new(column as u32), value);
+                    Ok::<_, HttpServiceError>(())
+                })
+            })
+        })?;
+        Ok(batch)
     }
 }

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -221,8 +221,8 @@ impl GivenRows for GivenRowsHttp {
 
 pub struct GivenRowsDecoderHttp;
 impl GivenRowsDecoder<Option<GivenEntryPayload>> for GivenRowsDecoderHttp {
-    fn decode(what: Option<GivenEntryPayload>) -> Result<GivenRowEntry, GivenRowDecodeError> {
-        if let Some(what) = what {
+    fn decode(item: Option<GivenEntryPayload>) -> Result<GivenRowEntry, GivenRowDecodeError> {
+        if let Some(what) = item {
             match what {
                 GivenEntryPayload::Value(value) => Ok(GivenRowEntry::Value(decode_value(value)?)),
                 GivenEntryPayload::Entity(entity) => {

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -20,7 +20,7 @@ use encoding::{
 use executor::batch::Batch;
 use ir::translation::{literal::FromTypeQLLiteral, parse_iid};
 use options::QueryOptions;
-use query::given_rows::{GivenRowDecodeError, GivenRowEntry, GivenRows, GivenRowsDecoder};
+use query::given_rows::{GivenRowDecodeError, GivenRowEntry, GivenRows};
 use resource::constants::server::{
     DEFAULT_ANSWER_COUNT_LIMIT_HTTP, DEFAULT_INCLUDE_INSTANCE_TYPES, DEFAULT_INCLUDE_STRUCTURE_HTTP,
     DEFAULT_PREFETCH_SIZE,
@@ -202,26 +202,14 @@ impl std::convert::From<GivenRowsPayload> for GivenRowsHttp {
 }
 
 impl GivenRows for GivenRowsHttp {
+    type Item = Option<GivenEntryPayload>;
+    type Row = Vec<Option<GivenEntryPayload>>;
+
     fn variables(&self) -> &[String] {
         self.variables.as_slice()
     }
 
-    fn into_batch_mapped(
-        self,
-        declared_variable_positions: &HashMap<&str, VariablePosition>,
-    ) -> Result<Batch, GivenRowDecodeError> {
-        query::given_rows::into_batch_mapped::<_, _, GivenRowsDecoderHttp>(
-            &declared_variable_positions,
-            self.variables,
-            self.rows.len(),
-            self.rows.into_iter(),
-        )
-    }
-}
-
-pub struct GivenRowsDecoderHttp;
-impl GivenRowsDecoder<Option<GivenEntryPayload>> for GivenRowsDecoderHttp {
-    fn decode(item: Option<GivenEntryPayload>) -> Result<GivenRowEntry, GivenRowDecodeError> {
+    fn decode(item: Self::Item) -> Result<GivenRowEntry, GivenRowDecodeError> {
         if let Some(what) = item {
             match what {
                 GivenEntryPayload::Value(value) => Ok(GivenRowEntry::Value(decode_value(value)?)),
@@ -259,6 +247,18 @@ impl GivenRowsDecoder<Option<GivenEntryPayload>> for GivenRowsDecoderHttp {
         } else {
             Ok(GivenRowEntry::None)
         }
+    }
+
+    fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    fn rows(self) -> impl Iterator<Item = Self::Row> {
+        self.rows.into_iter()
+    }
+
+    fn iter_row(row: Self::Row) -> impl Iterator<Item = Self::Item> {
+        row.into_iter()
     }
 }
 

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -227,7 +227,7 @@ impl GivenRows for GivenRowsHttp {
             match item {
                 GivenEntryPayload::PlainNumber(value) => {
                     let FunctionParameterAnnotation::Value(expected_type) = expected_type else {
-                        return Err(GivenRowDecodeError::ExpectedValueTypeWasNotProvided {});
+                        return Err(GivenRowDecodeError::ExpectedInstanceReceivedValue {});
                     };
                     let decoded_value = match expected_type {
                         ValueType::Integer => value.as_i64().map(Value::Integer),
@@ -243,7 +243,7 @@ impl GivenRows for GivenRowsHttp {
                 }
                 GivenEntryPayload::PlainBool(value) => {
                     let FunctionParameterAnnotation::Value(expected_type) = expected_type else {
-                        return Err(GivenRowDecodeError::ExpectedValueTypeWasNotProvided {});
+                        return Err(GivenRowDecodeError::ExpectedInstanceReceivedValue {});
                     };
                     match expected_type {
                         ValueType::Boolean => Ok(GivenRowEntry::Value(Value::Boolean(value))),
@@ -260,7 +260,9 @@ impl GivenRows for GivenRowsHttp {
                     FunctionParameterAnnotation::Value(expected_type) => decode_string_as_value(value, expected_type),
                 },
                 GivenEntryPayload::Concept(tagged) => match tagged {
-                    TaggedEntryPayload::Value(value) => Ok(GivenRowEntry::Value(decode_value(value)?)),
+                    TaggedEntryPayload::Value(value) => {
+                        GivenRowEntry::try_cast_value_to(decode_value(value)?, expected_type)
+                    }
                     TaggedEntryPayload::Entity(entity) => {
                         let iid = parse_iid(entity.iid.as_str()).map_err(|_: ()| {
                             GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: entity.iid.clone().to_owned() }

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use ::concept::{
     error::ConceptDecodeError,
@@ -160,10 +160,7 @@ impl IntoResponse for QueryAnswer {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GivenRowsPayload {
-    pub variables: Vec<String>,
-    pub rows: Vec<Vec<Option<GivenEntryPayload>>>,
-}
+pub struct GivenRowsPayload(pub Vec<BTreeMap<String, Option<GivenEntryPayload>>>);
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "kind")]
@@ -184,7 +181,27 @@ macro_rules! concept_decode_error {
     };
 }
 
-impl GivenRows for GivenRowsPayload {
+#[derive(Debug)]
+pub struct GivenRowsHttp {
+    pub variables: Vec<String>,
+    pub rows: Vec<Vec<Option<GivenEntryPayload>>>,
+}
+
+impl std::convert::From<GivenRowsPayload> for GivenRowsHttp {
+    fn from(value: GivenRowsPayload) -> Self {
+        let variables_as_set = value.0.iter().flat_map(|v| v.keys().cloned()).collect::<BTreeSet<String>>();
+        let variables = Vec::from_iter(variables_as_set.into_iter());
+        let variables_ref = &variables;
+        let rows = value
+            .0
+            .into_iter()
+            .map(|mut as_map| variables_ref.iter().map(move |var| as_map.remove(var).flatten()).collect())
+            .collect();
+        Self { variables, rows }
+    }
+}
+
+impl GivenRows for GivenRowsHttp {
     fn variables(&self) -> &[String] {
         self.variables.as_slice()
     }

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 use std::collections::HashMap;
+
 use ::concept::{
     error::ConceptDecodeError,
     thing::{ThingAPI, attribute::Attribute, entity::Entity, relation::Relation},
@@ -17,7 +18,7 @@ use encoding::{
     value::value::Value,
 };
 use executor::batch::Batch;
-use ir::translation::parse_iid;
+use ir::translation::{literal::FromTypeQLLiteral, parse_iid};
 use options::QueryOptions;
 use query::given_rows::{GivenRowDecodeError, GivenRowEntry, GivenRows, GivenRowsDecoder};
 use resource::constants::server::{
@@ -25,7 +26,7 @@ use resource::constants::server::{
     DEFAULT_PREFETCH_SIZE,
 };
 use serde::{Deserialize, Serialize};
-use ir::translation::literal::FromTypeQLLiteral;
+
 use crate::service::{
     AnswerType, QueryType,
     http::{
@@ -186,7 +187,10 @@ macro_rules! concept_decode_error {
 }
 
 impl GivenRows for GivenRowsPayload {
-    fn into_batch_mapped(self, declared_variable_positions: &HashMap<&str, VariablePosition>) -> Result<Batch, GivenRowDecodeError> {
+    fn into_batch_mapped(
+        self,
+        declared_variable_positions: &HashMap<&str, VariablePosition>,
+    ) -> Result<Batch, GivenRowDecodeError> {
         query::given_rows::into_batch_mapped::<_, _, GivenRowsDecoderHttp>(
             &declared_variable_positions,
             self.variables,
@@ -226,9 +230,7 @@ impl GivenRowsDecoder<GivenEntryPayload> for GivenRowsDecoderHttp {
             }
             GivenEntryPayload::Attribute(attribute) => {
                 let iid = parse_iid(attribute.iid.as_str()).map_err(|_: ()| {
-                    GivenRowDecodeError::InvalidIIDFormatForGivenEntry {
-                        iid: attribute.iid.clone().to_owned(),
-                    }
+                    GivenRowDecodeError::InvalidIIDFormatForGivenEntry { iid: attribute.iid.clone().to_owned() }
                 })?;
                 let vertex = AttributeVertex::try_decode(&iid)
                     .ok_or_else(|| concept_decode_error!(CouldNotDecodeIIDAsAttribute, iid))?;
@@ -239,7 +241,6 @@ impl GivenRowsDecoder<GivenEntryPayload> for GivenRowsDecoderHttp {
 }
 
 pub fn decode_value(value: ValueResponse) -> Result<Value<'static>, GivenRowDecodeError> {
-
     fn decode(to_parse: &str) -> Result<Value<'static>, GivenRowDecodeError> {
         let parsed = typeql::parse_value(to_parse).map_err(|typedb_source| {
             GivenRowDecodeError::ParsingValueFailedForGivenEntry { value: to_parse.to_owned(), typedb_source }

--- a/server/service/http/transaction_service.rs
+++ b/server/service/http/transaction_service.rs
@@ -34,7 +34,7 @@ use ir::pipeline::ParameterRegistry;
 use itertools::{Either, Itertools};
 use lending_iterator::LendingIterator;
 use options::{QueryOptions, TransactionOptions};
-use query::{error::QueryError};
+use query::error::QueryError;
 use resource::profile::StorageCounters;
 use storage::snapshot::ReadableSnapshot;
 use tokio::{
@@ -58,7 +58,7 @@ use crate::{
                 AnalysedQueryResponse, encode_analyzed_query,
                 structure::{AnalyzedPipelineResponse, encode_analyzed_pipeline_for_studio},
             },
-            query::{document::encode_document, row::encode_row},
+            query::{GivenRowsPayload, document::encode_document, row::encode_row},
         },
         may_encode_pipeline_structure,
         transaction_service::{
@@ -68,7 +68,6 @@ use crate::{
     },
     state::ServerState,
 };
-use crate::service::http::message::query::GivenRowsPayload;
 
 macro_rules! respond_error_and_return_break {
     ($responder:ident, $error:expr) => {{
@@ -157,7 +156,8 @@ pub(crate) struct TransactionService {
     timeout_at: Instant,
 
     transaction: Option<Transaction>,
-    query_queue: VecDeque<(TransactionResponder, QueueOptions, typeql::query::Pipeline, Option<GivenRowsPayload>, String)>,
+    query_queue:
+        VecDeque<(TransactionResponder, QueueOptions, typeql::query::Pipeline, Option<GivenRowsPayload>, String)>,
     running_write_query: Option<(TransactionResponder, JoinHandle<(Transaction, WriteQueryResult)>)>,
 
     close_sender: Sender<()>,

--- a/server/service/http/transaction_service.rs
+++ b/server/service/http/transaction_service.rs
@@ -34,7 +34,7 @@ use ir::pipeline::ParameterRegistry;
 use itertools::{Either, Itertools};
 use lending_iterator::LendingIterator;
 use options::{QueryOptions, TransactionOptions};
-use query::{error::QueryError, query_manager::GivenRows};
+use query::{error::QueryError};
 use resource::profile::StorageCounters;
 use storage::snapshot::ReadableSnapshot;
 use tokio::{
@@ -68,6 +68,7 @@ use crate::{
     },
     state::ServerState,
 };
+use crate::service::http::message::query::GivenRowsPayload;
 
 macro_rules! respond_error_and_return_break {
     ($responder:ident, $error:expr) => {{
@@ -112,7 +113,7 @@ macro_rules! unwrap_or_execute_else_respond_error_and_return_break {
 
 #[derive(Debug)]
 pub(crate) enum TransactionRequest {
-    Query(QueryOptions, Option<GivenRows>, String),
+    Query(QueryOptions, Option<GivenRowsPayload>, String),
     AnalyseQuery(String),
     Commit,
     Rollback,
@@ -156,7 +157,7 @@ pub(crate) struct TransactionService {
     timeout_at: Instant,
 
     transaction: Option<Transaction>,
-    query_queue: VecDeque<(TransactionResponder, QueueOptions, typeql::query::Pipeline, Option<GivenRows>, String)>,
+    query_queue: VecDeque<(TransactionResponder, QueueOptions, typeql::query::Pipeline, Option<GivenRowsPayload>, String)>,
     running_write_query: Option<(TransactionResponder, JoinHandle<(Transaction, WriteQueryResult)>)>,
 
     close_sender: Sender<()>,
@@ -633,7 +634,7 @@ impl TransactionService {
     async fn handle_query(
         &mut self,
         query_options: QueryOptions,
-        given_rows: Option<GivenRows>,
+        given_rows: Option<GivenRowsPayload>,
         query: String,
         responder: TransactionResponder,
     ) -> ControlFlow<(), ()> {
@@ -753,7 +754,7 @@ impl TransactionService {
         responder: TransactionResponder,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
-        given_rows: Option<GivenRows>,
+        given_rows: Option<GivenRowsPayload>,
         source_query: String,
     ) -> ControlFlow<(), ()> {
         debug_assert!(self.running_write_query.is_none());
@@ -830,7 +831,7 @@ impl TransactionService {
         &mut self,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
-        given_rows: Option<GivenRows>,
+        given_rows: Option<GivenRowsPayload>,
         source_query: String,
     ) -> Result<JoinHandle<(Transaction, WriteQueryResult)>, TransactionServiceError> {
         debug_assert!(self.running_write_query.is_none());
@@ -992,7 +993,7 @@ impl TransactionService {
         responder: TransactionResponder,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
-        given_rows: Option<GivenRows>,
+        given_rows: Option<GivenRowsPayload>,
         source_query: String,
         storage_counters: StorageCounters,
     ) -> JoinHandle<ControlFlow<(), ()>> {

--- a/server/service/http/transaction_service.rs
+++ b/server/service/http/transaction_service.rs
@@ -58,7 +58,7 @@ use crate::{
                 AnalysedQueryResponse, encode_analyzed_query,
                 structure::{AnalyzedPipelineResponse, encode_analyzed_pipeline_for_studio},
             },
-            query::{GivenRowsPayload, document::encode_document, row::encode_row},
+            query::{GivenRowsHttp, document::encode_document, row::encode_row},
         },
         may_encode_pipeline_structure,
         transaction_service::{
@@ -112,7 +112,7 @@ macro_rules! unwrap_or_execute_else_respond_error_and_return_break {
 
 #[derive(Debug)]
 pub(crate) enum TransactionRequest {
-    Query(QueryOptions, Option<GivenRowsPayload>, String),
+    Query(QueryOptions, Option<GivenRowsHttp>, String),
     AnalyseQuery(String),
     Commit,
     Rollback,
@@ -156,8 +156,7 @@ pub(crate) struct TransactionService {
     timeout_at: Instant,
 
     transaction: Option<Transaction>,
-    query_queue:
-        VecDeque<(TransactionResponder, QueueOptions, typeql::query::Pipeline, Option<GivenRowsPayload>, String)>,
+    query_queue: VecDeque<(TransactionResponder, QueueOptions, typeql::query::Pipeline, Option<GivenRowsHttp>, String)>,
     running_write_query: Option<(TransactionResponder, JoinHandle<(Transaction, WriteQueryResult)>)>,
 
     close_sender: Sender<()>,
@@ -634,7 +633,7 @@ impl TransactionService {
     async fn handle_query(
         &mut self,
         query_options: QueryOptions,
-        given_rows: Option<GivenRowsPayload>,
+        given_rows: Option<GivenRowsHttp>,
         query: String,
         responder: TransactionResponder,
     ) -> ControlFlow<(), ()> {
@@ -754,7 +753,7 @@ impl TransactionService {
         responder: TransactionResponder,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
-        given_rows: Option<GivenRowsPayload>,
+        given_rows: Option<GivenRowsHttp>,
         source_query: String,
     ) -> ControlFlow<(), ()> {
         debug_assert!(self.running_write_query.is_none());
@@ -831,7 +830,7 @@ impl TransactionService {
         &mut self,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
-        given_rows: Option<GivenRowsPayload>,
+        given_rows: Option<GivenRowsHttp>,
         source_query: String,
     ) -> Result<JoinHandle<(Transaction, WriteQueryResult)>, TransactionServiceError> {
         debug_assert!(self.running_write_query.is_none());
@@ -993,7 +992,7 @@ impl TransactionService {
         responder: TransactionResponder,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
-        given_rows: Option<GivenRowsPayload>,
+        given_rows: Option<GivenRowsHttp>,
         source_query: String,
         storage_counters: StorageCounters,
     ) -> JoinHandle<ControlFlow<(), ()>> {

--- a/server/service/http/transaction_service.rs
+++ b/server/service/http/transaction_service.rs
@@ -34,7 +34,7 @@ use ir::pipeline::ParameterRegistry;
 use itertools::{Either, Itertools};
 use lending_iterator::LendingIterator;
 use options::{QueryOptions, TransactionOptions};
-use query::error::QueryError;
+use query::{error::QueryError, query_manager::GivenRows};
 use resource::profile::StorageCounters;
 use storage::snapshot::ReadableSnapshot;
 use tokio::{
@@ -110,9 +110,9 @@ macro_rules! unwrap_or_execute_else_respond_error_and_return_break {
     }};
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug)]
 pub(crate) enum TransactionRequest {
-    Query(QueryOptions, String),
+    Query(QueryOptions, Option<GivenRows>, String),
     AnalyseQuery(String),
     Commit,
     Rollback,
@@ -156,7 +156,7 @@ pub(crate) struct TransactionService {
     timeout_at: Instant,
 
     transaction: Option<Transaction>,
-    query_queue: VecDeque<(TransactionResponder, QueueOptions, typeql::query::Pipeline, String)>,
+    query_queue: VecDeque<(TransactionResponder, QueueOptions, typeql::query::Pipeline, Option<GivenRows>, String)>,
     running_write_query: Option<(TransactionResponder, JoinHandle<(Transaction, WriteQueryResult)>)>,
 
     close_sender: Sender<()>,
@@ -371,8 +371,8 @@ impl TransactionService {
         match next {
             None => Break(()),
             Some((request, response_sender)) => match request {
-                TransactionRequest::Query(query_options, query) => {
-                    self.handle_query(query_options, query, response_sender).await
+                TransactionRequest::Query(query_options, given_rows, query) => {
+                    self.handle_query(query_options, given_rows, query, response_sender).await
                 }
                 TransactionRequest::AnalyseQuery(query) => self.handle_analyse_query(query, response_sender).await,
                 TransactionRequest::Commit => self.handle_commit(response_sender).await,
@@ -510,9 +510,11 @@ impl TransactionService {
 
     async fn cancel_queued_read_queries(&mut self, interrupt: InterruptType) -> ControlFlow<(), ()> {
         let mut write_queries = VecDeque::with_capacity(self.query_queue.len());
-        for (responder, query_options, pipeline, source_query) in self.query_queue.drain(0..self.query_queue.len()) {
+        for (responder, query_options, pipeline, given_rows, source_query) in
+            self.query_queue.drain(0..self.query_queue.len())
+        {
             if query_options.is_query() && is_write_pipeline(&pipeline) {
-                write_queries.push_back((responder, query_options, pipeline, source_query));
+                write_queries.push_back((responder, query_options, pipeline, given_rows, source_query));
             } else {
                 respond_else_return_break!(
                     responder,
@@ -557,14 +559,14 @@ impl TransactionService {
 
     async fn cancel_queued_write_queries(&mut self, interrupt: InterruptType) -> ControlFlow<(), ()> {
         let mut read_queries = VecDeque::with_capacity(self.query_queue.len());
-        for (responder, options, pipeline, source) in self.query_queue.drain(0..self.query_queue.len()) {
+        for (responder, options, pipeline, given_rows, source) in self.query_queue.drain(0..self.query_queue.len()) {
             if options.is_query() && is_write_pipeline(&pipeline) {
                 respond_else_return_break!(
                     responder,
                     TransactionServiceResponse::Err(TransactionServiceError::QueryInterrupted { interrupt })
                 );
             } else {
-                read_queries.push_back((responder, options, pipeline, source));
+                read_queries.push_back((responder, options, pipeline, given_rows, source));
             }
         }
         self.query_queue = read_queries;
@@ -574,17 +576,19 @@ impl TransactionService {
     async fn finish_queued_write_queries(&mut self, interrupt: InterruptType) -> ControlFlow<(), ()> {
         self.finish_running_write_query_no_transmit(interrupt).await?;
         let requests: Vec<_> = self.query_queue.drain(0..self.query_queue.len()).collect();
-        for (responder, options, pipeline, source_query) in requests.into_iter() {
+        for (responder, options, pipeline, given_rows, source_query) in requests.into_iter() {
             if options.is_query() && is_write_pipeline(&pipeline) {
                 let QueueOptions::Query(query_options) = options else { unreachable!() };
-                if let Break(()) = self.run_write_query(responder, query_options, pipeline, source_query).await {
+                if let Break(()) =
+                    self.run_write_query(responder, query_options, pipeline, given_rows, source_query).await
+                {
                     return Break(());
                 }
                 if let Break(()) = self.finish_running_write_query_no_transmit(interrupt).await {
                     return Break(());
                 }
             } else {
-                self.query_queue.push_back((responder, options, pipeline, source_query));
+                self.query_queue.push_back((responder, options, pipeline, given_rows, source_query));
             }
         }
         Continue(())
@@ -594,21 +598,27 @@ impl TransactionService {
         debug_assert!(self.running_write_query.is_none());
 
         // unblock requests until the first write request, which we begin executing if it exists
-        while let Some((responder, queue_options, query_pipeline, source_query)) = self.query_queue.pop_front() {
+        while let Some((responder, queue_options, query_pipeline, given_rows, source_query)) =
+            self.query_queue.pop_front()
+        {
             match (queue_options, is_write_pipeline(&query_pipeline)) {
                 (QueueOptions::Analyze, _) => {
+                    debug_assert!(given_rows.is_none());
                     if let Break(()) = self.run_analyse_query(responder, query_pipeline, source_query).await {
                         return Break(());
                     }
                 }
                 (QueueOptions::Query(query_options), true) => {
-                    return self.run_write_query(responder, query_options, query_pipeline, source_query).await;
+                    return self
+                        .run_write_query(responder, query_options, query_pipeline, given_rows, source_query)
+                        .await;
                 }
                 (QueueOptions::Query(query_options), false) => {
                     self.blocking_read_query_worker(
                         responder,
                         query_options,
                         query_pipeline,
+                        given_rows,
                         source_query,
                         StorageCounters::DISABLED,
                     )
@@ -623,6 +633,7 @@ impl TransactionService {
     async fn handle_query(
         &mut self,
         query_options: QueryOptions,
+        given_rows: Option<GivenRows>,
         query: String,
         responder: TransactionResponder,
     ) -> ControlFlow<(), ()> {
@@ -655,15 +666,27 @@ impl TransactionService {
                 #[allow(clippy::collapsible_else_if)]
                 if is_write_pipeline(&pipeline) {
                     if !self.query_queue.is_empty() || self.running_write_query.is_some() {
-                        self.query_queue.push_back((responder, QueueOptions::Query(query_options), pipeline, query));
+                        self.query_queue.push_back((
+                            responder,
+                            QueueOptions::Query(query_options),
+                            pipeline,
+                            given_rows,
+                            query,
+                        ));
                         // queued queries are not handled yet so there will be no query response yet
                         Continue(())
                     } else {
-                        self.run_write_query(responder, query_options, pipeline, query).await
+                        self.run_write_query(responder, query_options, pipeline, given_rows, query).await
                     }
                 } else {
                     if !self.query_queue.is_empty() || self.running_write_query.is_some() {
-                        self.query_queue.push_back((responder, QueueOptions::Query(query_options), pipeline, query));
+                        self.query_queue.push_back((
+                            responder,
+                            QueueOptions::Query(query_options),
+                            pipeline,
+                            given_rows,
+                            query,
+                        ));
                         // queued queries are not handled yet so there will be no query response yet
                         Continue(())
                     } else {
@@ -671,6 +694,7 @@ impl TransactionService {
                             responder,
                             query_options,
                             pipeline,
+                            given_rows,
                             query,
                             StorageCounters::DISABLED,
                         )
@@ -729,11 +753,12 @@ impl TransactionService {
         responder: TransactionResponder,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
+        given_rows: Option<GivenRows>,
         source_query: String,
     ) -> ControlFlow<(), ()> {
         debug_assert!(self.running_write_query.is_none());
         self.interrupt(InterruptType::WriteQueryExecution).await;
-        match self.spawn_blocking_execute_write_query(query_options, pipeline, source_query) {
+        match self.spawn_blocking_execute_write_query(query_options, pipeline, given_rows, source_query) {
             Ok(handle) => {
                 // running write queries have no valid response yet (until they finish) and will respond asynchronously
                 self.running_write_query = Some((responder, tokio::spawn(async move { handle.await.unwrap() })));
@@ -805,6 +830,7 @@ impl TransactionService {
         &mut self,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
+        given_rows: Option<GivenRows>,
         source_query: String,
     ) -> Result<JoinHandle<(Transaction, WriteQueryResult)>, TransactionServiceError> {
         debug_assert!(self.running_write_query.is_none());
@@ -812,13 +838,25 @@ impl TransactionService {
         let interrupt = self.query_interrupt_receiver.clone();
         match self.transaction.take() {
             Some(Transaction::Schema(schema_transaction)) => Ok(spawn_blocking(move || {
-                let (transaction, result) =
-                    execute_write_query_in_schema(schema_transaction, query_options, pipeline, source_query, interrupt);
+                let (transaction, result) = execute_write_query_in_schema(
+                    schema_transaction,
+                    query_options,
+                    pipeline,
+                    given_rows,
+                    source_query,
+                    interrupt,
+                );
                 (Transaction::Schema(transaction), result)
             })),
             Some(Transaction::Write(write_transaction)) => Ok(spawn_blocking(move || {
-                let (transaction, result) =
-                    execute_write_query_in_write(write_transaction, query_options, pipeline, source_query, interrupt);
+                let (transaction, result) = execute_write_query_in_write(
+                    write_transaction,
+                    query_options,
+                    pipeline,
+                    given_rows,
+                    source_query,
+                    interrupt,
+                );
                 (Transaction::Write(transaction), result)
             })),
             Some(Transaction::Read(transaction)) => {
@@ -954,6 +992,7 @@ impl TransactionService {
         responder: TransactionResponder,
         query_options: QueryOptions,
         pipeline: typeql::query::Pipeline,
+        given_rows: Option<GivenRows>,
         source_query: String,
         storage_counters: StorageCounters,
     ) -> JoinHandle<ControlFlow<(), ()>> {
@@ -976,6 +1015,7 @@ impl TransactionService {
                     thing_manager.clone(),
                     &function_manager,
                     &pipeline,
+                    given_rows,
                     &source_query,
                 );
                 let pipeline = match pipeline_result {
@@ -1176,7 +1216,7 @@ impl TransactionService {
         };
         if !self.query_queue.is_empty() || self.running_write_query.is_some() {
             // queued queries are not handled yet so there will be no query response yet
-            self.query_queue.push_back((responder, QueueOptions::Analyze, pipeline, query));
+            self.query_queue.push_back((responder, QueueOptions::Analyze, pipeline, None, query));
             Continue(())
         } else {
             self.run_analyse_query(responder, pipeline, query).await

--- a/server/service/http/typedb_service.rs
+++ b/server/service/http/typedb_service.rs
@@ -16,6 +16,7 @@ use concurrency::{IntervalTaskParameters, TokioTaskSpawner};
 use diagnostics::metrics::ActionKind;
 use http::StatusCode;
 use options::{QueryOptions, TransactionOptions};
+use query::query_manager::GivenRows;
 use resource::constants::common::SECONDS_IN_MINUTE;
 use system::concepts::{Credential, User};
 use tokio::{
@@ -41,7 +42,7 @@ use crate::{
                 authentication::{SigninPayload, encode_token},
                 body::{JsonBody, PlainTextBody},
                 database::{DatabasePath, encode_database, encode_databases},
-                query::{QueryOptionsPayload, QueryPayload, TransactionQueryPayload},
+                query::{GivenRowsPayload, QueryOptionsPayload, QueryPayload, TransactionQueryPayload},
                 server::encode_servers,
                 transaction::{TransactionOpenPayload, TransactionPath, encode_transaction},
                 user::{CreateUserPayload, UpdateUserPayload, UserPath, encode_user, encode_users},
@@ -51,7 +52,7 @@ use crate::{
                 QueryAnswer, TransactionRequest, TransactionResponder, TransactionService, TransactionServiceResponse,
             },
         },
-        transaction_service::TRANSACTION_REQUEST_BUFFER_SIZE,
+        transaction_service::{TRANSACTION_REQUEST_BUFFER_SIZE, TransactionServiceError},
     },
     state::ServerState,
 };
@@ -146,10 +147,18 @@ impl HTTPTypeDBService {
         }
     }
 
-    fn build_query_request(query_options_payload: Option<QueryOptionsPayload>, query: String) -> TransactionRequest {
+    fn build_query_request(
+        query_options_payload: Option<QueryOptionsPayload>,
+        given_rows: Option<GivenRows>,
+        query: String,
+    ) -> TransactionRequest {
         let query_options =
             query_options_payload.map(|options| options.into()).unwrap_or_else(|| QueryOptions::default_http());
-        TransactionRequest::Query(query_options, query)
+        TransactionRequest::Query(query_options, given_rows, query)
+    }
+
+    fn decode_given_rows(payload: Option<GivenRowsPayload>) -> Result<Option<GivenRows>, HttpServiceError> {
+        payload.map(|p| p.try_into()).transpose()
     }
 
     fn try_get_query_response(
@@ -672,9 +681,10 @@ impl HTTPTypeDBService {
                 if accessor != transaction.owner {
                     return Err(HttpServiceError::operation_not_permitted());
                 }
+                let given_rows = Self::decode_given_rows(payload.given_rows)?;
                 Self::transaction_request(
                     &transaction,
-                    Self::build_query_request(payload.query_options, payload.query),
+                    Self::build_query_request(payload.query_options, given_rows, payload.query),
                     true,
                 )
                 .await
@@ -697,9 +707,10 @@ impl HTTPTypeDBService {
                 let (transaction_info, _processing_time) =
                     Self::transaction_new(&service, accessor, payload.transaction_open_payload).await?;
 
+                let given_rows = Self::decode_given_rows(payload.given_rows)?;
                 let transaction_response = Self::transaction_request(
                     &transaction_info,
-                    Self::build_query_request(payload.query_options, payload.query),
+                    Self::build_query_request(payload.query_options, given_rows, payload.query),
                     true,
                 )
                 .await?;

--- a/server/service/http/typedb_service.rs
+++ b/server/service/http/typedb_service.rs
@@ -41,7 +41,7 @@ use crate::{
                 authentication::{SigninPayload, encode_token},
                 body::{JsonBody, PlainTextBody},
                 database::{DatabasePath, encode_database, encode_databases},
-                query::{GivenRowsPayload, QueryOptionsPayload, QueryPayload, TransactionQueryPayload},
+                query::{GivenRowsHttp, QueryOptionsPayload, QueryPayload, TransactionQueryPayload},
                 server::encode_servers,
                 transaction::{TransactionOpenPayload, TransactionPath, encode_transaction},
                 user::{CreateUserPayload, UpdateUserPayload, UserPath, encode_user, encode_users},
@@ -148,7 +148,7 @@ impl HTTPTypeDBService {
 
     fn build_query_request(
         query_options_payload: Option<QueryOptionsPayload>,
-        given_rows: Option<GivenRowsPayload>,
+        given_rows: Option<GivenRowsHttp>,
         query: String,
     ) -> TransactionRequest {
         let query_options =
@@ -678,7 +678,7 @@ impl HTTPTypeDBService {
                 }
                 Self::transaction_request(
                     &transaction,
-                    Self::build_query_request(payload.query_options, payload.given_rows, payload.query),
+                    Self::build_query_request(payload.query_options, payload.given_rows.map(Into::into), payload.query),
                     true,
                 )
                 .await
@@ -703,7 +703,7 @@ impl HTTPTypeDBService {
 
                 let transaction_response = Self::transaction_request(
                     &transaction_info,
-                    Self::build_query_request(payload.query_options, payload.given_rows, payload.query),
+                    Self::build_query_request(payload.query_options, payload.given_rows.map(Into::into), payload.query),
                     true,
                 )
                 .await?;

--- a/server/service/http/typedb_service.rs
+++ b/server/service/http/typedb_service.rs
@@ -16,7 +16,6 @@ use concurrency::{IntervalTaskParameters, TokioTaskSpawner};
 use diagnostics::metrics::ActionKind;
 use http::StatusCode;
 use options::{QueryOptions, TransactionOptions};
-use query::query_manager::GivenRows;
 use resource::constants::common::SECONDS_IN_MINUTE;
 use system::concepts::{Credential, User};
 use tokio::{
@@ -52,7 +51,7 @@ use crate::{
                 QueryAnswer, TransactionRequest, TransactionResponder, TransactionService, TransactionServiceResponse,
             },
         },
-        transaction_service::{TRANSACTION_REQUEST_BUFFER_SIZE, TransactionServiceError},
+        transaction_service::TRANSACTION_REQUEST_BUFFER_SIZE,
     },
     state::ServerState,
 };
@@ -149,16 +148,12 @@ impl HTTPTypeDBService {
 
     fn build_query_request(
         query_options_payload: Option<QueryOptionsPayload>,
-        given_rows: Option<GivenRows>,
+        given_rows: Option<GivenRowsPayload>,
         query: String,
     ) -> TransactionRequest {
         let query_options =
             query_options_payload.map(|options| options.into()).unwrap_or_else(|| QueryOptions::default_http());
         TransactionRequest::Query(query_options, given_rows, query)
-    }
-
-    fn decode_given_rows(payload: Option<GivenRowsPayload>) -> Result<Option<GivenRows>, HttpServiceError> {
-        payload.map(|p| p.try_into()).transpose()
     }
 
     fn try_get_query_response(
@@ -681,10 +676,9 @@ impl HTTPTypeDBService {
                 if accessor != transaction.owner {
                     return Err(HttpServiceError::operation_not_permitted());
                 }
-                let given_rows = Self::decode_given_rows(payload.given_rows)?;
                 Self::transaction_request(
                     &transaction,
-                    Self::build_query_request(payload.query_options, given_rows, payload.query),
+                    Self::build_query_request(payload.query_options, payload.given_rows, payload.query),
                     true,
                 )
                 .await
@@ -707,10 +701,9 @@ impl HTTPTypeDBService {
                 let (transaction_info, _processing_time) =
                     Self::transaction_new(&service, accessor, payload.transaction_open_payload).await?;
 
-                let given_rows = Self::decode_given_rows(payload.given_rows)?;
                 let transaction_response = Self::transaction_request(
                     &transaction_info,
-                    Self::build_query_request(payload.query_options, given_rows, payload.query),
+                    Self::build_query_request(payload.query_options, payload.given_rows, payload.query),
                     true,
                 )
                 .await?;

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -5,7 +5,12 @@
  */
 use std::{sync::Arc, time::Duration};
 
-use database::transaction::{CommitIntent, TransactionError, TransactionSchema, TransactionWrite};
+use concept::error::ConceptDecodeError;
+use database::transaction::{
+    CommitIntent, DataCommitError, SchemaCommitError, TransactionError, TransactionRead, TransactionSchema,
+    TransactionWrite,
+};
+use diagnostics::metrics::LoadKind;
 use error::typedb_error;
 use executor::{InterruptType, pipeline::PipelineExecutionError};
 use query::error::QueryError;
@@ -28,7 +33,7 @@ pub(crate) fn is_write_pipeline(pipeline: &typeql::query::Pipeline) -> bool {
     for stage in &pipeline.stages {
         match stage {
             Stage::Insert(_) | Stage::Put(_) | Stage::Delete(_) | Stage::Update(_) => return true,
-            Stage::Fetch(_) | Stage::Operator(_) | Stage::Match(_) => {}
+            Stage::Given(_) | Stage::Fetch(_) | Stage::Operator(_) | Stage::Match(_) => {}
         }
     }
     false
@@ -122,6 +127,7 @@ typedb_error! {
         AnalyseQueryExpectsPipeline(19, "Query analyse received a schema query.Only query pipeline can be analysed."),
         AnalyseQueryFailed(20, "Analysing the query failed.", typedb_source: QueryError),
         CannotOpen(21, "Could not open transaction.", typedb_source: ArcServerStateError),
+        DecodingGivenRowsFailed(22, "Decoding the input failed", typedb_source: ConceptDecodeError),
     }
 }
 
@@ -145,7 +151,8 @@ impl TransactionServiceError {
             | TransactionServiceError::TransactionTimeout { .. }
             | TransactionServiceError::InvalidPrefetchSize { .. }
             | TransactionServiceError::AnalyseQueryExpectsPipeline { .. }
-            | TransactionServiceError::AnalyseQueryFailed { .. } => None,
+            | TransactionServiceError::AnalyseQueryFailed { .. }
+            | TransactionServiceError::DecodingGivenRowsFailed { .. } => None,
 
             TransactionServiceError::DataCommitFailed { typedb_source }
             | TransactionServiceError::SchemaCommitFailed { typedb_source }

--- a/system/repositories.rs
+++ b/system/repositories.rs
@@ -32,7 +32,7 @@ pub mod user_repository {
         let unexpected_error_msg = "An unexpected error occurred when acquiring the list of users";
         let query_str = "match (user: $u, credentials: $c) isa user-credentials; $u has name $n;";
         let query = parse_query(query_str).expect(unexpected_error_msg);
-        let (tx, result) = execute_read_pipeline(tx, query.into_structure().into_pipeline(), None, query_str);
+        let (tx, result) = execute_read_pipeline(tx, query.into_structure().into_pipeline(), query_str);
         let rows = result.expect(unexpected_error_msg);
         let users = rows.iter().map(|row| User::new(get_string(&tx, row, "n"))).collect();
         users
@@ -50,7 +50,7 @@ pub mod user_repository {
                 $p has hash $h;"
         );
         let query = parse_query(&query_str).expect(unexpected_error_msg);
-        let (tx, result) = execute_read_pipeline(tx, query.into_structure().into_pipeline(), None, &query_str);
+        let (tx, result) = execute_read_pipeline(tx, query.into_structure().into_pipeline(), &query_str);
         let mut rows: Vec<HashMap<String, VariableValue>> = match result {
             Ok(rows) => rows,
             Err(_) => return Err(SystemDBError::QueryFailed {}),
@@ -103,7 +103,6 @@ pub mod user_repository {
             function_manager,
             query_manager,
             query.into_structure().into_pipeline(),
-            None,
             &query_string,
         );
         (Ok(()), snapshot)
@@ -136,7 +135,6 @@ pub mod user_repository {
                     function_manager,
                     query_manager,
                     query.into_structure().into_pipeline(),
-                    None,
                     &query_string,
                 );
                 (Ok(()), snapshot)
@@ -171,7 +169,6 @@ pub mod user_repository {
             function_manager,
             query_manager,
             query.into_structure().into_pipeline(),
-            None,
             &query_string,
         );
         (Ok(()), snapshot)

--- a/system/repositories.rs
+++ b/system/repositories.rs
@@ -32,7 +32,7 @@ pub mod user_repository {
         let unexpected_error_msg = "An unexpected error occurred when acquiring the list of users";
         let query_str = "match (user: $u, credentials: $c) isa user-credentials; $u has name $n;";
         let query = parse_query(query_str).expect(unexpected_error_msg);
-        let (tx, result) = execute_read_pipeline(tx, &query.into_structure().into_pipeline(), query_str);
+        let (tx, result) = execute_read_pipeline(tx, query.into_structure().into_pipeline(), None, query_str);
         let rows = result.expect(unexpected_error_msg);
         let users = rows.iter().map(|row| User::new(get_string(&tx, row, "n"))).collect();
         users
@@ -50,7 +50,7 @@ pub mod user_repository {
                 $p has hash $h;"
         );
         let query = parse_query(&query_str).expect(unexpected_error_msg);
-        let (tx, result) = execute_read_pipeline(tx, &query.into_structure().into_pipeline(), &query_str);
+        let (tx, result) = execute_read_pipeline(tx, query.into_structure().into_pipeline(), None, &query_str);
         let mut rows: Vec<HashMap<String, VariableValue>> = match result {
             Ok(rows) => rows,
             Err(_) => return Err(SystemDBError::QueryFailed {}),
@@ -102,7 +102,8 @@ pub mod user_repository {
             thing_manager,
             function_manager,
             query_manager,
-            &query.into_structure().into_pipeline(),
+            query.into_structure().into_pipeline(),
+            None,
             &query_string,
         );
         (Ok(()), snapshot)
@@ -134,7 +135,8 @@ pub mod user_repository {
                     thing_manager,
                     function_manager,
                     query_manager,
-                    &query.into_structure().into_pipeline(),
+                    query.into_structure().into_pipeline(),
+                    None,
                     &query_string,
                 );
                 (Ok(()), snapshot)
@@ -168,7 +170,8 @@ pub mod user_repository {
             thing_manager,
             function_manager,
             query_manager,
-            &query.into_structure().into_pipeline(),
+            query.into_structure().into_pipeline(),
+            None,
             &query_string,
         );
         (Ok(()), snapshot)

--- a/system/util.rs
+++ b/system/util.rs
@@ -132,13 +132,10 @@ pub mod query_util {
         pipeline::stage::{ExecutionContext, StageIterator},
     };
     use function::function_manager::FunctionManager;
-    use query::{
-        error::QueryError,
-        query_manager::{QueryManager},
-    };
+    use query::{error::QueryError, given_rows::GivenRowsSimple, query_manager::QueryManager};
     use storage::{durability_client::WALClient, snapshot::WriteSnapshot};
     use typeql::query::Pipeline;
-    use query::given_rows::GivenRowsSimple;
+
     use crate::util::answer_util::collect_answer;
 
     pub fn execute_read_pipeline(

--- a/system/util.rs
+++ b/system/util.rs
@@ -132,7 +132,10 @@ pub mod query_util {
         pipeline::stage::{ExecutionContext, StageIterator},
     };
     use function::function_manager::FunctionManager;
-    use query::{error::QueryError, query_manager::QueryManager};
+    use query::{
+        error::QueryError,
+        query_manager::{GivenRows, QueryManager},
+    };
     use storage::{durability_client::WALClient, snapshot::WriteSnapshot};
     use typeql::query::Pipeline;
 
@@ -140,7 +143,8 @@ pub mod query_util {
 
     pub fn execute_read_pipeline(
         tx: TransactionRead<WALClient>,
-        pipeline: &Pipeline,
+        pipeline: Pipeline,
+        given: Option<GivenRows>,
         source_query: &str,
     ) -> (TransactionRead<WALClient>, Result<Vec<HashMap<String, VariableValue<'static>>>, Box<QueryError>>) {
         let prepared_pipeline = match tx.query_manager.prepare_read_pipeline(
@@ -148,7 +152,8 @@ pub mod query_util {
             &tx.type_manager,
             tx.thing_manager.clone(),
             &tx.function_manager,
-            pipeline,
+            &pipeline,
+            given,
             source_query,
         ) {
             Ok(pipeline) => pipeline,
@@ -188,7 +193,8 @@ pub mod query_util {
         thing_manager: Arc<ThingManager>,
         function_manager: &FunctionManager,
         query_manager: &QueryManager,
-        pipeline: &Pipeline,
+        pipeline: Pipeline,
+        given_rows: Option<GivenRows>,
         source_query: &str,
     ) -> (Result<Vec<HashMap<String, VariableValue<'static>>>, Box<QueryError>>, Arc<WriteSnapshot<WALClient>>) {
         let prepared_pipeline = match query_manager.prepare_write_pipeline(
@@ -196,7 +202,8 @@ pub mod query_util {
             type_manager,
             thing_manager,
             function_manager,
-            pipeline,
+            &pipeline,
+            given_rows,
             source_query,
         ) {
             Ok(pipeline) => pipeline,

--- a/system/util.rs
+++ b/system/util.rs
@@ -134,17 +134,16 @@ pub mod query_util {
     use function::function_manager::FunctionManager;
     use query::{
         error::QueryError,
-        query_manager::{GivenRows, QueryManager},
+        query_manager::{QueryManager},
     };
     use storage::{durability_client::WALClient, snapshot::WriteSnapshot};
     use typeql::query::Pipeline;
-
+    use query::given_rows::GivenRowsSimple;
     use crate::util::answer_util::collect_answer;
 
     pub fn execute_read_pipeline(
         tx: TransactionRead<WALClient>,
         pipeline: Pipeline,
-        given: Option<GivenRows>,
         source_query: &str,
     ) -> (TransactionRead<WALClient>, Result<Vec<HashMap<String, VariableValue<'static>>>, Box<QueryError>>) {
         let prepared_pipeline = match tx.query_manager.prepare_read_pipeline(
@@ -153,7 +152,7 @@ pub mod query_util {
             tx.thing_manager.clone(),
             &tx.function_manager,
             &pipeline,
-            given,
+            None::<GivenRowsSimple>,
             source_query,
         ) {
             Ok(pipeline) => pipeline,
@@ -194,7 +193,6 @@ pub mod query_util {
         function_manager: &FunctionManager,
         query_manager: &QueryManager,
         pipeline: Pipeline,
-        given_rows: Option<GivenRows>,
         source_query: &str,
     ) -> (Result<Vec<HashMap<String, VariableValue<'static>>>, Box<QueryError>>, Arc<WriteSnapshot<WALClient>>) {
         let prepared_pipeline = match query_manager.prepare_write_pipeline(
@@ -203,7 +201,7 @@ pub mod query_util {
             thing_manager,
             function_manager,
             &pipeline,
-            given_rows,
+            None::<GivenRowsSimple>,
             source_query,
         ) {
             Ok(pipeline) => pipeline,

--- a/tests/behaviour/query/BUILD
+++ b/tests/behaviour/query/BUILD
@@ -26,6 +26,7 @@ rust_test(
         "@typedb_behaviour//query/language:delete.feature",
         "@typedb_behaviour//query/language:expression.feature",
         "@typedb_behaviour//query/language:fetch.feature",
+        "@typedb_behaviour//query/language:given.feature",
         "@typedb_behaviour//query/language:insert.feature",
         "@typedb_behaviour//query/language:match.feature",
         "@typedb_behaviour//query/language:modifiers.feature",

--- a/tests/behaviour/query/language/given.rs
+++ b/tests/behaviour/query/language/given.rs
@@ -9,7 +9,7 @@
 use steps::Context;
 
 #[tokio::test]
-async fn test_read_given() {
+async fn test_write_given() {
     // Bazel specific path: when running the test in bazel, the external data from
     // @typedb_behaviour is stored in a directory that is a sibling to
     // the working directory.

--- a/tests/behaviour/query/language/given.rs
+++ b/tests/behaviour/query/language/given.rs
@@ -9,7 +9,7 @@
 use steps::Context;
 
 #[tokio::test]
-async fn test_write_given() {
+async fn test_read_given() {
     // Bazel specific path: when running the test in bazel, the external data from
     // @typedb_behaviour is stored in a directory that is a sibling to
     // the working directory.

--- a/tests/behaviour/query/language/given.rs
+++ b/tests/behaviour/query/language/given.rs
@@ -1,0 +1,23 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#![allow(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
+use steps::Context;
+
+#[tokio::test]
+async fn test_write_given() {
+    // Bazel specific path: when running the test in bazel, the external data from
+    // @typedb_behaviour is stored in a directory that is a sibling to
+    // the working directory.
+    #[cfg(feature = "bazel")]
+    let path = "../typedb_behaviour+/query/language/given.feature";
+
+    #[cfg(not(feature = "bazel"))]
+    let path = "bazel-typedb/external/typedb_behaviour/query/language/given.feature";
+
+    assert!(Context::test(path, true).await);
+}

--- a/tests/behaviour/query/language/mod.rs
+++ b/tests/behaviour/query/language/mod.rs
@@ -11,6 +11,7 @@ mod delete;
 mod disjunction;
 mod expressions;
 mod fetch;
+mod given;
 mod insert;
 mod r#match;
 mod modifiers;

--- a/tests/behaviour/service/http/http_steps/lib.rs
+++ b/tests/behaviour/service/http/http_steps/lib.rs
@@ -52,7 +52,9 @@ macro_rules! in_background {
 }
 pub(crate) use in_background;
 use server::service::http::message::{
-    analyze::AnalysedQueryResponse, query::QueryOptionsPayload, transaction::TransactionOptionsPayload,
+    analyze::AnalysedQueryResponse,
+    query::{GivenRowsPayload, QueryOptionsPayload},
+    transaction::TransactionOptionsPayload,
 };
 
 use crate::{params::TokenMode, util::random_uuid};
@@ -136,6 +138,7 @@ pub struct Context {
     pub http_context: HttpContext,
     pub transaction_ids: VecDeque<String>,
     pub background_transaction_ids: VecDeque<String>,
+    pub given_rows: Option<GivenRowsPayload>,
     pub answer: Option<QueryAnswerResponse>,
     pub analyzed: Option<AnalysedQueryResponse>,
     pub concurrent_answers: Vec<QueryAnswerResponse>,
@@ -439,6 +442,7 @@ impl Default for Context {
             transaction_ids: VecDeque::new(),
             background_transaction_ids: VecDeque::new(),
             analyzed: None,
+            given_rows: None,
             answer: None,
             concurrent_answers: Vec::new(),
             concurrent_answers_last_consumed_index: 0,

--- a/tests/behaviour/service/http/http_steps/message.rs
+++ b/tests/behaviour/service/http/http_steps/message.rs
@@ -16,7 +16,7 @@ use server::service::http::message::{
     authentication::TokenResponse,
     database::{DatabaseResponse, DatabasesResponse},
     query::{
-        QueryAnswerResponse, QueryOptionsPayload,
+        GivenRowsPayload, QueryAnswerResponse, QueryOptionsPayload,
         concept::{
             AttributeResponse, AttributeTypeResponse, EntityResponse, EntityTypeResponse, RelationResponse,
             RelationTypeResponse, RoleTypeResponse, ValueResponse,
@@ -328,6 +328,7 @@ pub async fn transactions_query(
     auth_token: Option<impl AsRef<str>>,
     transaction_id: &str,
     query_options: &Option<QueryOptionsPayload>,
+    given_rows_payload: Option<GivenRowsPayload>,
     query: &str,
 ) -> Result<QueryAnswerResponse, HttpBehaviourTestError> {
     let url = format!("{}/transactions/{}/query", Context::default_versioned_endpoint(), transaction_id);
@@ -335,6 +336,9 @@ pub async fn transactions_query(
     json_map.insert("query".to_string(), json!(query));
     if let Some(query_options) = query_options {
         json_map.insert("queryOptions".to_string(), json!(query_options));
+    }
+    if let Some(given_rows_payload) = given_rows_payload {
+        json_map.insert("givenRows".to_string(), json!(given_rows_payload));
     }
     let response =
         send_request(http_client, auth_token, Method::POST, &url, Some(json!(json_map).to_string().as_str())).await?;

--- a/tests/behaviour/service/http/http_steps/params.rs
+++ b/tests/behaviour/service/http/http_steps/params.rs
@@ -318,3 +318,32 @@ impl fmt::Display for TokenMode {
         }
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Parameter)]
+#[param(name = "variable_list", regex = r"(\$[a-zA-Z0-9\-_]+(, \$[a-zA-Z0-9\-_]+)*)")]
+pub struct VariableList(pub Vec<String>);
+
+impl FromStr for VariableList {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.split(",").map(|s| s.replace("$", "").replace(" ", "")).collect()))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Parameter)]
+#[param(name = "with_given", regex = "(| with given rows)")]
+pub enum WithGiven {
+    False,
+    True,
+}
+
+impl FromStr for WithGiven {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            " with given rows" => Self::True,
+            "" => Self::False,
+            invalid => return Err(format!("Invalid `WithGiven`: {invalid}")),
+        })
+    }
+}

--- a/tests/behaviour/service/http/http_steps/query.rs
+++ b/tests/behaviour/service/http/http_steps/query.rs
@@ -3,8 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
-use std::str::FromStr;
+use std::{collections::BTreeMap, str::FromStr};
 
 use cucumber::gherkin::Step;
 use futures::future::join_all;
@@ -158,6 +157,8 @@ fn check_is_value(
 
 #[cucumber::given(expr = "set answers of typeql read query as given rows with order: {variable_list}")]
 #[cucumber::when(expr = "set answers of typeql read query as given rows with order: {variable_list}")]
+#[cucumber::given(expr = "set answers of typeql read query as given rows dictionary with variables: {variable_list}")]
+#[cucumber::when(expr = "set answers of typeql read query as given rows dictionary with variables: {variable_list}")]
 async fn set_given_rows(context: &mut Context, var_list: VariableList, step: &Step) {
     let result = (transactions_query(
         context.http_client(),
@@ -172,16 +173,23 @@ async fn set_given_rows(context: &mut Context, var_list: VariableList, step: &St
     let mut given_rows = Vec::with_capacity(rows.len());
     for row in rows {
         let data = row.get("data").expect("Expected to have 'data' key");
-
         let given_row = var_list
             .0
             .iter()
-            .map(|v| serde_json::from_value(data.get(v).cloned().unwrap()).unwrap())
-            .collect::<Vec<Option<GivenEntryPayload>>>();
+            .filter_map(|var| {
+                data.get(var).and_then(|value| {
+                    if value == &serde_json::Value::Null {
+                        None
+                    } else {
+                        Some((var.clone(), Some(serde_json::from_value(value.clone()).unwrap())))
+                    }
+                })
+            })
+            .collect::<BTreeMap<String, Option<GivenEntryPayload>>>();
         given_rows.push(given_row);
     }
 
-    context.given_rows = Some(GivenRowsPayload { variables: var_list.0, rows: given_rows })
+    context.given_rows = Some(GivenRowsPayload(given_rows))
 }
 
 #[apply(generic_step)]

--- a/tests/behaviour/service/http/http_steps/query.rs
+++ b/tests/behaviour/service/http/http_steps/query.rs
@@ -181,7 +181,7 @@ async fn set_given_rows(context: &mut Context, var_list: VariableList, step: &St
         given_rows.push(given_row);
     }
 
-    context.given_rows = Some(GivenRowsPayload(given_rows))
+    context.given_rows = Some(GivenRowsPayload { variables: var_list.0, rows: given_rows })
 }
 
 #[apply(generic_step)]

--- a/tests/behaviour/service/http/http_steps/query.rs
+++ b/tests/behaviour/service/http/http_steps/query.rs
@@ -177,7 +177,7 @@ async fn set_given_rows(context: &mut Context, var_list: VariableList, step: &St
             .0
             .iter()
             .map(|v| serde_json::from_value(data.get(v).cloned().unwrap()).unwrap())
-            .collect::<Vec<GivenEntryPayload>>();
+            .collect::<Vec<Option<GivenEntryPayload>>>();
         given_rows.push(given_row);
     }
 
@@ -185,24 +185,26 @@ async fn set_given_rows(context: &mut Context, var_list: VariableList, step: &St
 }
 
 #[apply(generic_step)]
-#[step(expr = "{token_mode}typeql schema query{typeql_may_error}")]
-#[step(expr = "{token_mode}typeql write query{typeql_may_error}")]
-#[step(expr = "{token_mode}typeql read query{typeql_may_error}")]
+#[step(expr = "{token_mode}typeql schema query{with_given}{typeql_may_error}")]
+#[step(expr = "{token_mode}typeql write query{with_given}{typeql_may_error}")]
+#[step(expr = "{token_mode}typeql read query{with_given}{typeql_may_error}")]
 pub async fn typeql_query(
     context: &mut Context,
     token_mode: TokenMode,
+    with_given: WithGiven,
     may_error: params::TypeQLMayError,
     step: &Step,
 ) {
     context.randomize_auth_token_if_needed(token_mode);
     context.cleanup_answers().await;
+    let given_rows = if with_given == WithGiven::True { context.given_rows.take() } else { None };
     may_error.check(
         transactions_query(
             context.http_client(),
             context.auth_token_by_mode(token_mode),
             context.transaction(),
             &context.query_options,
-            None,
+            given_rows,
             step.docstring().unwrap(),
         )
         .await,

--- a/tests/behaviour/service/http/http_steps/query.rs
+++ b/tests/behaviour/service/http/http_steps/query.rs
@@ -17,18 +17,23 @@ use server::service::{
         analyze::{
             annotations::bdd::{
                 encode_fetch_annotations_as_functor, encode_function_annotations_as_functor,
-                encode_pipeline_annotations_as_functor,
+                encode_pipeline_annotations_as_functor, encode_pipeline_given_annotations_as_functor,
             },
-            structure::bdd::{encode_function_structure_as_functor, encode_pipeline_structure_as_functor},
+            structure::bdd::{
+                encode_function_structure_as_functor, encode_pipeline_given_as_functor,
+                encode_pipeline_structure_as_functor,
+            },
         },
-        query::QueryAnswerResponse,
+        query::{GivenEntryPayload, GivenRowsPayload, QueryAnswerResponse},
     },
 };
 
 use crate::{
     Context, HttpBehaviourTestError, generic_step,
     message::{ConceptResponse, query, transactions_analyze, transactions_query},
-    params::{ConceptKind, IsByVarIndex, IsOrNot, QueryAnswerType, TokenMode, Var, WithCommit},
+    params::{
+        ConceptKind, IsByVarIndex, IsOrNot, QueryAnswerType, TokenMode, Var, VariableList, WithCommit, WithGiven,
+    },
     util::{iter_table, list_contains_json, parse_json},
 };
 
@@ -151,6 +156,34 @@ fn check_is_value(
     is_or_not.compare(expected_value.into_typedb(actual_value_type_converted), actual_value_converted);
 }
 
+#[cucumber::given(expr = "set answers of typeql read query as given rows with order: {variable_list}")]
+#[cucumber::when(expr = "set answers of typeql read query as given rows with order: {variable_list}")]
+async fn set_given_rows(context: &mut Context, var_list: VariableList, step: &Step) {
+    let result = (transactions_query(
+        context.http_client(),
+        context.auth_token(),
+        context.transaction(),
+        &context.query_options,
+        None,
+        step.docstring().unwrap(),
+    )
+    .await);
+    let rows = result.unwrap().answers.unwrap();
+    let mut given_rows = Vec::with_capacity(rows.len());
+    for row in rows {
+        let data = row.get("data").expect("Expected to have 'data' key");
+
+        let given_row = var_list
+            .0
+            .iter()
+            .map(|v| serde_json::from_value(data.get(v).cloned().unwrap()).unwrap())
+            .collect::<Vec<GivenEntryPayload>>();
+        given_rows.push(given_row);
+    }
+
+    context.given_rows = Some(GivenRowsPayload(given_rows))
+}
+
 #[apply(generic_step)]
 #[step(expr = "{token_mode}typeql schema query{typeql_may_error}")]
 #[step(expr = "{token_mode}typeql write query{typeql_may_error}")]
@@ -169,6 +202,7 @@ pub async fn typeql_query(
             context.auth_token_by_mode(token_mode),
             context.transaction(),
             &context.query_options,
+            None,
             step.docstring().unwrap(),
         )
         .await,
@@ -212,11 +246,12 @@ pub async fn one_shot_query_typeql_query(
 }
 
 #[apply(generic_step)]
-#[step("get answers of typeql schema query")]
-#[step(expr = "get answers of typeql write query")]
-#[step(expr = "get answers of typeql read query")]
-pub async fn get_answers_of_typeql_query(context: &mut Context, step: &Step) {
+#[step(expr = "get answers of typeql schema query{with_given}")]
+#[step(expr = "get answers of typeql write query{with_given}")]
+#[step(expr = "get answers of typeql read query{with_given}")]
+pub async fn get_answers_of_typeql_query(context: &mut Context, with_given: WithGiven, step: &Step) {
     context.cleanup_answers().await;
+    let given_rows = if with_given == WithGiven::True { context.given_rows.take() } else { None };
     context
         .set_answer(
             transactions_query(
@@ -224,6 +259,7 @@ pub async fn get_answers_of_typeql_query(context: &mut Context, step: &Step) {
                 context.auth_token(),
                 context.transaction(),
                 &context.query_options,
+                given_rows,
                 step.docstring().unwrap(),
             )
             .await,
@@ -280,6 +316,7 @@ pub async fn concurrently_get_answers_of_typeql_query_times(context: &mut Contex
             context.auth_token(),
             context.transaction(),
             &context.query_options,
+            None,
             query,
         )
     }))
@@ -1086,6 +1123,15 @@ async fn typeql_analyze_may_error(context: &mut Context, may_error: params::Type
     may_error.check_logic(result);
 }
 
+#[cucumber::then("analyzed query given structure is:")]
+async fn analyzed_query_given_is(context: &mut Context, step: &Step) {
+    let expected_functor = step.docstring().unwrap();
+    let analyzed = context.analyzed.as_ref().unwrap();
+    let actual_functor = encode_pipeline_given_as_functor(&analyzed.query, &analyzed.given.as_ref().unwrap());
+
+    assert_eq!(normalize_functor_for_compare(&actual_functor), normalize_functor_for_compare(&expected_functor));
+}
+
 #[cucumber::then("analyzed query pipeline structure is:")]
 async fn analyzed_query_pipeline_is(context: &mut Context, step: &Step) {
     let expected_functor = step.docstring().unwrap();
@@ -1112,6 +1158,16 @@ async fn analyzed_query_preamble_contains(context: &mut Context, step: &Step) {
         expected_functor,
         preamble_functors.iter().join("\n\t")
     );
+}
+
+#[cucumber::then("analyzed query given annotations are:")]
+async fn analyzed_query_given_annotations_is(context: &mut Context, step: &Step) {
+    let expected_functor = step.docstring().unwrap();
+    let analyzed = context.analyzed.as_ref().unwrap();
+    let actual_functor =
+        encode_pipeline_given_annotations_as_functor(&analyzed.query, analyzed.given.as_ref().unwrap());
+
+    assert_eq!(normalize_functor_for_compare(&actual_functor), normalize_functor_for_compare(expected_functor));
 }
 
 #[cucumber::then("analyzed query pipeline annotations are:")]

--- a/tests/behaviour/service/http/http_steps/query.rs
+++ b/tests/behaviour/service/http/http_steps/query.rs
@@ -493,7 +493,7 @@ pub async fn answer_get_row_get_variable_is_empty(
     if matches!(is_by_var_index, IsByVarIndex::Is) {
         return; // http does not have indices
     }
-    is_or_not.compare(get_answer_rows_var(context, index, var), None);
+    is_or_not.compare(get_answer_rows_var(context, index, var), Some(&serde_json::Value::Null));
 }
 
 #[apply(generic_step)]

--- a/tests/behaviour/steps/lib.rs
+++ b/tests/behaviour/steps/lib.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use ::concept::thing::{attribute::Attribute, object::Object};
-use ::query::error::QueryError;
+use ::query::{error::QueryError, query_manager::GivenRows};
 use cucumber::{StatsWriter, World, gherkin::Feature};
 use database::Database;
 use futures::{
@@ -113,6 +113,7 @@ pub struct Context {
     attributes: HashMap<String, Option<Attribute>>,
     attribute_lists: HashMap<String, Vec<Attribute>>,
 
+    given_rows: Option<GivenRows>,
     analyzed: Option<AnalysedQueryResponse>,
 }
 
@@ -209,6 +210,10 @@ impl Context {
 
     pub fn take_transaction(&mut self) -> Option<ActiveTransaction> {
         self.active_transaction.take()
+    }
+
+    pub fn take_given_rows(&mut self) -> Option<GivenRows> {
+        self.given_rows.take()
     }
 }
 

--- a/tests/behaviour/steps/lib.rs
+++ b/tests/behaviour/steps/lib.rs
@@ -17,6 +17,7 @@ use std::{
 
 use ::concept::thing::{attribute::Attribute, object::Object};
 use ::query::{error::QueryError, given_rows::GivenRowsSimple};
+use answer::variable_value::VariableValue;
 use cucumber::{StatsWriter, World, gherkin::Feature};
 use database::Database;
 use futures::{
@@ -24,7 +25,6 @@ use futures::{
     stream::{self, StreamExt},
 };
 use itertools::Itertools;
-use answer::variable_value::VariableValue;
 use server::{Server, service::http::message::analyze::AnalysedQueryResponse};
 use storage::durability_client::WALClient;
 use thing_util::ObjectWithKey;

--- a/tests/behaviour/steps/lib.rs
+++ b/tests/behaviour/steps/lib.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use ::concept::thing::{attribute::Attribute, object::Object};
-use ::query::{error::QueryError, query_manager::GivenRows};
+use ::query::{error::QueryError, given_rows::GivenRowsSimple};
 use cucumber::{StatsWriter, World, gherkin::Feature};
 use database::Database;
 use futures::{
@@ -24,6 +24,7 @@ use futures::{
     stream::{self, StreamExt},
 };
 use itertools::Itertools;
+use answer::variable_value::VariableValue;
 use server::{Server, service::http::message::analyze::AnalysedQueryResponse};
 use storage::durability_client::WALClient;
 use thing_util::ObjectWithKey;
@@ -113,7 +114,7 @@ pub struct Context {
     attributes: HashMap<String, Option<Attribute>>,
     attribute_lists: HashMap<String, Vec<Attribute>>,
 
-    given_rows: Option<GivenRows>,
+    given_rows: Option<GivenRowsSimple>,
     analyzed: Option<AnalysedQueryResponse>,
 }
 
@@ -212,7 +213,7 @@ impl Context {
         self.active_transaction.take()
     }
 
-    pub fn take_given_rows(&mut self) -> Option<GivenRows> {
+    pub fn take_given_rows(&mut self) -> Option<GivenRowsSimple> {
         self.given_rows.take()
     }
 }

--- a/tests/behaviour/steps/params/lib.rs
+++ b/tests/behaviour/steps/params/lib.rs
@@ -885,3 +885,21 @@ impl FromStr for Optional {
         })
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Parameter)]
+#[param(name = "with_given", regex = "(| with given rows)")]
+pub enum WithGiven {
+    False,
+    True,
+}
+
+impl FromStr for WithGiven {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            " with given rows" => Self::True,
+            "" => Self::False,
+            invalid => return Err(format!("Invalid `WithGiven`: {invalid}")),
+        })
+    }
+}

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -253,7 +253,7 @@ async fn given_rows(context: &mut Context, step: &Step) {
     let length = table.rows.len();
     let width = table.rows.first().unwrap().len() as u32;
     // First row is the variables
-    let variables = table.rows[0].clone();
+    let variables = table.rows[0].iter().map(|s| s.split(":").next().unwrap().to_owned()).collect();
     let rows = table.rows[1..].iter().map(|row| row.iter().map(parse_query_given_row_entry).collect()).collect();
 
     context.given_rows = Some(GivenRowsSimple { variables, rows })

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -10,28 +10,43 @@ use answer::{Thing, variable_value::VariableValue};
 use compiler::VariablePosition;
 use concept::{
     error::ConceptReadError,
-    thing::{attribute::Attribute, object::ObjectAPI},
+    thing::{ThingAPI, attribute::Attribute, entity::Entity, object::ObjectAPI, relation::Relation},
     type_::TypeAPI,
 };
 use cucumber::gherkin::Step;
-use encoding::value::{ValueEncodable, label::Label, value_type::ValueType};
+use encoding::{
+    Prefixed,
+    graph::{
+        thing::{
+            ThingVertex,
+            vertex_attribute::{AttributeID, AttributeVertex},
+            vertex_object::{ObjectID, ObjectVertex},
+        },
+        type_::vertex::TypeID,
+    },
+    layout::prefix::Prefix,
+    value::{ValueEncodable, label::Label, value_type::ValueType},
+};
 use executor::{
     ExecutionInterrupt,
     batch::Batch,
     pipeline::stage::{ExecutionContext, StageIterator},
 };
+use futures::StreamExt;
 use itertools::{Either, Itertools};
 use lending_iterator::LendingIterator;
 use macro_rules_attribute::apply;
-use query::{analyse::AnalysedQuery, error::QueryError};
+use query::{analyse::AnalysedQuery, error::QueryError, query_manager::GivenRows};
 use resource::profile::StorageCounters;
 use server::service::http::message::analyze::{
     annotations::bdd::{
         encode_fetch_annotations_as_functor, encode_function_annotations_as_functor,
-        encode_pipeline_annotations_as_functor,
+        encode_pipeline_annotations_as_functor, encode_pipeline_given_annotations_as_functor,
     },
     encode_analyzed_query,
-    structure::bdd::{encode_function_structure_as_functor, encode_pipeline_structure_as_functor},
+    structure::bdd::{
+        encode_function_structure_as_functor, encode_pipeline_given_as_functor, encode_pipeline_structure_as_functor,
+    },
 };
 use test_utils::assert_matches;
 
@@ -70,6 +85,7 @@ fn row_answers_to_string(rows: &[HashMap<String, VariableValue<'static>>]) -> St
 fn execute_read_query(
     context: &Context,
     query: typeql::Query,
+    given_rows: Option<GivenRows>,
     source_query: &str,
 ) -> Result<QueryAnswer, Box<QueryError>> {
     with_read_tx!(context, |tx| {
@@ -79,6 +95,7 @@ fn execute_read_query(
             tx.thing_manager.clone(),
             &tx.function_manager,
             &query.into_structure().into_pipeline(),
+            given_rows,
             source_query,
         )?;
         if pipeline.has_fetch() {
@@ -120,6 +137,7 @@ fn execute_read_query(
 fn execute_write_query(
     context: &mut Context,
     query: typeql::Query,
+    given_rows: Option<GivenRows>,
     source_query: &str,
 ) -> Result<QueryAnswer, BehaviourTestExecutionError> {
     if matches!(context.active_transaction.as_ref().unwrap(), Read(_)) {
@@ -139,6 +157,7 @@ fn execute_write_query(
             thing_manager.clone(),
             &function_manager,
             &query.into_structure().into_pipeline(),
+            given_rows,
             source_query,
         );
 
@@ -219,6 +238,29 @@ fn execute_analyze(
     })
 }
 
+fn may_take_given_rows(context: &mut Context, with_given: params::WithGiven) -> Option<GivenRows> {
+    (with_given == params::WithGiven::True).then(|| context.take_given_rows().expect("Expected given rows available"))
+}
+
+#[cucumber::given("query is given rows")]
+#[cucumber::when("query is given rows")]
+async fn given_rows(context: &mut Context, step: &Step) {
+    let table = step.table.as_ref().expect("Expected table for given rows");
+    let length = table.rows.len();
+    let width = table.rows.first().unwrap().len() as u32;
+    let mut given_rows = GivenRows::new(width, length);
+    // Ignore the first row as a documentational header
+    table.rows[1..].iter().for_each(|row| {
+        given_rows.append(|mut into_row| {
+            row.iter().map(parse_query_given_row_entry).enumerate().for_each(|(i, value)| {
+                into_row.set(VariablePosition::new(i as u32), value);
+            });
+        });
+    });
+
+    context.given_rows = Some(given_rows)
+}
+
 #[apply(generic_step)]
 #[step(expr = "typeql schema query{typeql_may_error}")]
 async fn typeql_schema_query(context: &mut Context, may_error: params::TypeQLMayError, step: &Step) {
@@ -252,55 +294,68 @@ async fn typeql_schema_query(context: &mut Context, may_error: params::TypeQLMay
 }
 
 #[apply(generic_step)]
-#[step(expr = "typeql write query{typeql_may_error}")]
-async fn typeql_write_query(context: &mut Context, may_error: params::TypeQLMayError, step: &Step) {
+#[step(expr = "typeql write query{with_given}{typeql_may_error}")]
+async fn typeql_write_query(
+    context: &mut Context,
+    with_given: params::WithGiven,
+    may_error: params::TypeQLMayError,
+    step: &Step,
+) {
     let query_str = step.docstring.as_ref().unwrap().as_str();
     let parse_result = typeql::parse_query(query_str);
     if let Either::Right(_) = may_error.check_parsing(parse_result.as_ref()) {
         return;
     }
     let query = parse_result.unwrap();
-
-    let result = execute_write_query(context, query, query_str);
+    let given_rows = may_take_given_rows(context, with_given);
+    let result = execute_write_query(context, query, given_rows, query_str);
     if let Either::Right(_) = may_error.check_logic(result) {
         context.close_active_transaction();
     }
 }
 
 #[apply(generic_step)]
-#[step(expr = "get answers of typeql write query")]
-async fn get_answers_of_typeql_write_query(context: &mut Context, step: &Step) {
+#[step(expr = "get answers of typeql write query{with_given}")]
+async fn get_answers_of_typeql_write_query(context: &mut Context, with_given: params::WithGiven, step: &Step) {
     let query_str = step.docstring.as_ref().unwrap().as_str();
     let query = typeql::parse_query(query_str).unwrap();
-    let result = execute_write_query(context, query, query_str);
+    let given_rows = may_take_given_rows(context, with_given);
+    let result = execute_write_query(context, query, given_rows, query_str);
     context.query_answer = Some(result.unwrap());
 }
 
 #[apply(generic_step)]
-#[step(expr = "typeql read query{typeql_may_error}")]
-async fn typeql_read_query(context: &mut Context, may_error: params::TypeQLMayError, step: &Step) {
+#[step(expr = "typeql read query{with_given}{typeql_may_error}")]
+async fn typeql_read_query(
+    context: &mut Context,
+    with_given: params::WithGiven,
+    may_error: params::TypeQLMayError,
+    step: &Step,
+) {
     let query_str = step.docstring.as_ref().unwrap().as_str();
     let parse_result = typeql::parse_query(query_str);
     if let Either::Right(_) = may_error.check_parsing(parse_result.as_ref()) {
         return;
     }
     let query = parse_result.unwrap();
-    let result = execute_read_query(context, query, query_str);
+    let given_rows = may_take_given_rows(context, with_given);
+    let result = execute_read_query(context, query, given_rows, query_str);
     may_error.check_logic(result); // we don't close read transactions with logical errors
 }
 
-fn record_answers_of_typeql_read_query(context: &mut Context, query_str: &str) {
+fn record_answers_of_typeql_read_query(context: &mut Context, query_str: &str, given_rows: Option<GivenRows>) {
     let query = typeql::parse_query(query_str).unwrap();
-    context.query_answer = match execute_read_query(context, query, query_str) {
+    context.query_answer = match execute_read_query(context, query, given_rows, query_str) {
         Ok(answers) => Some(answers),
         Err(error) => panic!("Unexpected get answers error: {:?}", error),
     }
 }
 
 #[apply(generic_step)]
-#[step("get answers of typeql read query")]
-async fn get_answers_of_typeql_read_query(context: &mut Context, step: &Step) {
-    record_answers_of_typeql_read_query(context, step.docstring.as_ref().unwrap().as_str());
+#[step(expr = "get answers of typeql read query{with_given}")]
+async fn get_answers_of_typeql_read_query(context: &mut Context, with_given: params::WithGiven, step: &Step) {
+    let given_rows = may_take_given_rows(context, with_given);
+    record_answers_of_typeql_read_query(context, step.docstring.as_ref().unwrap().as_str(), given_rows);
 }
 
 #[cucumber::when("get answers of templated typeql read query")]
@@ -309,7 +364,7 @@ async fn get_answers_of_templated_typeql_read_query(context: &mut Context, step:
     let rows = context.query_answer.as_ref().unwrap().as_rows();
     let [answer] = rows else { panic!("Expected single answer, found {}", rows.len()) };
     let templated_query = step.docstring.as_ref().unwrap().as_str();
-    record_answers_of_typeql_read_query(context, &apply_query_template(templated_query, answer));
+    record_answers_of_typeql_read_query(context, &apply_query_template(templated_query, answer), None);
 }
 
 #[apply(generic_step)]
@@ -444,12 +499,8 @@ fn does_attribute_match(id: &str, var_value: &VariableValue<'_>, context: &Conte
     })
 }
 
-fn does_value_match(id: &str, var_value: &VariableValue<'_>, _context: &Context) -> bool {
-    let VariableValue::Value(value) = var_value else {
-        return false;
-    };
-    let (id_type, id_value) = id.split_once(":").unwrap();
-    let expected_value_type = match id_type {
+fn parse_value_type(value_type_string: &str) -> ValueType {
+    match value_type_string {
         "boolean" => ValueType::Boolean,
         "integer" => ValueType::Integer,
         "double" => ValueType::Double,
@@ -460,7 +511,15 @@ fn does_value_match(id: &str, var_value: &VariableValue<'_>, _context: &Context)
         "duration" => ValueType::Duration,
         "string" => ValueType::String,
         _ => todo!("TypeQL test value type is not covered"),
+    }
+}
+
+fn does_value_match(id: &str, var_value: &VariableValue<'_>, _context: &Context) -> bool {
+    let VariableValue::Value(value) = var_value else {
+        return false;
     };
+    let (id_type, id_value) = id.split_once(":").unwrap();
+    let expected_value_type = parse_value_type(id_type);
     let expected = params::Value::from_str(id_value).unwrap().into_typedb(expected_value_type);
     if expected.value_type() == ValueType::Double {
         let precision = id_value.split_once(".").map(|(_, decimal)| decimal.len()).unwrap_or(5) as i32;
@@ -539,7 +598,7 @@ async fn each_answer_satisfies(context: &mut Context, step: &Step) {
     for answer in context.query_answer.as_ref().unwrap().as_rows() {
         let query_string = apply_query_template(templated_query, answer);
         let query = typeql::parse_query(&query_string).unwrap();
-        let answer_size = match execute_read_query(context, query, &query_string) {
+        let answer_size = match execute_read_query(context, query, None, &query_string) {
             Ok(answers) => answers.len(),
             Err(error) => panic!("Unexpected get answers error: {:?}", error),
         };
@@ -578,7 +637,7 @@ async fn verify_answer_set(context: &mut Context, step: &Step) {
     }
     let query_str = step.docstring.as_ref().unwrap().as_str();
     let query = typeql::parse_query(query_str).unwrap();
-    let verify_answers = execute_read_query(context, query, query_str).unwrap();
+    let verify_answers = execute_read_query(context, query, None, query_str).unwrap();
     match (&context.query_answer.as_ref().unwrap(), verify_answers) {
         (QueryAnswer::ConceptRows(actual), QueryAnswer::ConceptRows(expected)) => {
             assert_eq!(
@@ -629,6 +688,15 @@ async fn typeql_analyze_may_error(context: &mut Context, may_error: params::Type
     may_error.check_logic(result);
 }
 
+#[cucumber::then("analyzed query given structure is:")]
+async fn analyzed_query_given_is(context: &mut Context, step: &Step) {
+    let expected_functor = step.docstring().unwrap();
+    let analyzed = context.analyzed.as_ref().unwrap();
+    let actual_functor = encode_pipeline_given_as_functor(&analyzed.query, &analyzed.given.as_ref().unwrap());
+
+    assert_eq!(normalize_functor_for_compare(&actual_functor), normalize_functor_for_compare(&expected_functor));
+}
+
 #[cucumber::then("analyzed query pipeline structure is:")]
 async fn analyzed_query_pipeline_is(context: &mut Context, step: &Step) {
     let expected_functor = step.docstring().unwrap();
@@ -655,6 +723,16 @@ async fn analyzed_query_preamble_contains(context: &mut Context, step: &Step) {
         expected_functor,
         preamble_functors.iter().join("\n\t")
     );
+}
+
+#[cucumber::then("analyzed query given annotations are:")]
+async fn analyzed_query_given_annotations_is(context: &mut Context, step: &Step) {
+    let expected_functor = step.docstring().unwrap();
+    let analyzed = context.analyzed.as_ref().unwrap();
+    let actual_functor =
+        encode_pipeline_given_annotations_as_functor(&analyzed.query, analyzed.given.as_ref().unwrap());
+
+    assert_eq!(normalize_functor_for_compare(&actual_functor), normalize_functor_for_compare(expected_functor));
 }
 
 #[cucumber::then("analyzed query pipeline annotations are:")]
@@ -698,4 +776,56 @@ fn normalize_functor_for_compare(functor: &str) -> String {
     let mut normalized = functor.to_lowercase();
     normalized.retain(|c| !c.is_whitespace());
     normalized
+}
+
+fn parse_query_given_row(row: &[String]) -> Vec<VariableValue<'static>> {
+    row.iter().map(parse_query_given_row_entry).collect()
+}
+
+fn parse_query_given_row_entry(entry: &String) -> VariableValue<'static> {
+    fn hex_to_u64(hex: &str) -> u64 {
+        u64::from_str_radix(hex, 16).expect("Bad hex in iid: {hex}")
+    }
+
+    let mut parts = entry.split(":");
+    match parts.next().unwrap() {
+        "none" => VariableValue::None,
+        "value" => {
+            let value_type_str = parts.next().expect("value:<value-type>:<value>");
+            let value_str = parts.next().expect("value:<value-type>:<value>");
+            let expected_value_type = parse_value_type(value_type_str);
+            let value = params::Value::from_str(value_str).unwrap().into_typedb(expected_value_type);
+            VariableValue::Value(value)
+        }
+        "iid" => {
+            let expected = "Expected iid:<kind>:<typeid-hex>:<instanceid-hex>";
+            let kind = parts.next().unwrap();
+            let type_id = TypeID::new(hex_to_u64(parts.next().expect(expected)) as u16);
+
+            let thing = match kind {
+                "entity" => {
+                    let instance_id = hex_to_u64(parts.next().expect(expected));
+                    Entity::new(ObjectVertex::build_entity(type_id, ObjectID::new(instance_id))).into()
+                }
+                "relation" => {
+                    let instance_id = hex_to_u64(parts.next().expect(expected));
+                    Relation::new(ObjectVertex::build_entity(type_id, ObjectID::new(instance_id))).into()
+                }
+                "attr" => {
+                    debug_assert!(false, "Untested code. Remove this assert and try your luck");
+                    let hex = parts.next().expect(expected);
+                    let hex = hex.replace("_", "");
+                    let bytes = (0..hex.len())
+                        .step_by(2)
+                        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16))
+                        .collect::<Result<Vec<_>, _>>()
+                        .unwrap();
+                    Attribute::new(AttributeVertex::new(type_id, AttributeID::new(&bytes))).into()
+                }
+                other => panic!("Invalid kind: {other}"),
+            };
+            VariableValue::Thing(thing)
+        }
+        other => panic!("Invalid entry type: {other}"),
+    }
 }

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -36,8 +36,11 @@ use futures::StreamExt;
 use itertools::{Either, Itertools};
 use lending_iterator::LendingIterator;
 use macro_rules_attribute::apply;
-use query::{analyse::AnalysedQuery, error::QueryError, given_rows::GivenRowsSimple};
-use query::given_rows::GivenRowEntry;
+use query::{
+    analyse::AnalysedQuery,
+    error::QueryError,
+    given_rows::{GivenRowEntry, GivenRowsSimple},
+};
 use resource::profile::StorageCounters;
 use server::service::http::message::analyze::{
     annotations::bdd::{
@@ -251,9 +254,7 @@ async fn given_rows(context: &mut Context, step: &Step) {
     let width = table.rows.first().unwrap().len() as u32;
     // First row is the variables
     let variables = table.rows[0].clone();
-    let rows = table.rows[1..].iter().map(|row| {
-        row.iter().map(parse_query_given_row_entry).collect()
-    }).collect();
+    let rows = table.rows[1..].iter().map(|row| row.iter().map(parse_query_given_row_entry).collect()).collect();
 
     context.given_rows = Some(GivenRowsSimple { variables, rows })
 }

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -36,7 +36,8 @@ use futures::StreamExt;
 use itertools::{Either, Itertools};
 use lending_iterator::LendingIterator;
 use macro_rules_attribute::apply;
-use query::{analyse::AnalysedQuery, error::QueryError, query_manager::GivenRows};
+use query::{analyse::AnalysedQuery, error::QueryError, given_rows::GivenRowsSimple};
+use query::given_rows::GivenRowEntry;
 use resource::profile::StorageCounters;
 use server::service::http::message::analyze::{
     annotations::bdd::{
@@ -85,7 +86,7 @@ fn row_answers_to_string(rows: &[HashMap<String, VariableValue<'static>>]) -> St
 fn execute_read_query(
     context: &Context,
     query: typeql::Query,
-    given_rows: Option<GivenRows>,
+    given_rows: Option<GivenRowsSimple>,
     source_query: &str,
 ) -> Result<QueryAnswer, Box<QueryError>> {
     with_read_tx!(context, |tx| {
@@ -137,7 +138,7 @@ fn execute_read_query(
 fn execute_write_query(
     context: &mut Context,
     query: typeql::Query,
-    given_rows: Option<GivenRows>,
+    given_rows: Option<GivenRowsSimple>,
     source_query: &str,
 ) -> Result<QueryAnswer, BehaviourTestExecutionError> {
     if matches!(context.active_transaction.as_ref().unwrap(), Read(_)) {
@@ -238,7 +239,7 @@ fn execute_analyze(
     })
 }
 
-fn may_take_given_rows(context: &mut Context, with_given: params::WithGiven) -> Option<GivenRows> {
+fn may_take_given_rows(context: &mut Context, with_given: params::WithGiven) -> Option<GivenRowsSimple> {
     (with_given == params::WithGiven::True).then(|| context.take_given_rows().expect("Expected given rows available"))
 }
 
@@ -248,17 +249,13 @@ async fn given_rows(context: &mut Context, step: &Step) {
     let table = step.table.as_ref().expect("Expected table for given rows");
     let length = table.rows.len();
     let width = table.rows.first().unwrap().len() as u32;
-    let mut given_rows = GivenRows::new(width, length);
-    // Ignore the first row as a documentational header
-    table.rows[1..].iter().for_each(|row| {
-        given_rows.append(|mut into_row| {
-            row.iter().map(parse_query_given_row_entry).enumerate().for_each(|(i, value)| {
-                into_row.set(VariablePosition::new(i as u32), value);
-            });
-        });
-    });
+    // First row is the variables
+    let variables = table.rows[0].clone();
+    let rows = table.rows[1..].iter().map(|row| {
+        row.iter().map(parse_query_given_row_entry).collect()
+    }).collect();
 
-    context.given_rows = Some(given_rows)
+    context.given_rows = Some(GivenRowsSimple { variables, rows })
 }
 
 #[apply(generic_step)]
@@ -343,7 +340,7 @@ async fn typeql_read_query(
     may_error.check_logic(result); // we don't close read transactions with logical errors
 }
 
-fn record_answers_of_typeql_read_query(context: &mut Context, query_str: &str, given_rows: Option<GivenRows>) {
+fn record_answers_of_typeql_read_query(context: &mut Context, query_str: &str, given_rows: Option<GivenRowsSimple>) {
     let query = typeql::parse_query(query_str).unwrap();
     context.query_answer = match execute_read_query(context, query, given_rows, query_str) {
         Ok(answers) => Some(answers),
@@ -778,24 +775,20 @@ fn normalize_functor_for_compare(functor: &str) -> String {
     normalized
 }
 
-fn parse_query_given_row(row: &[String]) -> Vec<VariableValue<'static>> {
-    row.iter().map(parse_query_given_row_entry).collect()
-}
-
-fn parse_query_given_row_entry(entry: &String) -> VariableValue<'static> {
+fn parse_query_given_row_entry(entry: &String) -> GivenRowEntry {
     fn hex_to_u64(hex: &str) -> u64 {
         u64::from_str_radix(hex, 16).expect("Bad hex in iid: {hex}")
     }
 
     let mut parts = entry.split(":");
     match parts.next().unwrap() {
-        "none" => VariableValue::None,
+        "none" => GivenRowEntry::None,
         "value" => {
             let value_type_str = parts.next().expect("value:<value-type>:<value>");
             let value_str = parts.next().expect("value:<value-type>:<value>");
             let expected_value_type = parse_value_type(value_type_str);
             let value = params::Value::from_str(value_str).unwrap().into_typedb(expected_value_type);
-            VariableValue::Value(value)
+            GivenRowEntry::Value(value)
         }
         "iid" => {
             let expected = "Expected iid:<kind>:<typeid-hex>:<instanceid-hex>";
@@ -824,7 +817,7 @@ fn parse_query_given_row_entry(entry: &String) -> VariableValue<'static> {
                 }
                 other => panic!("Invalid kind: {other}"),
             };
-            VariableValue::Thing(thing)
+            GivenRowEntry::Thing(thing)
         }
         other => panic!("Invalid entry type: {other}"),
     }

--- a/tests/benchmarks/concurrent_ops/BUILD
+++ b/tests/benchmarks/concurrent_ops/BUILD
@@ -13,6 +13,7 @@ rust_test(
         "//database",
         "//diagnostics",
         "//executor",
+        "//query",
         "//storage",
 
         "//util/test:test_utils",

--- a/tests/benchmarks/concurrent_ops/bench_concurrency.rs
+++ b/tests/benchmarks/concurrent_ops/bench_concurrency.rs
@@ -26,6 +26,7 @@ use database::{
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 use executor::{ExecutionInterrupt, pipeline::stage::StageIterator};
 use options::{QueryOptions, TransactionOptions};
+use query::given_rows::GivenRowsSimple;
 use rand_core::RngCore;
 use storage::durability_client::WALClient;
 use test_utils::{TempDir, create_tmp_storage_dir};
@@ -169,7 +170,7 @@ fn seed_persons(database: &Arc<Database<WALClient>>, count: usize) {
                 tx,
                 QueryOptions::default_grpc(),
                 pipeline,
-                None,
+                None::<GivenRowsSimple>,
                 query_str,
                 ExecutionInterrupt::new_uninterruptible(),
             );
@@ -204,7 +205,7 @@ fn execute_insert_batch(
             tx,
             QueryOptions::default_grpc(),
             pipeline,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
             ExecutionInterrupt::new_uninterruptible(),
         );
@@ -241,7 +242,7 @@ fn execute_update_batch(
             tx,
             QueryOptions::default_grpc(),
             pipeline,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
             ExecutionInterrupt::new_uninterruptible(),
         );
@@ -280,7 +281,7 @@ fn execute_relation_batch(
             tx,
             QueryOptions::default_grpc(),
             pipeline,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
             ExecutionInterrupt::new_uninterruptible(),
         );
@@ -309,7 +310,7 @@ fn execute_read_query(database: &Arc<Database<WALClient>>, query_str: &str) {
             thing_manager.clone(),
             function_manager,
             &query,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
         )
         .unwrap();

--- a/tests/benchmarks/concurrent_ops/bench_concurrency.rs
+++ b/tests/benchmarks/concurrent_ops/bench_concurrency.rs
@@ -169,6 +169,7 @@ fn seed_persons(database: &Arc<Database<WALClient>>, count: usize) {
                 tx,
                 QueryOptions::default_grpc(),
                 pipeline,
+                None,
                 query_str,
                 ExecutionInterrupt::new_uninterruptible(),
             );
@@ -203,6 +204,7 @@ fn execute_insert_batch(
             tx,
             QueryOptions::default_grpc(),
             pipeline,
+            None,
             query_str,
             ExecutionInterrupt::new_uninterruptible(),
         );
@@ -239,6 +241,7 @@ fn execute_update_batch(
             tx,
             QueryOptions::default_grpc(),
             pipeline,
+            None,
             query_str,
             ExecutionInterrupt::new_uninterruptible(),
         );
@@ -277,6 +280,7 @@ fn execute_relation_batch(
             tx,
             QueryOptions::default_grpc(),
             pipeline,
+            None,
             query_str,
             ExecutionInterrupt::new_uninterruptible(),
         );
@@ -305,6 +309,7 @@ fn execute_read_query(database: &Arc<Database<WALClient>>, query_str: &str) {
             thing_manager.clone(),
             function_manager,
             &query,
+            None,
             query_str,
         )
         .unwrap();

--- a/tests/benchmarks/iam/bench_iam.rs
+++ b/tests/benchmarks/iam/bench_iam.rs
@@ -14,6 +14,7 @@ use database::{
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 use executor::{ExecutionInterrupt, batch::Batch, pipeline::stage::StageIterator};
 use options::TransactionOptions;
+use query::given_rows::GivenRowsSimple;
 use storage::durability_client::WALClient;
 use test_utils::create_tmp_storage_dir;
 
@@ -90,7 +91,7 @@ fn load_data_tql(database: Arc<Database<WALClient>>, data_tql: &Path) {
             thing_manager.clone(),
             &function_manager,
             &data_query,
-            None,
+            None::<GivenRowsSimple>,
             &data_str,
         )
         .unwrap();
@@ -140,7 +141,7 @@ fn run_query(database: Arc<Database<WALClient>>, query_str: &str) -> Batch {
             thing_manager.clone(),
             function_manager,
             &query,
-            None,
+            None::<GivenRowsSimple>,
             query_str,
         )
         .unwrap();

--- a/tests/benchmarks/iam/bench_iam.rs
+++ b/tests/benchmarks/iam/bench_iam.rs
@@ -90,6 +90,7 @@ fn load_data_tql(database: Arc<Database<WALClient>>, data_tql: &Path) {
             thing_manager.clone(),
             &function_manager,
             &data_query,
+            None,
             &data_str,
         )
         .unwrap();
@@ -139,6 +140,7 @@ fn run_query(database: Arc<Database<WALClient>>, query_str: &str) -> Batch {
             thing_manager.clone(),
             function_manager,
             &query,
+            None,
             query_str,
         )
         .unwrap();


### PR DESCRIPTION
## Product change and motivation
Introduces the TypeQL `given` stage which allows `rows" to be passed to a query as input. By running the same pipeline for multiple rows of input data (~~SIMD~~ SQMD?) in a single query, it avoids the network and query-compilation overhead that running multiple queries  (or just the query-compilation overhead in case of one large query). Since given rows are separate from the TypeQL query string, using to get input parameters into queries is safe from TypeQL-injection (c.f. working them into the TypeQL query string).

**Examples:** 
```
# Insert a new `person`s  with name =`$n` for each row given.
given $n: string;
insert $p isa person, has name == $n;
```

```
# Get the name for each person `$p` in the given rows.
given $p: person;
match $p has name $n;
```

For examples on how to construct the given rows in the GRPC drivers, Please check that driver's README on [github](https://github.com/typedb/typedb-driver)

## Implementation
* Protocol & HTTP query requests have GivenRows.
* These are decoded into a batch by the QueryManager, via a trait `GivenRows`. 
* A `GivenStage` type-checks the input row (and optionality checks too)

