### PR TITLE
Fix apt: remove empty server/data dir that collides with the data symlink

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,42 +401,42 @@ workflows:
       - test-deploy-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, fix-apt ]
 
       - test-deploy-snapshot-linux-arm64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, fix-apt ]
 
       - test-deploy-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, fix-apt ]
 
       - test-deploy-snapshot-mac-arm64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, fix-apt ]
 
       - test-deploy-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, fix-apt ]
 
       - deploy-docker-snapshot-x86_64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, fix-apt ]
 
       - deploy-docker-snapshot-arm64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, fix-apt ]
 
       - deploy-docker-snapshot-multiarch:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, fix-apt ]
           requires:
             - deploy-docker-snapshot-x86_64
             - deploy-docker-snapshot-arm64
@@ -444,7 +444,7 @@ workflows:
       - sync-to-typedb-benchmark:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, fix-apt ]
           requires:
             - test-deploy-snapshot-linux-x86_64
   release:

--- a/BUILD
+++ b/BUILD
@@ -15,7 +15,7 @@ load("@typedb_bazel_distribution//platform:constraints.bzl", "constraint_linux_a
 load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 
-load("@rules_pkg//:mappings.bzl", "pkg_attributes" , "pkg_files", "pkg_filegroup", "pkg_mkdirs")
+load("@rules_pkg//:mappings.bzl", "pkg_attributes" , "pkg_files", "pkg_filegroup")
 load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_zip")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rustfmt_test")
 
@@ -56,12 +56,6 @@ rust_binary(
 # Assembly
 package_version_vars(name = "server-version-vars")
 
-pkg_mkdirs(
-    name = "package-layout-server-dirs",
-    dirs = ["server/data"],
-    attributes = pkg_attributes(mode = "0755"),
-)
-
 binary_permissions = pkg_attributes(mode = "0744")
 
 alias(
@@ -89,7 +83,7 @@ pkg_files(
 
 pkg_filegroup(
     name = "package-typedb-server",
-    srcs = [":package-layout-server-files", ":package-layout-server-dirs"]
+    srcs = [":package-layout-server-files"]
 )
 
 pkg_zip(

--- a/tests/assembly/fail_points.rs
+++ b/tests/assembly/fail_points.rs
@@ -190,7 +190,11 @@ fn extract_typedb() {
 }
 
 fn delete_data() {
-    fs::remove_dir_all("typedb-extracted/server/data").unwrap();
+    match fs::remove_dir_all("typedb-extracted/server/data") {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => panic!("Failed to delete server data directory: {err}"),
+    }
 }
 
 fn setup(port: u16) {


### PR DESCRIPTION
## Product change and motivation

Remove the pre-created data directory from the bazel targets to avoid conflicts in apt.

The Debian package built from current master installs a regular directory at `/opt/typedb/core/server/data` instead of the symlink to `/var/lib/typedb/core/data/` that the package is supposed to create. As a consequence, an apt-installed TypeDB writes its data files under `/opt/typedb/core/server/data` -- a directory the package owns and dpkg may rewrite on upgrade, instead of under the volume-managed `/var/lib/typedb/core/data/`, which is the path that:                                 
- apt_empty_dirs provisions with mode 0777 at install time.                                                              
- Operators expect to back up / mount / chown.                  
- The deb's own `apt_symlinks` entry explicitly points at.

Two entries collide inside the deb's data.tar.gz:
- opt/typedb/core/server/data (symlink)
- opt/typedb/core/server/data/ (directory)

The server starts, the database files end up on disk (just in a different directory than designed), restarts preserve state. However, with the data going to the wrong directory, anyone running `tar czf backup.tgz /var/lib/typedb/`, mounting a separate disk at `/var/lib/typedb/core/data/`, or following typical sysadmin playbooks gets a silent no-op. Leading to losing data. Also, the same issue with `apt upgrade` and `apt purge`. 

At [bd671fa29](https://github.com/typedb/typedb/commit/bd671fa29857f020554c8627bccf2d73043103ea) the empty server/data directory was supplied via the `assemble_targz(empty_directories=["server/data"], …)` parameter on each download archive (`assemble-server-*-{zip,targz}` and `assemble-all-*-{zip,targz}`). Those rules are unrelated to the apt build path, so the empty directory never reached the deb. apt only had the symlink. Working.
                                                                                                                           
Commit [e4f16b8b4](https://github.com/typedb/typedb/commit/e4f16b8b40114eeb4ebf2f8b5bc053a60c823fdb) migrated the assembly rules from `assemble_targz` to `pkg_tar` and replaced the macro-local `empty_directories` parameter with a standalone `pkg_mkdirs(name =  "package-layout-server-dirs", dirs = ["server/data"])` rule, then included it inside the shared `package-typedb-server` filegroup. From that point on, every consumer of `package-typedb-server` inherits the empty directory -- including the apt-payload chain `package-typedb-server` -> `package-typedb-all` -> `package-typedb-all-targz`. The conflict with apt_symlinks is the consequence.  

**This PR changes the way we distribute TypeDB packages**: they no longer contain the pre-created empty directory. However, they are created on the initial server boot up, and it seems even cleaner.

## Reproducer:                             
                                                                                                                           
$ bazel build //:assemble-linux-arm64-apt                                                                                
$ dpkg-deb -x bazel-bin/typedb__arm64.deb /tmp/probe
tar: opt/typedb/core/server/data: Cannot unlink: Is a directory                                                          
tar: Exiting with failure status due to previous errors         
dpkg-deb: error: tar subprocess returned error exit status 2                                                             
$ ls -ld /tmp/probe/opt/typedb/core/server/data                                                                          
drwxr-xr-x ... /tmp/probe/opt/typedb/core/server/data            # ← should be a symlink  

## Implementation

Delete the empty-directory rule entirely.

The server creates its data directory on first start if missing (via `--storage.data-directory`). All consumers behave correctly without it:                     
- Downloads (`typedb-all-*-{tar.gz,zip}`): on first `./typedb server`, the data directory is created automatically. The only user-visible change is that ls of a freshly-extracted archive no longer shows an empty `server/data/`.
- Docker images: entrypoint already uses `--storage.data-directory=/var/lib/typedb/data` (an unrelated path) plus `Volumes = /var/lib/typedb/data/`. Untouched. 
- Apt packages: the symlink at `/opt/typedb/core/server/data` is now the only entry, no conflict; data ends up at `/var/lib/typedb/core/data/` as designed; `dpkg-deb -x` succeeds. 
