### PR TITLE
Add graceful SIGTERM handling for Unix systems

### DIFF
--- a/server/lib.rs
+++ b/server/lib.rs
@@ -524,8 +524,8 @@ impl Server {
 
     fn spawn_shutdown_handler(shutdown_sender: Sender<()>) {
         tokio::spawn(async move {
-            let first = Self::wait_for_shutdown_signal().await;
-            println!("\nReceived {first}. Initiating shutdown...");
+            let initial_signal = Self::wait_for_shutdown_signal().await;
+            println!("\nReceived {initial_signal}. Initiating shutdown...");
             shutdown_sender.send(()).expect("Expected a successful shutdown signal");
 
             tokio::spawn(Self::forced_shutdown_handler());
@@ -533,8 +533,8 @@ impl Server {
     }
 
     async fn forced_shutdown_handler() {
-        let second = Self::wait_for_shutdown_signal().await;
-        println!("\nReceived {second}. Forcing shutdown...");
+        let forced_signal = Self::wait_for_shutdown_signal().await;
+        println!("\nReceived {forced_signal}. Forcing shutdown...");
         std::process::exit(1);
     }
 

--- a/server/lib.rs
+++ b/server/lib.rs
@@ -524,8 +524,8 @@ impl Server {
 
     fn spawn_shutdown_handler(shutdown_sender: Sender<()>) {
         tokio::spawn(async move {
-            Self::wait_for_ctrl_c_signal().await;
-            println!("\nReceived CTRL-C. Initiating shutdown...");
+            let first = Self::wait_for_shutdown_signal().await;
+            println!("\nReceived {first}. Initiating shutdown...");
             shutdown_sender.send(()).expect("Expected a successful shutdown signal");
 
             tokio::spawn(Self::forced_shutdown_handler());
@@ -533,13 +533,29 @@ impl Server {
     }
 
     async fn forced_shutdown_handler() {
-        Self::wait_for_ctrl_c_signal().await;
-        println!("\nReceived CTRL-C. Forcing shutdown...");
+        let second = Self::wait_for_shutdown_signal().await;
+        println!("\nReceived {second}. Forcing shutdown...");
         std::process::exit(1);
     }
 
-    async fn wait_for_ctrl_c_signal() {
-        tokio::signal::ctrl_c().await.expect("Failed to listen for CTRL-C signal");
+    async fn wait_for_shutdown_signal() -> &'static str {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{SignalKind, signal};
+            let mut sigterm = signal(SignalKind::terminate()).expect("Failed to install SIGTERM handler");
+            tokio::select! {
+                result = tokio::signal::ctrl_c() => {
+                    result.expect("Failed to listen for SIGINT");
+                    "SIGINT"
+                }
+                _ = sigterm.recv() => "SIGTERM",
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            tokio::signal::ctrl_c().await.expect("Failed to listen for Ctrl-C");
+            "CTRL-C"
+        }
     }
 
     fn install_default_encryption_provider() -> Result<(), ServerOpenError> {


### PR DESCRIPTION
## Product change and motivation

SIGTERM is now gracefully processed together with SIGINT, leading to a usual shutdown process with careful cleanup (exit 0, admin socket removed, in-flight requests drained). This includes commands like `kill <pid>`, `docker stop`, `systemctl stop`, and Kubernetes pod termination.

SIGKILL is uncatchable by the OS and continues to hard-kill the server immediately. 

*Note:* In case of a SIGKILL, the socket file is left in the filesystem, but is correctly overridden on the next server restart. 

## Implementation

Add a `tokio::select` for multiple sources instead of one for Unix (`ctrl_c()` + `SignalKind::terminate()`). Windows does not have an analog of SIGTERM, so its behavior remains the same.