### PR TITLE
Fix docker entrypoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ commands:
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-          bazel run --config=ci --jobs=8 --define version=$(git rev-parse HEAD) //:deploy-typedb-server --compilation_mode=opt -- snapshot
+          bazel run --config=ci --jobs=8 --define version=$(git rev-parse HEAD) //:deploy-typedb-all --compilation_mode=opt -- snapshot
 
   deploy-release-unix:
     steps:
@@ -102,7 +102,7 @@ commands:
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-          bazel run --config=ci --jobs=8 --define version=$(cat VERSION) //:deploy-typedb-server --compilation_mode=opt --//server:mode=published -- release
+          bazel run --config=ci --jobs=8 --define version=$(cat VERSION) //:deploy-typedb-all --compilation_mode=opt --//server:mode=published -- release
 
   deploy-release-apt:
     steps:

--- a/.circleci/windows/deploy_release.bat
+++ b/.circleci/windows/deploy_release.bat
@@ -16,4 +16,4 @@ copy target\release\typedb_admin_bin.exe  .\
 SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
 SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 set /p VER=<VERSION
-bazel --output_base=C:\b --windows_enable_symlinks run --config=ci --define version=%VER% --//server:mode=published --enable_runfiles //:deploy-typedb-server -- release
+bazel --output_base=C:\b --windows_enable_symlinks run --config=ci --define version=%VER% --//server:mode=published --enable_runfiles //:deploy-typedb-all -- release

--- a/.circleci/windows/deploy_snapshot.bat
+++ b/.circleci/windows/deploy_snapshot.bat
@@ -18,4 +18,4 @@ SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
 SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 git rev-parse HEAD > version_snapshot.txt
 set /p VER=<version_snapshot.txt
-bazel --output_base=C:\b --windows_enable_symlinks run --config=ci --define version=%VER% --enable_runfiles //:deploy-typedb-server -- snapshot
+bazel --output_base=C:\b --windows_enable_symlinks run --config=ci --define version=%VER% --enable_runfiles //:deploy-typedb-all -- snapshot

--- a/BUILD
+++ b/BUILD
@@ -285,8 +285,16 @@ alias(
 
 # docker
 pkg_tar(
+    name = "docker-package-x86_64",
+    srcs = [":package-typedb-server"],
+    package_dir = "typedb-server-linux-x86_64",
+    extension = "tar.gz",
+    target_compatible_with = constraint_linux_x86_64,
+)
+
+pkg_tar(
     name = "docker-layer-x86_64",
-    deps = [":assemble-server-linux-x86_64-targz"],
+    deps = [":docker-package-x86_64"],
     package_dir = "/opt",
     extension = "tar.gz",
 )
@@ -309,8 +317,16 @@ oci_image(
 )
 
 pkg_tar(
+    name = "docker-package-arm64",
+    srcs = [":package-typedb-server"],
+    package_dir = "typedb-server-linux-arm64",
+    extension = "tar.gz",
+    target_compatible_with = constraint_linux_arm64,
+)
+
+pkg_tar(
     name = "docker-layer-arm64",
-    deps = [":assemble-server-linux-arm64-targz"],
+    deps = [":docker-package-arm64"],
     package_dir = "/opt",
     extension = "tar.gz",
 )

--- a/BUILD
+++ b/BUILD
@@ -273,7 +273,7 @@ alias(
     visibility = ["//tests/assembly:__subpackages__"],
 )
 alias(
-    name = "deploy-typedb-server",
+    name = "deploy-typedb-all",
     actual = select({
         "@typedb_bazel_distribution//platform:is_linux_arm64" : ":deploy-linux-arm64-targz",
         "@typedb_bazel_distribution//platform:is_linux_x86_64" : ":deploy-linux-x86_64-targz",


### PR DESCRIPTION
## Product change and motivation

Fix the recently introduced broken entrypoint for the Docker image: the binary the entrypoint points at did not exist inside the image.

The regression was introduced in https://github.com/typedb/typedb/commit/e4f16b8b40114eeb4ebf2f8b5bc053a60c823fdb ("Fix CI pipelines after rules_python upgrade #7829"), which migrated the assembly rules from `assemble_targz`/`assemble_zip` to `pkg_tar`/`pkg_zip` with explicit `package_dir = "...-{version}"`. Inside the docker layer the binary lived at:

```
/opt/typedb-server-linux-<arch>-<version>/typedb
```

(e.g. `…-0.0.0/typedb` for snapshots, `…-3.11.6/typedb` for the next release), but the OCI `entrypoint` was still hardcoded to the pre-migration, un-suffixed path:

```
/opt/typedb-server-linux-<arch>/typedb
```

The downloadable `assemble-server-*` and `assemble-all-*` tarballs/zips are unchanged: they keep the `-{version}` suffix in their extracted directory names, which is what end users want when extracting a downloaded archive locally.

Current release artifacts breakdown:
```
  Snapshot tar/zip contents (all 5 OS×arch matrices):
  typedb-all-<os>-<arch>-<v>/             
  ├── LICENSE                
  ├── typedb                       (typedb.bat on Windows)                                                                 
  ├── admin/typedb_admin_bin       (.exe on Windows)      
  ├── console/typedb_console_bin   (.exe on Windows)                                                                       
  └── server/                                                     
      ├── config.yml                          
      ├── typedb_server_bin        (.exe on Windows)                                                                       
      └── data/                    (empty)          
                                                                                                                           
  Docker layer contents (linux x86_64 + arm64):                   
  /opt/typedb-server-linux-<arch>/   ← matches OCI entrypoint thanks to this PR                                            
  ├── LICENSE                                                                  
  ├── typedb                                  
  ├── admin/typedb_admin_bin                                                                                               
  └── server/{config.yml, typedb_server_bin, data/}
  OCI metadata: Entrypoint = ["/opt/typedb-server-linux-<arch>/typedb", "server",                                          
  "--storage.data-directory=/var/lib/typedb/data"], WorkingDir = /opt/typedb-server-linux-<arch>, ExposedPorts = 1729/tcp, 
  8000/tcp, Volumes = /var/lib/typedb/data/.                                                                               
                                                                  
  APT package install layout:                                                                                              
  /opt/typedb/core/                      ← payload from package-typedb-all (includes console)                              
  ├── typedb, admin/, server/, console/, LICENSE                                                                           
  └── typedb.service                     (systemd unit)                                                                    
  Symlinks:                                                       
    /usr/local/bin/typedb              → /opt/typedb/core/typedb
    /opt/typedb/core/server/data       → /var/lib/typedb/core/data/                                                        
    /opt/typedb/core/server/logs       → /var/log/typedb/          
    /usr/lib/systemd/system/typedb.service → /opt/typedb/core/typedb.service  
```

**Additionally**, rename `deploy-typedb-server` alias to `deploy-typedb-all`, because this target is related to `typedb-all-` artifacts.

## Implementation

Inserts a docker-only intermediate `pkg_tar` per arch (`docker-package-x86_64` / `docker-package-arm64`) that re-packages the existing `package-typedb-server` filegroup under a **version-less** `package_dir`. The `docker-layer-*` rules now consume that instead of `assemble-server-linux-*-targz`. The entrypoint and workdir paths are unchanged — they now actually match what's in the layer.

