### PR TITLE
Skip rebuilding behaviour test binaries in main CI build

### DIFF
--- a/tests/behaviour/concept/BUILD
+++ b/tests/behaviour/concept/BUILD
@@ -32,6 +32,7 @@ rust_test(
     ],
     crate_features = ["bazel"],
     size = "enormous",
+    tags = ["manual"],
 )
 
 rustfmt_test(

--- a/tests/behaviour/connection/BUILD
+++ b/tests/behaviour/connection/BUILD
@@ -19,6 +19,7 @@ rust_test(
         "@typedb_behaviour//connection:transaction.feature"
     ],
     crate_features = ["bazel"],
+    tags = ["manual"],
 )
 
 rustfmt_test(

--- a/tests/behaviour/debug/BUILD
+++ b/tests/behaviour/debug/BUILD
@@ -14,6 +14,7 @@ rust_test(
         "@crates//:tokio",
     ],
     data = ["debug.feature"],
+    tags = ["manual"],
 )
 
 rustfmt_test(

--- a/tests/behaviour/query/BUILD
+++ b/tests/behaviour/query/BUILD
@@ -48,6 +48,7 @@ rust_test(
     crate_features = ["bazel"],
     env = {"RUST_MIN_STACK" : "40960000"}, # for recursion.feature
     size = "enormous",
+    tags = ["manual"],
 )
 
 rustfmt_test(

--- a/tests/behaviour/service/http/driver/BUILD
+++ b/tests/behaviour/service/http/driver/BUILD
@@ -15,6 +15,7 @@ rust_test(
     ],
     data = ["@typedb_behaviour//driver:concept.feature"],
     crate_features = ["bazel"],
+    tags = ["manual"],
 )
 
 rust_test(
@@ -27,6 +28,7 @@ rust_test(
     ],
     data = ["@typedb_behaviour//driver:connection.feature"],
     crate_features = ["bazel"],
+    tags = ["manual"],
 )
 
 rust_test(
@@ -39,6 +41,7 @@ rust_test(
     ],
     data = ["@typedb_behaviour//driver/http:http.feature"],
     crate_features = ["bazel"],
+    tags = ["manual"],
 )
 
 rust_test(
@@ -51,6 +54,7 @@ rust_test(
     ],
     data = ["@typedb_behaviour//driver:query.feature"],
     crate_features = ["bazel"],
+    tags = ["manual"],
 )
 
 rust_test(
@@ -63,6 +67,7 @@ rust_test(
     ],
     data = ["@typedb_behaviour//driver:user.feature"],
     crate_features = ["bazel"],
+    tags = ["manual"],
 )
 
 rustfmt_test(


### PR DESCRIPTION
## Product change and motivation
Skip rebuilding in main CI build to make it shorter

## Implementation
Tag all BDD `rust_test` targets as manual,  because they never change, we'd notice immediately and it makes the `build //...` slow.