### PR TITLE
Optimize schema commit with in-memory preloaded snapshot

### DIFF
--- a/admin/tests/admin_assembly.rs
+++ b/admin/tests/admin_assembly.rs
@@ -15,9 +15,8 @@
 
 use std::{
     env,
-    io::Write,
     path::PathBuf,
-    process::{Child, Command, Stdio},
+    process::{Child, Command},
     sync::OnceLock,
     thread,
     time::Duration,

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -22,7 +22,7 @@ use ir::{
 use itertools::Itertools;
 
 use crate::{
-    ExecutorVariable, VariablePosition,
+    VariablePosition,
     annotation::{
         fetch::{AnnotatedFetch, AnnotatedFetchObject, AnnotatedFetchSome},
         function::{AnnotatedPreambleFunctions, AnnotatedSchemaFunctions, FunctionParameterAnnotation},
@@ -34,7 +34,7 @@ use crate::{
         fetch::executable::{ExecutableFetch, compile_fetch},
         function::{ExecutableFunctionRegistry, FunctionCallCostProvider, executable::compile_functions},
         insert::{self, executable::InsertExecutable},
-        match_::{instructions::CheckInstruction, planner::conjunction_executable::ConjunctionExecutable},
+        match_::planner::conjunction_executable::ConjunctionExecutable,
         modifiers::{
             DistinctExecutable, LimitExecutable, OffsetExecutable, RequireExecutable, SelectExecutable, SortExecutable,
         },

--- a/concept/error.rs
+++ b/concept/error.rs
@@ -9,11 +9,10 @@ use std::{fmt, sync::Arc};
 use bytes::util::HexBytesFormatter;
 use encoding::{
     error::EncodingError,
-    graph::type_::Kind,
     value::{label::Label, value_type::ValueType},
 };
 use error::typedb_error;
-use storage::snapshot::{SnapshotGetError, iterator::SnapshotIteratorError};
+use storage::snapshot::{SnapshotError, SnapshotGetError, iterator::SnapshotIteratorError};
 
 use crate::{
     thing::thing_manager::validation::DataValidationError,
@@ -89,6 +88,7 @@ typedb_error! {
         Format(26, "Formatting error.", source: fmt::Error),
         IidRepresentsWrongInstanceKind(27, "Could not read a concept of the expected kind by IID."),
         FunctionNotFound(28, "Function named '{function_name}' not found.", function_name: String),
+        LoadSchemaSnapshot(29, "Failed to load schema keyspace into cached read snapshot.", typedb_source: SnapshotError),
     }
 }
 

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use encoding::{
+    EncodingKeyspace,
     error::EncodingError,
     graph::{
         definition::{
@@ -18,6 +19,7 @@ use encoding::{
         },
         type_::{Kind, vertex::TypeVertexEncoding, vertex_generator::TypeVertexGenerator},
     },
+    layout::prefix::Prefix,
     value::{label::Label, value_type::ValueType},
 };
 use itertools::Itertools;
@@ -26,7 +28,11 @@ use resource::{
     constants::{concept::RELATION_INDEX_THRESHOLD, encoding::StructFieldIDUInt},
     profile::StorageCounters,
 };
-use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
+use storage::{
+    durability_client::DurabilityClient,
+    keyspace::KeyspaceSet,
+    snapshot::{PreloadedRangesSnapshot, ReadableSnapshot, WritableSnapshot, iterator::SnapshotIteratorError},
+};
 use type_cache::TypeCache;
 use type_writer::TypeWriter;
 use validation::{commit_time_validation::CommitTimeValidation, operation_time_validation::OperationTimeValidation};
@@ -378,6 +384,15 @@ macro_rules! get_type_capability_filtered_constraints_methods {
             }
         )*
     }
+}
+
+pub(crate) fn preload_schema_from(
+    snapshot: &impl ReadableSnapshot,
+) -> Result<PreloadedRangesSnapshot, Arc<SnapshotIteratorError>> {
+    PreloadedRangesSnapshot::load_from(
+        snapshot,
+        vec![(EncodingKeyspace::DefaultOptimisedPrefix11.id(), Prefix::schema_byte_ranges())],
+    )
 }
 
 impl TypeManager {

--- a/concept/type_/type_manager/type_cache/type_cache.rs
+++ b/concept/type_/type_manager/type_cache/type_cache.rs
@@ -14,7 +14,10 @@ use encoding::{
     value::{label::Label, value_type::ValueType},
 };
 use error::typedb_error;
-use storage::{MVCCStorage, sequence_number::SequenceNumber};
+use storage::{
+    MVCCStorage, durability_client::DurabilityClient, keyspace::KeyspaceSet, sequence_number::SequenceNumber,
+    snapshot::iterator::SnapshotIteratorError,
+};
 
 use crate::type_::{
     Independent, KindAPI, Ordering, OwnerAPI, PlayerAPI,
@@ -28,13 +31,16 @@ use crate::type_::{
     relation_type::RelationType,
     role_type::RoleType,
     sub::{Sub, SubAnnotation},
-    type_manager::type_cache::{
-        kind_cache::{
-            AttributeTypeCache, CommonTypeCache, EntityTypeCache, ObjectCache, OwnsCache, PlaysCache, RelatesCache,
-            RelationTypeCache, RoleTypeCache,
+    type_manager::{
+        preload_schema_from,
+        type_cache::{
+            kind_cache::{
+                AttributeTypeCache, CommonTypeCache, EntityTypeCache, ObjectCache, OwnsCache, PlaysCache, RelatesCache,
+                RelationTypeCache, RoleTypeCache,
+            },
+            selection::{self, CacheGetter, HasCommonTypeCache, HasObjectCache},
+            struct_definition_cache::StructDefinitionCache,
         },
-        selection::{self, CacheGetter, HasCommonTypeCache, HasObjectCache},
-        struct_definition_cache::StructDefinitionCache,
     },
 };
 
@@ -81,16 +87,15 @@ selection::impl_has_object_cache!(EntityTypeCache, EntityType);
 selection::impl_has_object_cache!(RelationTypeCache, RelationType);
 
 impl TypeCache {
-    // If creation becomes slow, We should restore pre-fetching of the schema
-    //  with a single pass on disk (as it was in 1f339733feaf4542e47ff604462f107d2ade1f1a)
     pub fn new<D>(
         storage: Arc<MVCCStorage<D>>,
         open_sequence_number: SequenceNumber,
-    ) -> Result<Self, TypeCacheCreateError> {
-        // note: since we will parse out many heterogenous properties/edges from the schema, we will scan once into a vector,
-        //       then go through it again to pull out the type information.
-
-        let snapshot = storage.open_snapshot_read_at(open_sequence_number);
+    ) -> Result<Self, TypeCacheCreateError>
+    where
+        D: DurabilityClient,
+    {
+        let snapshot = preload_schema_from(&storage.clone().open_snapshot_read_at(open_sequence_number))
+            .map_err(|source| TypeCacheCreateError::SnapshotIterate { source })?;
 
         let entity_type_caches = EntityTypeCache::create(&snapshot);
         let relation_type_caches = RelationTypeCache::create(&snapshot);
@@ -524,5 +529,6 @@ impl TypeCache {
 typedb_error! {
     pub TypeCacheCreateError(component = "TypeCache create", prefix = "TCC") {
         Empty(1, ""),
+        SnapshotIterate(2, "Failed to load schema keyspace into the type cache.", source: Arc<SnapshotIteratorError>),
     }
 }

--- a/concept/type_/type_manager/validation/commit_time_validation.rs
+++ b/concept/type_/type_manager/validation/commit_time_validation.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 
 use encoding::graph::definition::r#struct::StructDefinition;
 use itertools::Itertools;
-use storage::snapshot::ReadableSnapshot;
+use storage::{keyspace::KeyspaceSet, snapshot::ReadableSnapshot};
 
 use crate::{
     error::ConceptReadError,
@@ -24,7 +24,7 @@ use crate::{
         relation_type::RelationType,
         role_type::RoleType,
         type_manager::{
-            TypeManager,
+            TypeManager, preload_schema_from,
             type_reader::TypeReader,
             validation::{
                 SchemaValidationError,
@@ -85,11 +85,13 @@ impl CommitTimeValidation {
         snapshot: &impl ReadableSnapshot,
         type_manager: &TypeManager,
     ) -> Result<Vec<Box<SchemaValidationError>>, Box<ConceptReadError>> {
+        let snapshot =
+            preload_schema_from(snapshot).map_err(|source| Box::new(ConceptReadError::SnapshotIterate { source }))?;
         let mut errors = Vec::new();
-        Self::validate_entity_types(snapshot, type_manager, &mut errors)?;
-        Self::validate_relation_types(snapshot, type_manager, &mut errors)?;
-        Self::validate_attribute_types(snapshot, type_manager, &mut errors)?;
-        Self::validate_struct_definitions(snapshot, type_manager, &mut errors)?;
+        Self::validate_entity_types(&snapshot, type_manager, &mut errors)?;
+        Self::validate_relation_types(&snapshot, type_manager, &mut errors)?;
+        Self::validate_attribute_types(&snapshot, type_manager, &mut errors)?;
+        Self::validate_struct_definitions(&snapshot, type_manager, &mut errors)?;
         Ok(errors)
     }
 

--- a/database/tests/statistics_synchronization.rs
+++ b/database/tests/statistics_synchronization.rs
@@ -4,13 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
-    thread,
-};
+use std::{sync::Arc, thread};
 
 use database::{
     Database,

--- a/database/tools/read_wal.rs
+++ b/database/tools/read_wal.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 use concept::thing::statistics::Statistics;

--- a/database/tools/replay_wal.rs
+++ b/database/tools/replay_wal.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{fs::create_dir_all, io, path::PathBuf, sync::Arc};
+use std::{fs::create_dir_all, io, path::PathBuf};
 
 use clap::{Parser, ValueEnum};
 use concept::thing::statistics::Statistics;

--- a/diagnostics/reports/json_monitoring.rs
+++ b/diagnostics/reports/json_monitoring.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use serde::{Serialize, Serializer, ser::SerializeStruct};
-use serde_json::{Value, json};
+use serde_json::Value;
 
 use crate::{
     CoreMetrics, DatabaseId,

--- a/diagnostics/reports/mod.rs
+++ b/diagnostics/reports/mod.rs
@@ -6,7 +6,6 @@
 
 use std::{
     collections::HashMap,
-    fmt,
     hash::{Hash, Hasher},
     sync::Arc,
 };
@@ -16,7 +15,7 @@ use serde::{Serialize, Serializer, ser::SerializeStruct};
 use serde_json::{Map, Value, to_value};
 
 use crate::{
-    DatabaseHash, DatabaseId,
+    DatabaseId,
     metrics::{ActionKind, ClientEndpoint, LoadKind},
 };
 

--- a/durability/benches/throughput.rs
+++ b/durability/benches/throughput.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{path::Path, sync::Arc};
+use std::path::Path;
 
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use diagnostics::metrics::FsyncMetrics;

--- a/encoding/encoding.rs
+++ b/encoding/encoding.rs
@@ -7,7 +7,7 @@
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unused_must_use)]
 
-use std::{ffi::c_int, num::NonZero};
+use std::ffi::c_int;
 
 use bytes::Bytes;
 use resource::constants::common::MB;
@@ -172,6 +172,6 @@ pub trait Prefixed<const INLINE_SIZE: usize>: AsBytes<INLINE_SIZE> + Clone {
 
     fn prefix(&self) -> Prefix {
         let byte = self.clone().to_bytes()[Self::INDEX_PREFIX];
-        Prefix::from_prefix_id(PrefixID::new(byte))
+        Prefix::from_prefix_id(PrefixID::new(byte)).expect("Unrecognized prefix byte")
     }
 }

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -483,7 +483,7 @@ impl ThingEdgeLinks {
 
     pub fn decode(bytes: Bytes<'_, BUFFER_KEY_INLINE>) -> Self {
         debug_assert_eq!(bytes.length(), Self::LENGTH);
-        match Prefix::from_prefix_id(PrefixID::new(bytes[Self::INDEX_PREFIX])) {
+        match Prefix::from_prefix_id(PrefixID::new(bytes[Self::INDEX_PREFIX])).expect("Unrecognized prefix byte") {
             Self::PREFIX => {
                 let relation = ObjectVertex::decode(&bytes[Self::RANGE_FROM]);
                 let player = ObjectVertex::decode(&bytes[Self::RANGE_TO]);

--- a/encoding/graph/thing/vertex_object.rs
+++ b/encoding/graph/thing/vertex_object.rs
@@ -116,7 +116,7 @@ impl ThingVertex for ObjectVertex {
 
     fn decode(bytes: &[u8]) -> ObjectVertex {
         debug_assert_eq!(bytes.len(), Self::LENGTH);
-        let prefix = Prefix::from_prefix_id(PrefixID { byte: bytes[0] });
+        let prefix = Prefix::from_prefix_id(PrefixID { byte: bytes[0] }).expect("Unrecognized prefix byte");
         let type_id = TypeID::decode(bytes[Self::RANGE_TYPE_ID].try_into().unwrap());
         let object_id = ObjectID::decode(bytes[Self::range_object_id()].try_into().unwrap());
         Self { prefix, type_id, object_id }

--- a/encoding/graph/type_/edge.rs
+++ b/encoding/graph/type_/edge.rs
@@ -38,7 +38,8 @@ impl TypeEdge {
 
     pub fn decode(bytes: Bytes<'_, BUFFER_KEY_INLINE>) -> Self {
         debug_assert_eq!(bytes.length(), Self::LENGTH);
-        let prefix = Prefix::from_prefix_id(PrefixID::new(bytes[Self::INDEX_PREFIX]));
+        let prefix =
+            Prefix::from_prefix_id(PrefixID::new(bytes[Self::INDEX_PREFIX])).expect("Unrecognized prefix byte");
         let from = TypeVertex::decode(bytes.clone().into_range(Self::range_from()));
         let to = TypeVertex::decode(bytes.clone().into_range(Self::range_to()));
         Self { prefix, from, to }

--- a/encoding/layout/prefix.rs
+++ b/encoding/layout/prefix.rs
@@ -4,13 +4,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+use std::ops::RangeInclusive;
+
+use itertools::Itertools;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct PrefixID {
     pub(crate) byte: u8,
 }
 
 impl PrefixID {
     pub const LENGTH: usize = 1;
+    pub const MAX: u8 = u8::MAX;
+
     pub const fn new(byte: u8) -> Self {
         PrefixID { byte }
     }
@@ -20,7 +26,7 @@ impl PrefixID {
 }
 
 macro_rules! make_prefix_enum {
-    ($($name:ident => $byte:literal = $hex:literal, $fixed_width_keys:literal);*) => {
+    ($($name:ident => $byte:literal = $hex:literal, $width:expr, $domain:expr);* $(;)?) => {
         // assert that $byte and $hex are the same literal
         $(const _: [(); $byte] = [(); $hex];)*
 
@@ -30,6 +36,8 @@ macro_rules! make_prefix_enum {
         }
 
         impl Prefix {
+            pub const ALL: &'static [Prefix] = &[$(Self::$name,)*];
+
             pub const fn prefix_id(&self) -> PrefixID {
                 match self {
                     $(Self::$name => PrefixID::new($byte),)*
@@ -42,24 +50,42 @@ macro_rules! make_prefix_enum {
                 }
             }
 
-            pub fn from_prefix_id(prefix: PrefixID) -> Self {
+            pub fn from_prefix_id(prefix: PrefixID) -> Option<Self> {
                 match prefix.byte {
-                    $($byte => Self::$name,)*
-                    _ => unreachable!(),
+                    $($byte => Some(Self::$name),)*
+                    _ => None
                 }
-           }
+            }
 
             ///
             /// Return true if we expect all keys within this exact prefix to have the same width.
             /// Note: two different prefixes with fixed width are not necessarily the same fixed widths!
             ///
-           pub const fn fixed_width_keys(&self) -> bool {
-                match self {
-                    $(Self::$name => $fixed_width_keys,)*
-                }
+            pub const fn fixed_width_keys(&self) -> bool {
+                let width = match self {
+                    $(Self::$name => $width,)*
+                };
+                matches!(width, Width::Fixed)
+            }
+
+            pub const fn is_schema(&self) -> bool {
+                let domain = match self {
+                    $(Self::$name => $domain,)*
+                };
+                matches!(domain, Domain::Schema)
             }
         }
     };
+}
+
+enum Width {
+    Fixed,
+    Variable,
+}
+
+enum Domain {
+    Schema,
+    Data,
 }
 
 impl Prefix {
@@ -78,46 +104,66 @@ impl Prefix {
             Prefix::VertexEntityType
         }
     }
+
+    pub fn schema_byte_ranges() -> Vec<RangeInclusive<u8>> {
+        let mut ranges: Vec<RangeInclusive<u8>> = Vec::new();
+        let mut current: Option<(u8, u8)> = None;
+        for prefix in Self::ALL.iter().copied().sorted_by_key(|p| p.prefix_id()) {
+            let byte = prefix.prefix_id().byte;
+            if prefix.is_schema() {
+                current = Some(match current {
+                    Some((start, _)) => (start, byte),
+                    None => (byte, byte),
+                });
+            } else if let Some((start, end)) = current.take() {
+                ranges.push(start..=end);
+            }
+        }
+        if let Some((start, end)) = current {
+            ranges.push(start..=end);
+        }
+        ranges
+    }
 }
 
 make_prefix_enum! {
     // Reserved: 0-9 = 0x00-0x09
-    VertexEntityType => 10 = 0x0A, true;
-    VertexRelationType => 11 = 0x0B, true;
-    VertexAttributeType => 12 = 0x0C, true;
-    VertexRoleType => 15 = 0x0F, true;
-    DefinitionStruct => 20 = 0x14, true;
-    DefinitionFunction => 21 = 0x15, true;
+    VertexEntityType => 10 = 0x0A, Width::Fixed, Domain::Schema;
+    VertexRelationType => 11 = 0x0B, Width::Fixed, Domain::Schema;
+    VertexAttributeType => 12 = 0x0C, Width::Fixed, Domain::Schema;
+    VertexRoleType => 15 = 0x0F, Width::Fixed, Domain::Schema;
+    DefinitionStruct => 20 = 0x14, Width::Fixed, Domain::Schema;
+    DefinitionFunction => 21 = 0x15, Width::Fixed, Domain::Schema;
 
     // All objects are stored consecutively for iteration
-    VertexEntity => 30 = 0x1E, true;
-    VertexRelation => 31 = 0x1F, true;
-    VertexAttribute => 32 = 0x20, false;
+    VertexEntity => 30 = 0x1E, Width::Fixed, Domain::Data;
+    VertexRelation => 31 = 0x1F, Width::Fixed, Domain::Data;
+    VertexAttribute => 32 = 0x20, Width::Variable, Domain::Data;
 
-    EdgeSub => 100 = 0x64, true;
-    EdgeSubReverse => 101 = 0x65, true;
-    EdgeOwns => 102 = 0x66, true;
-    EdgeOwnsReverse => 103 = 0x67, true;
-    EdgePlays => 104 = 0x68, true;
-    EdgePlaysReverse => 105 = 0x69, true;
-    EdgeRelates => 106 = 0x6A, true;
-    EdgeRelatesReverse => 107 = 0x6B, true;
+    EdgeSub => 100 = 0x64, Width::Fixed, Domain::Schema;
+    EdgeSubReverse => 101 = 0x65, Width::Fixed, Domain::Schema;
+    EdgeOwns => 102 = 0x66, Width::Fixed, Domain::Schema;
+    EdgeOwnsReverse => 103 = 0x67, Width::Fixed, Domain::Schema;
+    EdgePlays => 104 = 0x68, Width::Fixed, Domain::Schema;
+    EdgePlaysReverse => 105 = 0x69, Width::Fixed, Domain::Schema;
+    EdgeRelates => 106 = 0x6A, Width::Fixed, Domain::Schema;
+    EdgeRelatesReverse => 107 = 0x6B, Width::Fixed, Domain::Schema;
 
-    EdgeHas => 130 = 0x82, false;
-    EdgeHasReverse => 131 = 0x83, false;
-    EdgeLinks => 132 = 0x84, true;
-    EdgeLinksReverse => 133 = 0x85, true;
-    EdgeLinksIndex => 140 = 0x8C, true;
+    EdgeHas => 130 = 0x82, Width::Variable, Domain::Data;
+    EdgeHasReverse => 131 = 0x83, Width::Variable, Domain::Data;
+    EdgeLinks => 132 = 0x84, Width::Fixed, Domain::Data;
+    EdgeLinksReverse => 133 = 0x85, Width::Fixed, Domain::Data;
+    EdgeLinksIndex => 140 = 0x8C, Width::Fixed, Domain::Data;
 
-    PropertyTypeVertex => 160 = 0xA0, true;
-    PropertyTypeEdge => 162 = 0xA2, true;
-    PropertyObjectVertex => 163 = 0xA3, true;
-    PropertyFunction => 164 = 0xA4, true;
+    PropertyTypeVertex => 160 = 0xA0, Width::Fixed, Domain::Schema;
+    PropertyTypeEdge => 162 = 0xA2, Width::Fixed, Domain::Schema;
+    PropertyObjectVertex => 163 = 0xA3, Width::Fixed, Domain::Data;
+    PropertyFunction => 164 = 0xA4, Width::Fixed, Domain::Schema;
 
-    IndexLabelToType => 182 = 0xB6, false;
-    IndexNameToDefinitionStruct => 183 = 0xB7, false;
-    IndexNameToDefinitionFunction => 184 = 0xB8, false;
+    IndexLabelToType => 182 = 0xB6, Width::Variable, Domain::Schema;
+    IndexNameToDefinitionStruct => 183 = 0xB7, Width::Variable, Domain::Schema;
+    IndexNameToDefinitionFunction => 184 = 0xB8, Width::Variable, Domain::Schema;
 
-    IndexValueToStruct => 190 = 0xBE, false
+    IndexValueToStruct => 190 = 0xBE, Width::Variable, Domain::Data;
     // Reserved: 200-255 = 0xC8-0xFF
 }

--- a/executor/pipeline/given.rs
+++ b/executor/pipeline/given.rs
@@ -7,20 +7,18 @@ use std::{marker::PhantomData, sync::Arc};
 
 use answer::variable_value::VariableValue;
 use compiler::{annotation::function::FunctionParameterAnnotation, executable::pipeline::GivenExecutable};
-use concept::{ConceptStatus, error::ConceptReadError, thing::ThingAPI};
+use concept::thing::ThingAPI;
 use encoding::value::ValueEncodable;
 use error::needs_update_when_feature_is_implemented;
 use ir::pattern::variable_category::VariableOptionality;
 use lending_iterator::LendingIterator;
-use resource::profile::{StageProfile, StepProfile, StorageCounters};
-use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
+use resource::profile::{StepProfile, StorageCounters};
+use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     ExecutionInterrupt,
-    batch::{Batch, BatchRowIterator},
     pipeline::{
         PipelineExecutionError, StageIterator,
-        initial::InitialIterator,
         stage::{ExecutionContext, StageAPI},
     },
     row::MaybeOwnedRow,

--- a/executor/pipeline/initial.rs
+++ b/executor/pipeline/initial.rs
@@ -7,12 +7,8 @@
 use lending_iterator::LendingIterator;
 
 use crate::{
-    ExecutionInterrupt, Provenance,
-    batch::{Batch, BatchRowIterator, FixedBatch, FixedBatchRowIterator},
-    pipeline::{
-        PipelineExecutionError, StageIterator,
-        stage::{ExecutionContext, StageAPI},
-    },
+    batch::{Batch, BatchRowIterator},
+    pipeline::{PipelineExecutionError, StageIterator, stage::StageAPI},
     row::MaybeOwnedRow,
 };
 

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -46,7 +46,6 @@ use crate::{
         },
         update::UpdateStageExecutor,
     },
-    row::MaybeOwnedRow,
 };
 
 pub struct Pipeline<Snapshot: ReadableSnapshot, Nonterminals: StageAPI<Snapshot>> {

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, iter, sync::Arc};
 use answer::variable_value::VariableValue;
 use compiler::VariablePosition;
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
-use encoding::{graph::definition::definition_key_generator::DefinitionKeyGenerator, value::value::Value};
+use encoding::value::value::Value;
 use executor::{
     ExecutionInterrupt,
     pipeline::{PipelineExecutionError, stage::ExecutionContext},

--- a/ir/translation/fetch.rs
+++ b/ir/translation/fetch.rs
@@ -41,7 +41,6 @@ use crate::{
     },
     translation::{
         PipelineTranslationContext,
-        constraints::register_type_label,
         expression::{add_function_call, build_expression},
         fetch::FetchRepresentationError::{
             AnonymousVariableEncountered, InvalidAttributeLabelEncountered, NamedVariableEncountered,

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -20,7 +20,7 @@ use typeql::{
 
 use crate::{
     RepresentationError,
-    pattern::{Pattern, variable_category::VariableCategory},
+    pattern::Pattern,
     pipeline::{
         ParameterRegistry, VariableRegistry,
         block::Block,

--- a/query/definable_resolution.rs
+++ b/query/definable_resolution.rs
@@ -12,7 +12,7 @@ use concept::{
     type_::{
         ObjectTypeAPI, Ordering, OwnerAPI, PlayerAPI, TypeAPI, attribute_type::AttributeType, entity_type::EntityType,
         object_type::ObjectType, owns::Owns, plays::Plays, relates::Relates, relation_type::RelationType,
-        role_type::RoleType, sub::Sub, type_manager::TypeManager,
+        role_type::RoleType, type_manager::TypeManager,
     },
 };
 use encoding::{

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -23,13 +23,9 @@ use concept::{
     thing::{ThingAPI, attribute::Attribute, entity::Entity, relation::Relation, thing_manager::ThingManager},
     type_::type_manager::TypeManager,
 };
-use database::{
-    database_manager::DatabaseManager,
-    query::{
-        StreamQueryOutputDescriptor, WriteQueryAnswer, WriteQueryResult, execute_schema_query,
-        execute_write_query_in_schema, execute_write_query_in_write,
-    },
-    transaction::{TransactionRead, TransactionSchema, TransactionWrite},
+use database::query::{
+    StreamQueryOutputDescriptor, WriteQueryAnswer, WriteQueryResult, execute_schema_query,
+    execute_write_query_in_schema, execute_write_query_in_write,
 };
 use diagnostics::{
     diagnostics_manager::DiagnosticsManager,

--- a/server/service/http/message/analyze/structure.rs
+++ b/server/service/http/message/analyze/structure.rs
@@ -520,8 +520,8 @@ fn encode_role_type_as_vertex(
 #[cfg(debug_assertions)]
 pub mod bdd {
     use compiler::query_structure::{
-        FunctionReturnStructure, QueryStructureConjunctionID, QueryStructureGiven, QueryStructureStage,
-        StructureReduceAssign, StructureReducer, StructureSortVariable, StructureVariableId,
+        FunctionReturnStructure, QueryStructureConjunctionID, QueryStructureStage, StructureReduceAssign,
+        StructureReducer, StructureSortVariable, StructureVariableId,
     };
     use itertools::Itertools;
     use serde_json::Value;

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use super::{IteratorPool, constants, iterator};
 use crate::{key_range::KeyRange, keyspace::rocks_resources::RocksResources, write_batches::WriteBatches};
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyspaceId(pub u8);
 
 impl fmt::Debug for KeyspaceId {

--- a/storage/snapshot/buffer.rs
+++ b/storage/snapshot/buffer.rs
@@ -185,13 +185,13 @@ impl WriteBuffer {
 
     pub(crate) fn iterate_range<const INLINE: usize>(&self, range: KeyRange<Bytes<'_, INLINE>>) -> BufferRangeIterator {
         let (range_start, range_end, _) = range.into_raw();
-        let exclusive_end_bytes = Self::compute_exclusive_end(&range_start, &range_end);
+        let exclusive_end_bytes = compute_exclusive_end(&range_start, &range_end);
         let end = if matches!(range_end, RangeEnd::Unbounded) {
             Bound::Unbounded
         } else {
             Bound::Excluded(&*exclusive_end_bytes)
         };
-        let start_as_bound = Self::range_start_as_bound(range_start);
+        let start_as_bound = range_start_as_bound(range_start);
         let start_bytes = start_as_bound.as_ref().map(|bytes| bytes.as_ref());
         // TODO: we shouldn't have to copy now that we use single-writer semantics
         BufferRangeIterator::new(
@@ -205,49 +205,15 @@ impl WriteBuffer {
     // TODO: if the iterate_range becomes zero-copy, then we can eliminate this method
     pub(crate) fn any_not_deleted_in_range<const INLINE: usize>(&self, range: KeyRange<Bytes<'_, INLINE>>) -> bool {
         let (range_start, range_end, _) = range.into_raw();
-        let exclusive_end_bytes = Self::compute_exclusive_end(&range_start, &range_end);
+        let exclusive_end_bytes = compute_exclusive_end(&range_start, &range_end);
         let end = if matches!(range_end, RangeEnd::Unbounded) {
             Bound::Unbounded
         } else {
             Bound::Excluded(&*exclusive_end_bytes)
         };
-        let start_as_bound = Self::range_start_as_bound(range_start);
+        let start_as_bound = range_start_as_bound(range_start);
         let start_bytes = start_as_bound.as_ref().map(|bytes| bytes.as_ref());
         self.writes.range::<[u8], _>((start_bytes, end)).any(|(_, write)| !write.is_delete())
-    }
-
-    fn range_start_as_bound<const INLINE: usize>(
-        range_start: RangeStart<Bytes<'_, INLINE>>,
-    ) -> Bound<Bytes<'_, INLINE>> {
-        match range_start {
-            RangeStart::Inclusive(bytes) => Bound::Included(bytes),
-            RangeStart::ExcludeFirstWithPrefix(bytes) => Bound::Excluded(bytes),
-            RangeStart::ExcludePrefix(bytes) => {
-                let mut cloned = bytes.clone().into_array();
-                cloned.increment().unwrap();
-                Bound::Included(Bytes::Array(cloned))
-            }
-        }
-    }
-
-    fn compute_exclusive_end<const INLINE: usize>(
-        start: &RangeStart<Bytes<'_, INLINE>>,
-        end: &RangeEnd<Bytes<'_, INLINE>>,
-    ) -> ByteArray<INLINE> {
-        match end {
-            RangeEnd::WithinStartAsPrefix => {
-                let mut start_plus_1 = start.get_value().clone().into_array();
-                increment(&mut start_plus_1).unwrap();
-                start_plus_1
-            }
-            RangeEnd::EndPrefixInclusive(value) => {
-                let mut end_plus_1 = value.clone().into_array();
-                increment(&mut end_plus_1).unwrap();
-                end_plus_1
-            }
-            RangeEnd::EndPrefixExclusive(value) => value.clone().into_array(),
-            RangeEnd::Unbounded => ByteArray::empty(),
-        }
     }
 
     pub(crate) fn writes(&self) -> &BTreeMap<ByteArray<BUFFER_KEY_INLINE>, Write> {
@@ -267,13 +233,47 @@ impl WriteBuffer {
     }
 }
 
+pub(crate) fn range_start_as_bound<const INLINE: usize>(
+    range_start: RangeStart<Bytes<'_, INLINE>>,
+) -> Bound<Bytes<'_, INLINE>> {
+    match range_start {
+        RangeStart::Inclusive(bytes) => Bound::Included(bytes),
+        RangeStart::ExcludeFirstWithPrefix(bytes) => Bound::Excluded(bytes),
+        RangeStart::ExcludePrefix(bytes) => {
+            let mut cloned = bytes.clone().into_array();
+            cloned.increment().unwrap();
+            Bound::Included(Bytes::Array(cloned))
+        }
+    }
+}
+
+pub(crate) fn compute_exclusive_end<const INLINE: usize>(
+    start: &RangeStart<Bytes<'_, INLINE>>,
+    end: &RangeEnd<Bytes<'_, INLINE>>,
+) -> ByteArray<INLINE> {
+    match end {
+        RangeEnd::WithinStartAsPrefix => {
+            let mut start_plus_1 = start.get_value().clone().into_array();
+            increment(&mut start_plus_1).unwrap();
+            start_plus_1
+        }
+        RangeEnd::EndPrefixInclusive(value) => {
+            let mut end_plus_1 = value.clone().into_array();
+            increment(&mut end_plus_1).unwrap();
+            end_plus_1
+        }
+        RangeEnd::EndPrefixExclusive(value) => value.clone().into_array(),
+        RangeEnd::Unbounded => ByteArray::empty(),
+    }
+}
+
 // TODO: this iterator takes a 'snapshot' of the time it was opened at - we could have it read without clones and have it 'live' if the buffers are immutable
 pub struct BufferRangeIterator {
     inner: Peekable<<Vec<(StorageKeyArray<BUFFER_KEY_INLINE>, Write)> as IntoIterator>::IntoIter>,
 }
 
 impl BufferRangeIterator {
-    fn new(range: Vec<(StorageKeyArray<BUFFER_KEY_INLINE>, Write)>) -> Self {
+    pub(crate) fn new(range: Vec<(StorageKeyArray<BUFFER_KEY_INLINE>, Write)>) -> Self {
         Self { inner: range.into_iter().peekable() }
     }
 

--- a/storage/snapshot/iterator.rs
+++ b/storage/snapshot/iterator.rs
@@ -33,6 +33,13 @@ impl SnapshotRangeIterator {
     pub(crate) fn new(mvcc_iterator: MVCCRangeIterator, buffered_iterator: Option<BufferRangeIterator>) -> Self {
         SnapshotRangeIterator { storage_iterator: Some(mvcc_iterator), buffered_iterator, ready_item_source: None }
     }
+    pub fn new_buffered_only(buffered_iterator: BufferRangeIterator) -> Self {
+        SnapshotRangeIterator {
+            storage_iterator: None,
+            buffered_iterator: Some(buffered_iterator),
+            ready_item_source: None,
+        }
+    }
 
     // for testing
     pub fn new_empty() -> Self {
@@ -61,19 +68,22 @@ impl SnapshotRangeIterator {
                     // buffered iterators check that the seek is in ascending order internally
                     iter.seek(key.bytes())
                 }
-                // storage iterators check that the seek is in ascending order internally
-                self.storage_iterator.as_mut().unwrap().seek(key.bytes());
+                if let Some(iter) = self.storage_iterator.as_mut() {
+                    // storage iterators check that the seek is in ascending order internally
+                    iter.seek(key.bytes());
+                }
                 self.find_next_state();
             }
         }
     }
 
     fn find_next_state(&mut self) {
-        while self.ready_item_source.is_none() && self.storage_iterator.is_some() {
-            let Some(Ok((storage_key, _storage_value))) = self.storage_iterator.as_mut().unwrap().peek() else {
+        while self.ready_item_source.is_none() {
+            // get the storage key if there is one, else just fall back to the next buffered key
+            let storage_peek = self.storage_iterator.as_mut().and_then(|iter| iter.peek());
+            let Some(Ok((storage_key, _storage_value))) = storage_peek else {
                 if let Some(buffered_iterator) = self.buffered_iterator.as_mut() {
                     while let Some((_, Write::Delete)) = buffered_iterator.peek() {
-                        // SKIP buffered
                         buffered_iterator.next();
                     }
                     if buffered_iterator.peek().is_some() {
@@ -83,12 +93,14 @@ impl SnapshotRangeIterator {
                 break;
             };
 
+            // if we have a storage key, try to get the next buffered key, else just fall back to storage key
             let Some(Some((buffered_key, buffered_write))) = self.buffered_iterator.as_mut().map(|iter| iter.peek())
             else {
                 self.ready_item_source = Some(ReadyItemSource::Storage);
                 break;
             };
 
+            // if we have both, compare
             let (buffered_key, buffered_write) = (StorageKeyReference::from(buffered_key), buffered_write);
             match buffered_key.cmp(storage_key) {
                 Ordering::Less => {
@@ -117,11 +129,6 @@ impl SnapshotRangeIterator {
                 }
             }
         }
-    }
-
-    fn get_buffered_peek(buffered_iterator: &mut BufferRangeIterator) -> (StorageKeyReference<'_>, &[u8]) {
-        let (key, write) = buffered_iterator.peek().unwrap();
-        (StorageKeyReference::from(key), write.get_value())
     }
 
     pub fn collect_cloned_vec<F, M>(self, mapper: F) -> Result<Vec<M>, Arc<SnapshotIteratorError>>
@@ -174,13 +181,6 @@ impl SnapshotRangeIterator {
         match self.storage_iterator.as_mut().unwrap().next()? {
             Ok((key, value)) => Some(Ok((StorageKey::Reference(key), Bytes::Reference(value)))),
             Err(error) => Some(Err(Arc::new(SnapshotIteratorError::MVCCRead { source: error.clone() }))),
-        }
-    }
-
-    fn storage_peek(&mut self) -> Option<Result<(StorageKeyReference<'_>, &[u8]), SnapshotIteratorError>> {
-        match self.storage_iterator.as_mut().unwrap().peek()? {
-            &Ok((key, value)) => Some(Ok((key, value))),
-            Err(error) => Some(Err(SnapshotIteratorError::MVCCRead { source: error.clone() })),
         }
     }
 

--- a/storage/snapshot/lock.rs
+++ b/storage/snapshot/lock.rs
@@ -4,7 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use bytes::byte_array::ByteArray;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, Hash, Eq, PartialEq)]

--- a/storage/snapshot/mod.rs
+++ b/storage/snapshot/mod.rs
@@ -5,8 +5,8 @@
  */
 
 pub use snapshot::{
-    CommittableSnapshot, ReadSnapshot, ReadableSnapshot, SchemaSnapshot, SnapshotError, SnapshotGetError,
-    WritableSnapshot, WriteSnapshot,
+    CommittableSnapshot, PreloadedRangesSnapshot, ReadSnapshot, ReadableSnapshot, SchemaSnapshot, SnapshotError,
+    SnapshotGetError, WritableSnapshot, WriteSnapshot,
 };
 
 pub mod buffer;

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -4,7 +4,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{any::type_name, error::Error, fmt, iter::empty, sync::Arc};
+use std::{
+    any::type_name,
+    collections::{BTreeMap, HashMap},
+    error::Error,
+    fmt,
+    iter::empty,
+    ops::{Bound, RangeInclusive},
+    sync::Arc,
+};
 
 use bytes::byte_array::ByteArray;
 use error::typedb_error;
@@ -19,14 +27,14 @@ use crate::{
     durability_client::DurabilityClient,
     isolation_manager::ReaderDropGuard,
     iterator::MVCCReadError,
-    key_range::KeyRange,
+    key_range::{KeyRange, RangeEnd, RangeStart},
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
-    keyspace::IteratorPool,
+    keyspace::{IteratorPool, KeyspaceId},
     record::{CommitRecord, CommitType},
     sequence_number::SequenceNumber,
     snapshot::{
-        buffer::{BufferRangeIterator, OperationsBuffer},
-        iterator::SnapshotRangeIterator,
+        buffer::{BufferRangeIterator, OperationsBuffer, compute_exclusive_end, range_start_as_bound},
+        iterator::{SnapshotIteratorError, SnapshotRangeIterator},
         lock::LockType,
         snapshot_id::SnapshotId,
         write::Write,
@@ -665,6 +673,146 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for SchemaSnapshot<D> {
     fn into_commit_record(self) -> (ReaderDropGuard, CommitRecord) {
         let Self { operations, open_sequence_number, reader_guard, id, iterator_pool: _, storage: _ } = self;
         (reader_guard, CommitRecord::new(operations, open_sequence_number, CommitType::Schema, id))
+    }
+}
+
+type KeyspaceBtree = BTreeMap<ByteArray<BUFFER_KEY_INLINE>, ByteArray<BUFFER_VALUE_INLINE>>;
+
+pub struct PreloadedRangesSnapshot {
+    open_sequence_number: SequenceNumber,
+    id: SnapshotId,
+    keyspaces: HashMap<KeyspaceId, KeyspaceBtree>,
+}
+
+impl PreloadedRangesSnapshot {
+    pub fn load_from(
+        source: &impl ReadableSnapshot,
+        keyspaces_ranges: Vec<(KeyspaceId, Vec<RangeInclusive<u8>>)>,
+    ) -> Result<Self, Arc<SnapshotIteratorError>> {
+        let mut keyspaces: HashMap<KeyspaceId, KeyspaceBtree> = HashMap::new();
+        for (keyspace_id, ranges) in keyspaces_ranges {
+            let map = keyspaces.entry(keyspace_id).or_default();
+            for range in ranges {
+                let (start, end) = range.into_inner();
+                let start_key: StorageKey<'_, 1> =
+                    StorageKey::Array(StorageKeyArray::new_raw(keyspace_id, ByteArray::inline([start], 1)));
+                let end_key: StorageKey<'_, 1> =
+                    StorageKey::Array(StorageKeyArray::new_raw(keyspace_id, ByteArray::inline([end], 1)));
+                let key_range = KeyRange::new_variable_width(
+                    RangeStart::Inclusive(start_key),
+                    RangeEnd::EndPrefixInclusive(end_key),
+                );
+                let mut iterator = source.iterate_range(&key_range, StorageCounters::DISABLED);
+                while let Some(result) = iterator.next() {
+                    let (key, value) = result?;
+                    map.insert(key.into_bytes().into_array(), value.into_array());
+                }
+            }
+        }
+        Ok(Self { open_sequence_number: source.open_sequence_number(), id: SnapshotId::new(), keyspaces })
+    }
+
+    fn keyspace_map(&self, keyspace_id: KeyspaceId) -> Option<&KeyspaceBtree> {
+        debug_assert!(
+            self.keyspaces.contains_key(&keyspace_id),
+            "PreloadedRangesSnapshot asked for keyspace {:?}, which was not preloaded at load time",
+            keyspace_id,
+        );
+        self.keyspaces.get(&keyspace_id)
+    }
+}
+
+impl ReadableSnapshot for PreloadedRangesSnapshot {
+    const IMMUTABLE_SCHEMA: bool = true;
+
+    fn open_sequence_number(&self) -> SequenceNumber {
+        self.open_sequence_number
+    }
+
+    fn id(&self) -> SnapshotId {
+        self.id
+    }
+
+    fn get<const INLINE_BYTES: usize>(
+        &self,
+        key: StorageKeyReference<'_>,
+        _storage_counters: StorageCounters,
+    ) -> Result<Option<ByteArray<INLINE_BYTES>>, SnapshotGetError> {
+        let Some(map) = self.keyspace_map(key.keyspace_id()) else { return Ok(None) };
+        Ok(map.get(key.bytes()).map(|v| ByteArray::copy(&**v)))
+    }
+
+    fn get_last_existing<const INLINE_BYTES: usize>(
+        &self,
+        key: StorageKeyReference<'_>,
+        storage_counters: StorageCounters,
+    ) -> Result<Option<ByteArray<INLINE_BYTES>>, SnapshotGetError> {
+        self.get(key, storage_counters)
+    }
+
+    fn iterate_range<const PS: usize>(
+        &self,
+        range: &KeyRange<StorageKey<'_, PS>>,
+        _storage_counters: StorageCounters,
+    ) -> SnapshotRangeIterator {
+        let keyspace_id = range.start().get_value().keyspace_id();
+        let Some(map) = self.keyspace_map(keyspace_id) else {
+            return SnapshotRangeIterator::new_buffered_only(BufferRangeIterator::new_empty());
+        };
+        let (range_start, range_end, _) = range.map(|sk| sk.as_bytes(), |w| w).into_raw();
+        let exclusive_end_bytes = compute_exclusive_end(&range_start, &range_end);
+        let end = if matches!(range_end, RangeEnd::Unbounded) {
+            Bound::Unbounded
+        } else {
+            Bound::Excluded(&*exclusive_end_bytes)
+        };
+        let start_as_bound = range_start_as_bound(range_start);
+        let start_bytes = start_as_bound.as_ref().map(|bytes| bytes.as_ref());
+        let preloaded: Vec<(StorageKeyArray<BUFFER_KEY_INLINE>, Write)> = map
+            .range::<[u8], _>((start_bytes, end))
+            .map(|(k, v)| (StorageKeyArray::new_raw(keyspace_id, k.clone()), Write::Insert { value: v.clone() }))
+            .collect();
+        SnapshotRangeIterator::new_buffered_only(BufferRangeIterator::new(preloaded))
+    }
+
+    fn any_in_range<const PS: usize>(&self, range: &KeyRange<StorageKey<'_, PS>>, _buffered_only: bool) -> bool {
+        let keyspace_id = range.start().get_value().keyspace_id();
+        let Some(map) = self.keyspace_map(keyspace_id) else { return false };
+        let (range_start, range_end, _) = range.map(|sk| sk.as_bytes(), |w| w).into_raw();
+        let exclusive_end_bytes = compute_exclusive_end(&range_start, &range_end);
+        let end = if matches!(range_end, RangeEnd::Unbounded) {
+            Bound::Unbounded
+        } else {
+            Bound::Excluded(&*exclusive_end_bytes)
+        };
+        let start_as_bound = range_start_as_bound(range_start);
+        let start_bytes = start_as_bound.as_ref().map(|bytes| bytes.as_ref());
+        map.range::<[u8], _>((start_bytes, end)).next().is_some()
+    }
+
+    fn get_write(&self, _: StorageKeyReference<'_>) -> Option<&Write> {
+        None
+    }
+
+    fn iterate_writes(&self) -> impl Iterator<Item = (StorageKeyArray<BUFFER_KEY_INLINE>, Write)> + '_ {
+        empty()
+    }
+
+    fn iterate_writes_range<const PS: usize>(&self, _range: &KeyRange<StorageKey<'_, PS>>) -> BufferRangeIterator {
+        BufferRangeIterator::new_empty()
+    }
+
+    fn iterate_storage_range<const PS: usize>(
+        &self,
+        range: &KeyRange<StorageKey<'_, PS>>,
+        storage_counters: StorageCounters,
+    ) -> SnapshotRangeIterator {
+        self.iterate_range(range, storage_counters)
+    }
+
+    fn iterator_pool(&self) -> &IteratorPool {
+        static EMPTY_POOL: std::sync::OnceLock<IteratorPool> = std::sync::OnceLock::new();
+        EMPTY_POOL.get_or_init(IteratorPool::default)
     }
 }
 

--- a/storage/tests/test_isolation.rs
+++ b/storage/tests/test_isolation.rs
@@ -17,7 +17,6 @@ use resource::{
 use storage::{
     MVCCStorage, StorageCommitError,
     durability_client::{DurabilityClient, WALClient},
-    isolation_manager::IsolationConflict,
     key_range::KeyRange,
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
     snapshot::{CommittableSnapshot, ReadableSnapshot, SnapshotError, WritableSnapshot, WriteSnapshot},

--- a/storage/tests/test_recovery.rs
+++ b/storage/tests/test_recovery.rs
@@ -6,7 +6,7 @@
 
 #![allow(const_item_mutation, reason = "`&mut CommitProfile::DISABLED` is a dummy")]
 
-use std::{fs, sync::Arc};
+use std::fs;
 
 use diagnostics::metrics::FsyncMetrics;
 use durability::wal::WAL;

--- a/storage/tests/test_snapshot.rs
+++ b/storage/tests/test_snapshot.rs
@@ -14,17 +14,19 @@ use resource::{
     profile::{CommitProfile, StorageCounters},
 };
 use storage::{
-    key_range::KeyRange,
+    key_range::{KeyRange, RangeEnd, RangeStart},
     key_value::{StorageKey, StorageKeyArray},
-    snapshot::{CommittableSnapshot, ReadableSnapshot, WritableSnapshot},
+    keyspace::KeyspaceSet,
+    snapshot::{CommittableSnapshot, PreloadedRangesSnapshot, ReadableSnapshot, WritableSnapshot},
 };
 use test_utils::{create_tmp_storage_dir, init_logging};
 use test_utils_storage::{create_storage, test_keyspace_set};
 
-use self::TestKeyspaceSet::Keyspace;
+use self::TestKeyspaceSet::{Keyspace, Keyspace2};
 
 test_keyspace_set! {
     Keyspace => 0: "keyspace",
+    Keyspace2 => 1: "keyspace2",
 }
 
 #[test]
@@ -276,4 +278,186 @@ fn snapshot_delete_reinserted() {
             .unwrap(),
         None
     );
+}
+
+// ---------------------------------------------------------------------------
+// PreloadedRangesSnapshot
+// ---------------------------------------------------------------------------
+
+fn collect_range<S: ReadableSnapshot>(
+    snapshot: &S,
+    range: &KeyRange<StorageKey<'_, BUFFER_KEY_INLINE>>,
+) -> Vec<(StorageKeyArray<BUFFER_KEY_INLINE>, ByteArray<BUFFER_VALUE_INLINE>)> {
+    snapshot
+        .iterate_range(range, StorageCounters::DISABLED)
+        .collect_cloned_vec(|k, v| (StorageKeyArray::from(k), ByteArray::from(v)))
+        .unwrap()
+}
+
+#[test]
+fn preloaded_snapshot_matches_source_over_mixed_writes() {
+    init_logging();
+    let storage_path = create_tmp_storage_dir();
+    let storage = create_storage::<TestKeyspaceSet>(&storage_path).unwrap();
+
+    let committed_key = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x10, 0xAA]));
+    let committed_then_deleted = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x10, 0xBB]));
+    let val_committed = ByteArray::copy(&[1, 1]);
+    {
+        let mut snapshot = storage.clone().open_snapshot_write();
+        snapshot.put_val(committed_key.clone(), val_committed.clone());
+        snapshot.put_val(committed_then_deleted.clone(), ByteArray::copy(&[9, 9]));
+        snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
+    }
+
+    let buffered_put = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x10, 0xCC]));
+    let buffered_insert = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x11, 0x00]));
+    let out_of_range_key = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x20, 0xDD]));
+    let val_buffered = ByteArray::copy(&[2, 2]);
+
+    let mut source = storage.clone().open_snapshot_write();
+    source.put_val(buffered_put.clone(), val_buffered.clone());
+    source.insert_val(buffered_insert.clone(), ByteArray::copy(&[3, 3]));
+    source.delete(committed_then_deleted.clone());
+    source.put(out_of_range_key.clone());
+
+    // Materialise the keyspace, limiting the leading byte to {0x10, 0x11}. Keys at
+    // 0x20 should be excluded by the load-time scan.
+    let preloaded = PreloadedRangesSnapshot::load_from(&source, vec![(Keyspace.id(), vec![0x10..=0x11])]).unwrap();
+
+    // get: present keys hit, tombstoned + out-of-range miss.
+    assert_eq!(
+        preloaded
+            .get::<BUFFER_VALUE_INLINE>(
+                StorageKey::Array(committed_key.clone()).as_reference(),
+                StorageCounters::DISABLED
+            )
+            .unwrap(),
+        Some(val_committed.clone())
+    );
+    assert_eq!(
+        preloaded
+            .get::<BUFFER_VALUE_INLINE>(
+                StorageKey::Array(buffered_put.clone()).as_reference(),
+                StorageCounters::DISABLED
+            )
+            .unwrap(),
+        Some(val_buffered.clone())
+    );
+    assert_eq!(
+        preloaded
+            .get::<BUFFER_VALUE_INLINE>(
+                StorageKey::Array(committed_then_deleted.clone()).as_reference(),
+                StorageCounters::DISABLED,
+            )
+            .unwrap(),
+        None,
+    );
+
+    // iterate_range over [0x10..=0x11] inclusive matches the source's view of the
+    // same range, minus the tombstoned committed_then_deleted.
+    let range_start = StorageKey::Array(StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x10])));
+    let range_end = StorageKey::Array(StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x11])));
+    let key_range = KeyRange::new_variable_width(
+        RangeStart::Inclusive(range_start.clone()),
+        RangeEnd::EndPrefixInclusive(range_end),
+    );
+    let source_view = collect_range(&source, &key_range);
+    let preloaded_view = collect_range(&preloaded, &key_range);
+    assert_eq!(source_view, preloaded_view);
+    assert_eq!(
+        preloaded_view,
+        vec![(committed_key, val_committed), (buffered_put, val_buffered), (buffered_insert, ByteArray::copy(&[3, 3])),],
+    );
+
+    // any_in_range over a range fully covered by the preloaded set.
+    assert!(preloaded.any_in_range(&key_range, false));
+
+    // any_in_range over an empty sub-range: no keys live between 0x10..0x10/0x00
+    // exclusive of 0x10/0xAA, so the buffered-only iterator should report none.
+    let empty_range = KeyRange::new_variable_width(
+        RangeStart::Inclusive(StorageKey::Array(StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x10, 0x00])))),
+        RangeEnd::EndPrefixExclusive(StorageKey::Array(StorageKeyArray::<BUFFER_KEY_INLINE>::from((
+            Keyspace,
+            [0x10, 0xAA],
+        )))),
+    );
+    assert!(!preloaded.any_in_range(&empty_range, false));
+}
+
+#[test]
+fn preloaded_snapshot_multi_keyspace() {
+    init_logging();
+    let storage_path = create_tmp_storage_dir();
+    let storage = create_storage::<TestKeyspaceSet>(&storage_path).unwrap();
+
+    let k1_a = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x05, 0x01]));
+    let k1_b = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x05, 0x02]));
+    let k2_a = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace2, [0x05, 0x01]));
+    let k2_b = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace2, [0x05, 0x02]));
+
+    let mut source = storage.clone().open_snapshot_write();
+    source.put_val(k1_a.clone(), ByteArray::copy(&[1]));
+    source.put_val(k1_b.clone(), ByteArray::copy(&[2]));
+    source.put_val(k2_a.clone(), ByteArray::copy(&[3]));
+    source.put_val(k2_b.clone(), ByteArray::copy(&[4]));
+
+    let preloaded = PreloadedRangesSnapshot::load_from(
+        &source,
+        vec![(Keyspace.id(), vec![0x05..=0x05]), (Keyspace2.id(), vec![0x05..=0x05])],
+    )
+    .unwrap();
+
+    let range_for = |ks: TestKeyspaceSet| {
+        KeyRange::new_within(StorageKey::Array(StorageKeyArray::<BUFFER_KEY_INLINE>::from((ks, [0x05]))), false)
+    };
+    assert_eq!(
+        collect_range(&preloaded, &range_for(Keyspace)),
+        vec![(k1_a.clone(), ByteArray::copy(&[1])), (k1_b.clone(), ByteArray::copy(&[2]))],
+    );
+    assert_eq!(
+        collect_range(&preloaded, &range_for(Keyspace2)),
+        vec![(k2_a.clone(), ByteArray::copy(&[3])), (k2_b.clone(), ByteArray::copy(&[4]))],
+    );
+
+    assert_eq!(
+        preloaded
+            .get::<BUFFER_VALUE_INLINE>(StorageKey::Array(k1_a).as_reference(), StorageCounters::DISABLED)
+            .unwrap(),
+        Some(ByteArray::copy(&[1]))
+    );
+    assert_eq!(
+        preloaded
+            .get::<BUFFER_VALUE_INLINE>(StorageKey::Array(k2_a).as_reference(), StorageCounters::DISABLED)
+            .unwrap(),
+        Some(ByteArray::copy(&[3]))
+    );
+}
+
+#[test]
+fn preloaded_snapshot_load_from_at_sequence_number() {
+    init_logging();
+    let storage_path = create_tmp_storage_dir();
+    let storage = create_storage::<TestKeyspaceSet>(&storage_path).unwrap();
+
+    let key_at_t0 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x07, 0x01]));
+    let key_at_t1 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x07, 0x02]));
+
+    let mut snap_t0 = storage.clone().open_snapshot_write();
+    snap_t0.put_val(key_at_t0.clone(), ByteArray::copy(&[0]));
+    let seq_t0 = snap_t0.commit(&mut CommitProfile::DISABLED).unwrap().unwrap();
+
+    let mut snap_t1 = storage.clone().open_snapshot_write();
+    snap_t1.put_val(key_at_t1.clone(), ByteArray::copy(&[1]));
+    snap_t1.commit(&mut CommitProfile::DISABLED).unwrap();
+
+    let preloaded = PreloadedRangesSnapshot::load_from(
+        &storage.clone().open_snapshot_read_at(seq_t0),
+        vec![(Keyspace.id(), vec![0x07..=0x07])],
+    )
+    .unwrap();
+
+    let key_range =
+        KeyRange::new_within(StorageKey::Array(StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x07]))), false);
+    assert_eq!(collect_range(&preloaded, &key_range), vec![(key_at_t0, ByteArray::copy(&[0]))]);
 }

--- a/tests/assembly/fail_points.rs
+++ b/tests/assembly/fail_points.rs
@@ -7,7 +7,6 @@
 use std::{
     fs,
     io::Read,
-    path::Path,
     process::{Child, Command, Output},
     thread,
     time::{Duration, Instant},

--- a/tests/behaviour/steps/lib.rs
+++ b/tests/behaviour/steps/lib.rs
@@ -17,7 +17,6 @@ use std::{
 
 use ::concept::thing::{attribute::Attribute, object::Object};
 use ::query::{error::QueryError, given_rows::GivenRowsSimple};
-use answer::variable_value::VariableValue;
 use cucumber::{StatsWriter, World, gherkin::Feature};
 use database::Database;
 use futures::{


### PR DESCRIPTION
## Product change and motivation

Optimize schema commit by preloading the entire schema storage range into a new in-memory data structure. This makes the thousands of validation and cache rebuild lookups up significantly faster compared to the previous approach of always going to RocksDB.

As an example, a schema with 21k schema types being committed with a set of new types, went from 40s to ~9s for the complete schema revalidation and cache rebuilds.

## Implementation

Introduces a new `PreloadedRangesSnapshot` that implements `ReadableSnapshot`. All reads and range iterators are served from those maps; storage is never consulted.

It is used at the two points in the schema-commit path that collectively make millions of small reads against the schema keyspace:

  - `TypeCache::new` (post-commit cache rebuild)
  - `CommitTimeValidation::validate` (pre-commit validation)

Each of those previously opened 10s of thousands iterators against rocksdb per schema commit. 

`SnapshotRangeIterator` gains a `new_buffered_only` constructor and its state machine is relaxed to drive the buffered iterator alone when no MVCC `storage_iterator` is present. `BufferRangeIterator::new` becomes `pub(crate)` so the new snapshot can construct iterators that wrap a materialised slice of its BTreeMap.
