### PR TITLE
Support redirects in any HTTP error

### DIFF
--- a/server/service/http/error.rs
+++ b/server/service/http/error.rs
@@ -50,4 +50,14 @@ impl HttpServiceError {
     pub(crate) fn transaction_timeout() -> Self {
         Self::Transaction { typedb_source: TransactionServiceError::TransactionTimeout {} }
     }
+
+    pub(crate) fn to_service_error(&self) -> Option<&ArcServerStateError> {
+        match self {
+            HttpServiceError::State { typedb_source } => Some(typedb_source),
+            HttpServiceError::Transaction { typedb_source }
+            | HttpServiceError::QueryClose { typedb_source }
+            | HttpServiceError::QueryCommit { typedb_source } => typedb_source.to_service_error(),
+            _ => None,
+        }
+    }
 }

--- a/server/service/http/error.rs
+++ b/server/service/http/error.rs
@@ -57,7 +57,15 @@ impl HttpServiceError {
             HttpServiceError::Transaction { typedb_source }
             | HttpServiceError::QueryClose { typedb_source }
             | HttpServiceError::QueryCommit { typedb_source } => typedb_source.to_service_error(),
-            _ => None,
+
+            HttpServiceError::Internal { .. }
+            | HttpServiceError::JsonBodyExpected { .. }
+            | HttpServiceError::RequestTimeout { .. }
+            | HttpServiceError::NotFound { .. }
+            | HttpServiceError::UnknownVersion { .. }
+            | HttpServiceError::MissingPathParameter { .. }
+            | HttpServiceError::InvalidPathParameter { .. }
+            | HttpServiceError::Authentication { .. } => None,
         }
     }
 }

--- a/server/service/http/message/error.rs
+++ b/server/service/http/message/error.rs
@@ -102,19 +102,7 @@ impl IntoResponse for HttpServiceError {
 }
 
 fn find_redirect_outcome(error: &HttpServiceError) -> Option<RedirectOutcome> {
-    let state_err = match error {
-        HttpServiceError::State { typedb_source } => typedb_source,
-        HttpServiceError::Transaction { typedb_source }
-        | HttpServiceError::QueryClose { typedb_source }
-        | HttpServiceError::QueryCommit { typedb_source } => match typedb_source {
-            TransactionServiceError::CannotOpen { typedb_source }
-            | TransactionServiceError::DataCommitFailed { typedb_source }
-            | TransactionServiceError::SchemaCommitFailed { typedb_source } => typedb_source,
-            _ => return None,
-        },
-        _ => return None,
-    };
-    match state_err.error_response_category() {
+    match error.to_service_error()?.error_response_category() {
         ErrorResponseCategory::Redirect { http_address: Some(addr), .. } => Some(RedirectOutcome::Misdirected(addr)),
         ErrorResponseCategory::Redirect { .. } => Some(RedirectOutcome::Unavailable),
         _ => None,

--- a/server/service/http/message/error.rs
+++ b/server/service/http/message/error.rs
@@ -16,6 +16,11 @@ use crate::{
     },
 };
 
+enum RedirectOutcome {
+    Misdirected(String),
+    Unavailable,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ErrorResponse {
@@ -35,6 +40,17 @@ pub struct MisdirectedResponse {
 
 impl IntoResponse for HttpServiceError {
     fn into_response(self) -> Response {
+        if let Some(outcome) = find_redirect_outcome(&self) {
+            return match outcome {
+                RedirectOutcome::Misdirected(primary_address) => (
+                    StatusCode::MISDIRECTED_REQUEST,
+                    JsonBody(MisdirectedResponse { error: encode_error(self), primary_address }),
+                )
+                    .into_response(),
+                RedirectOutcome::Unavailable => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+            };
+        }
+
         let code = match &self {
             HttpServiceError::Internal { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             HttpServiceError::JsonBodyExpected { .. } => StatusCode::BAD_REQUEST,
@@ -49,16 +65,8 @@ impl IntoResponse for HttpServiceError {
                 ErrorResponseCategory::Forbidden => StatusCode::FORBIDDEN,
                 ErrorResponseCategory::NotImplemented => StatusCode::NOT_IMPLEMENTED,
                 ErrorResponseCategory::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-                ErrorResponseCategory::Redirect { http_address, .. } => match http_address {
-                    Some(primary_address) => {
-                        return (
-                            StatusCode::MISDIRECTED_REQUEST,
-                            JsonBody(MisdirectedResponse { error: encode_error(self), primary_address }),
-                        )
-                            .into_response();
-                    }
-                    None => StatusCode::SERVICE_UNAVAILABLE,
-                },
+                // Redirect is handled by `find_redirect_state` above.
+                ErrorResponseCategory::Redirect { .. } => StatusCode::SERVICE_UNAVAILABLE,
                 ErrorResponseCategory::InvalidRequest => StatusCode::BAD_REQUEST,
                 ErrorResponseCategory::Internal => StatusCode::INTERNAL_SERVER_ERROR,
             },
@@ -90,6 +98,26 @@ impl IntoResponse for HttpServiceError {
             HttpServiceError::QueryCommit { .. } => StatusCode::BAD_REQUEST,
         };
         (code, JsonBody(encode_error(self))).into_response()
+    }
+}
+
+fn find_redirect_outcome(error: &HttpServiceError) -> Option<RedirectOutcome> {
+    let state_err = match error {
+        HttpServiceError::State { typedb_source } => typedb_source,
+        HttpServiceError::Transaction { typedb_source }
+        | HttpServiceError::QueryClose { typedb_source }
+        | HttpServiceError::QueryCommit { typedb_source } => match typedb_source {
+            TransactionServiceError::CannotOpen { typedb_source }
+            | TransactionServiceError::DataCommitFailed { typedb_source }
+            | TransactionServiceError::SchemaCommitFailed { typedb_source } => typedb_source,
+            _ => return None,
+        },
+        _ => return None,
+    };
+    match state_err.error_response_category() {
+        ErrorResponseCategory::Redirect { http_address: Some(addr), .. } => Some(RedirectOutcome::Misdirected(addr)),
+        ErrorResponseCategory::Redirect { .. } => Some(RedirectOutcome::Unavailable),
+        _ => None,
     }
 }
 

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -124,3 +124,32 @@ typedb_error! {
         CannotOpen(21, "Could not open transaction.", typedb_source: ArcServerStateError),
     }
 }
+
+impl TransactionServiceError {
+    pub fn to_service_error(&self) -> Option<&ArcServerStateError> {
+        match self {
+            TransactionServiceError::DatabaseNotFound { .. }
+            | TransactionServiceError::CannotCommitReadTransaction { .. }
+            | TransactionServiceError::CannotRollbackReadTransaction { .. }
+            | TransactionServiceError::TransactionFailed { .. }
+            | TransactionServiceError::QueryParseFailed { .. }
+            | TransactionServiceError::SchemaQueryRequiresSchemaTransaction { .. }
+            | TransactionServiceError::WriteQueryRequiresSchemaOrWriteTransaction { .. }
+            | TransactionServiceError::SchemaQueryFailedAbortingTransaction { .. }
+            | TransactionServiceError::QueryFailed { .. }
+            | TransactionServiceError::NoOpenTransaction { .. }
+            | TransactionServiceError::QueryInterrupted { .. }
+            | TransactionServiceError::QueryStreamNotFound { .. }
+            | TransactionServiceError::QueueCleanupFailed { .. }
+            | TransactionServiceError::PipelineExecution { .. }
+            | TransactionServiceError::TransactionTimeout { .. }
+            | TransactionServiceError::InvalidPrefetchSize { .. }
+            | TransactionServiceError::AnalyseQueryExpectsPipeline { .. }
+            | TransactionServiceError::AnalyseQueryFailed { .. } => None,
+
+            TransactionServiceError::DataCommitFailed { typedb_source }
+            | TransactionServiceError::SchemaCommitFailed { typedb_source }
+            | TransactionServiceError::CannotOpen { typedb_source } => Some(typedb_source),
+        }
+    }
+}


### PR DESCRIPTION
## Product change and motivation

Expand the set of service errors that can return `421 Misdirected Request`, including transaction errors (e.g., on attempts to run write operations against a non-primary replica). This replicates the behavior of gRPC errors.

Before, some `TransactionServiceError`s could contain the redirection errors, but they would be ignored because these categories of errors were not covered with the right conversion logic.

## Implementation

Handle any case of a `Redirect` `error_response_category` in the `HttpErrorResponse` conversion logic. 