### PR TITLE
Remove default advertised address

### DIFF
--- a/admin/client/commands/server.rs
+++ b/admin/client/commands/server.rs
@@ -51,16 +51,20 @@ async fn server_status(client: &mut AdminClient) -> CommandResult {
 
     if let Some(grpc) = &res.grpc {
         print!("  gRPC:  {}", grpc.listen_address);
-        if grpc.advertise_address != grpc.listen_address {
-            print!(" (connect via {})", grpc.advertise_address);
+        if let Some(advertise_address) = &grpc.advertise_address {
+            if advertise_address != &grpc.listen_address {
+                print!(" (connect via {})", advertise_address);
+            }
         }
         println!();
     }
 
     if let Some(http) = &res.http {
         print!("  HTTP:  {}", http.listen_address);
-        if http.advertise_address != http.listen_address {
-            print!(" (connect via {})", http.advertise_address);
+        if let Some(advertise_address) = &http.advertise_address {
+            if advertise_address != &http.listen_address {
+                print!(" (connect via {})", advertise_address);
+            }
         }
         println!();
     }

--- a/server/lib.rs
+++ b/server/lib.rs
@@ -437,11 +437,11 @@ impl Server {
         println!("Serving:");
 
         let grpc_listen_address = server_status.grpc_listen_address().unwrap_or(UNKNOWN);
-        let grpc_advertise_address = server_status.grpc_advertise_address().unwrap_or(UNKNOWN);
-        if grpc_advertise_address != grpc_listen_address {
-            println!("  gRPC:  {grpc_listen_address} (connect via {grpc_advertise_address})");
-        } else {
-            println!("  gRPC:  {grpc_listen_address}");
+        match server_status.grpc_advertise_address() {
+            Some(grpc_advertise_address) if grpc_advertise_address != grpc_listen_address => {
+                println!("  gRPC:  {grpc_listen_address} (connect via {grpc_advertise_address})");
+            }
+            _ => println!("  gRPC:  {grpc_listen_address}"),
         }
 
         if let Some(http_listen_address) = server_status.http_listen_address() {

--- a/server/service/admin/admin_service.rs
+++ b/server/service/admin/admin_service.rs
@@ -46,20 +46,13 @@ impl admin_proto::type_db_admin_server::TypeDbAdmin for AdminService {
 
         let grpc = admin_proto::EndpointStatus {
             listen_address: status.grpc_listen_address().unwrap_or_default().to_string(),
-            advertise_address: status.grpc_advertise_address().unwrap_or_default().to_string(),
+            advertise_address: status.grpc_advertise_address().map(str::to_string),
         };
 
-        let http = match (status.http_listen_address(), status.http_advertise_address()) {
-            (Some(listen), Some(advertise)) => Some(admin_proto::EndpointStatus {
-                listen_address: listen.to_string(),
-                advertise_address: advertise.to_string(),
-            }),
-            (Some(listen), None) => Some(admin_proto::EndpointStatus {
-                listen_address: listen.to_string(),
-                advertise_address: listen.to_string(),
-            }),
-            _ => None,
-        };
+        let http = status.http_listen_address().map(|listen| admin_proto::EndpointStatus {
+            listen_address: listen.to_string(),
+            advertise_address: status.http_advertise_address().map(str::to_string),
+        });
 
         let admin_address = status.admin_address().map(|a| a.to_string());
 

--- a/server/service/admin/admin_service_test.rs
+++ b/server/service/admin/admin_service_test.rs
@@ -15,7 +15,8 @@ use server::{
 use test_utils::{TempDir, create_tmp_storage_dir};
 use tokio::sync::OnceCell;
 
-const GRPC_ADDRESS: &str = "127.0.0.1:11729";
+const GRPC_ADDRESS: &str = "0.0.0.0:11729";
+const GRPC_ADVERTISE_ADDRESS: &str = "127.0.0.1:11729";
 const ADMIN_PORT: u16 = 11728;
 const DISTRIBUTION_INFO: DistributionInfo =
     DistributionInfo { logo: "logo", distribution: "TypeDB CE TEST", version: "0.0.0-test" };
@@ -34,6 +35,7 @@ async fn ensure_server_started() {
             let config = ConfigBuilder::from_file(config_path())
                 .expect("Failed to load config file")
                 .server_listen_address(GRPC_ADDRESS)
+                .server_advertise_address(GRPC_ADVERTISE_ADDRESS)
                 .server_http_enabled(false)
                 .admin_port(ADMIN_PORT)
                 .admin_enabled(true)
@@ -91,7 +93,8 @@ async fn admin_server_status() {
 
     let grpc = res.grpc.expect("gRPC endpoint status should be present");
     assert!(!grpc.listen_address.is_empty(), "gRPC listen address should not be empty");
-    assert!(!grpc.advertise_address.is_empty(), "gRPC advertise address should not be empty");
+    assert!(grpc.advertise_address.is_some(), "gRPC advertise address should be some");
+    assert!(!grpc.advertise_address.unwrap().is_empty(), "gRPC advertise address should not be empty");
 
     assert!(res.http.is_none(), "HTTP should be disabled in test config");
 

--- a/server/service/admin/proto/admin_service.proto
+++ b/server/service/admin/proto/admin_service.proto
@@ -29,5 +29,5 @@ message ServerStatus {
 
 message EndpointStatus {
     string listen_address = 1;
-    string advertise_address = 2;
+    optional string advertise_address = 2;
 }

--- a/server/state/mod.rs
+++ b/server/state/mod.rs
@@ -9,12 +9,7 @@ pub mod server_operator;
 pub mod transaction_operator;
 pub mod user_operator;
 
-use std::{
-    collections::HashSet,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
-    path::PathBuf,
-    sync::Arc,
-};
+use std::{collections::HashSet, net::SocketAddr, path::PathBuf, sync::Arc};
 
 use concurrency::{IntervalRunner, TokioTaskSpawner};
 use database::database_manager::DatabaseManager;
@@ -224,28 +219,15 @@ impl ServerState {
             .ok_or_else(|| ServerOpenError::AddressResolutionEmpty { address: address.to_string() })
     }
 
-    fn default_advertise_address(listen: SocketAddr) -> String {
-        if listen.ip().is_unspecified() {
-            let loopback =
-                if listen.is_ipv4() { IpAddr::V4(Ipv4Addr::LOCALHOST) } else { IpAddr::V6(Ipv6Addr::LOCALHOST) };
-            SocketAddr::new(loopback, listen.port()).to_string()
-        } else {
-            listen.to_string()
-        }
-    }
-
     async fn resolve_endpoints(
         config: &crate::parameters::config::ServerConfig,
     ) -> Result<(SocketAddr, Option<SocketAddr>, LocalServerStatus), ServerOpenError> {
         let grpc_listen_address = Self::resolve_address(&config.listen_address).await?;
-        let grpc_advertise_address =
-            config.advertise_address.clone().unwrap_or_else(|| Self::default_advertise_address(grpc_listen_address));
+        let grpc_advertise_address = config.advertise_address.clone();
 
         let http_listen_address =
             if config.http.enabled { Some(Self::resolve_address(&config.http.listen_address).await?) } else { None };
-        let http_advertise_address = http_listen_address.map(|listen| {
-            config.http.advertise_address.clone().unwrap_or_else(|| Self::default_advertise_address(listen))
-        });
+        let http_advertise_address = config.http.advertise_address.clone();
 
         let admin_address = if config.admin.enabled {
             Some(SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, config.admin.port)))
@@ -267,9 +249,7 @@ impl ServerState {
 
         let server_status = LocalServerStatus::new(
             PublicEndpointAddress::from_socket_addr(grpc_listen_address, grpc_advertise_address),
-            http_listen_address
-                .zip(http_advertise_address)
-                .map(|(serv, conn)| PublicEndpointAddress::from_socket_addr(serv, conn)),
+            http_listen_address.map(|listen| PublicEndpointAddress::from_socket_addr(listen, http_advertise_address)),
             admin_address.map(PrivateEndpointAddress::from_socket_addr),
         );
 
@@ -365,34 +345,5 @@ impl ServerStateBuilder {
             transaction_operator,
             user_operator,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::net::SocketAddr;
-
-    use super::ServerState;
-
-    fn default_advertise_address(input: &str) -> String {
-        ServerState::default_advertise_address(input.parse::<SocketAddr>().unwrap())
-    }
-
-    #[test]
-    fn ipv4_wildcard_resolves_to_loopback() {
-        assert_eq!(default_advertise_address("0.0.0.0:1729"), "127.0.0.1:1729");
-        assert_eq!(default_advertise_address("0.0.0.0:8000"), "127.0.0.1:8000");
-    }
-
-    #[test]
-    fn ipv6_wildcard_resolves_to_loopback() {
-        assert_eq!(default_advertise_address("[::]:1729"), "[::1]:1729");
-    }
-
-    #[test]
-    fn explicit_listen_address_is_kept_as_is() {
-        assert_eq!(default_advertise_address("127.0.0.1:1729"), "127.0.0.1:1729");
-        assert_eq!(default_advertise_address("192.168.1.10:1729"), "192.168.1.10:1729");
-        assert_eq!(default_advertise_address("[2001:db8::1]:1729"), "[2001:db8::1]:1729");
     }
 }

--- a/server/status.rs
+++ b/server/status.rs
@@ -12,17 +12,17 @@ use crate::service::http::message::server::{BoxHttpServerResponse, LocalServerRe
 #[derive(Clone, Debug)]
 pub struct PublicEndpointAddress {
     listen_address: String,
-    advertise_address: String,
+    advertise_address: Option<String>,
 }
 
 impl PublicEndpointAddress {
-    pub fn new(listen_address: String, advertise_address: String) -> Self {
+    pub fn new(listen_address: String, advertise_address: Option<String>) -> Self {
         Self { listen_address, advertise_address }
     }
 
     pub fn from_socket_addr(
         listen_address: SocketAddr,
-        advertise_address: String, // reference info (can be an alias), do not resolve!
+        advertise_address: Option<String>, // reference info (can be an alias), do not resolve!
     ) -> Self {
         Self::new(listen_address.to_string(), advertise_address)
     }
@@ -31,8 +31,8 @@ impl PublicEndpointAddress {
         &self.listen_address
     }
 
-    pub fn advertise_address(&self) -> &str {
-        &self.advertise_address
+    pub fn advertise_address(&self) -> Option<&str> {
+        self.advertise_address.as_deref()
     }
 }
 
@@ -90,19 +90,21 @@ pub trait ServerStatus: Debug {
 
 impl ServerStatus for LocalServerStatus {
     fn to_proto(&self) -> typedb_protocol::Server {
-        typedb_protocol::Server { address: Some(self.grpc.advertise_address().to_string()), replication_status: None }
+        typedb_protocol::Server { address: self.grpc.advertise_address().map(str::to_string), replication_status: None }
     }
 
     fn to_http(&self) -> BoxHttpServerResponse {
-        Box::new(LocalServerResponse { address: self.http.as_ref().map(|http| http.advertise_address().to_string()) })
+        Box::new(LocalServerResponse {
+            address: self.http.as_ref().and_then(|http| http.advertise_address()).map(str::to_string),
+        })
     }
 
     fn grpc_listen_address(&self) -> Option<&str> {
-        Some(&self.grpc.listen_address())
+        Some(self.grpc.listen_address())
     }
 
     fn grpc_advertise_address(&self) -> Option<&str> {
-        Some(&self.grpc.advertise_address())
+        self.grpc.advertise_address()
     }
 
     fn http_listen_address(&self) -> Option<&str> {
@@ -110,7 +112,7 @@ impl ServerStatus for LocalServerStatus {
     }
 
     fn http_advertise_address(&self) -> Option<&str> {
-        self.http.as_ref().map(|http| http.advertise_address())
+        self.http.as_ref().and_then(|http| http.advertise_address())
     }
 
     fn admin_address(&self) -> Option<&str> {


### PR DESCRIPTION
## Product change and motivation

Return empty advertised server address (both grpc and http) in case it's not specified instead of using a default value.

This change lets the clients to understand when the server does not enforce any address for connections and make independent decisions. It is especially important in cases of connecting to a docker container or a proxy, when the server used to return a not accessible address, which the client eagerly used and failed to connect regardless of the correctness of the connection address provided by the user.

## Implementation

Make `advertise_address` state fields optional. Support it in public protocols (grpc, http -- the protocols already expected an `Option`) and the admin tool (changed the protocol -- is fine for an early tool which is usually bundled with the needed server...)