### PR TITLE
Use Bazel `exclusive` tag for HTTP service tests instead of CLI --jobs=1

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -171,7 +171,7 @@ build:
       dependencies: [build]
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci $(bazel query 'kind(rust_test, //tests/behaviour/service/...)') --test_output=streamed --jobs=1
+        bazel test --config=ci $(bazel query 'kind(rust_test, //tests/behaviour/service/...)') --test_output=streamed
 
 release:
   filter:

--- a/tests/behaviour/service/http/connection/BUILD
+++ b/tests/behaviour/service/http/connection/BUILD
@@ -15,7 +15,7 @@ rust_test(
     ],
     data = ["@typedb_behaviour//connection:database.feature"],
     crate_features = ["bazel"],
-    tags = ["manual_build"],
+    tags = ["manual_build", "exclusive"],
 )
 
 rust_test(
@@ -28,7 +28,7 @@ rust_test(
     ],
     data = ["@typedb_behaviour//connection:transaction.feature"],
     crate_features = ["bazel"],
-    tags = ["manual_build"],
+    tags = ["manual_build", "exclusive"],
 )
 
 rustfmt_test(

--- a/tests/behaviour/service/http/debug/BUILD
+++ b/tests/behaviour/service/http/debug/BUILD
@@ -15,7 +15,7 @@ rust_test(
     ],
     data = ["debug.feature"],
     crate_features = ["bazel"],
-    tags = ["manual_build"],
+    tags = ["manual_build", "exclusive"],
 )
 
 rustfmt_test(

--- a/tests/behaviour/service/http/driver/BUILD
+++ b/tests/behaviour/service/http/driver/BUILD
@@ -15,7 +15,7 @@ rust_test(
     ],
     data = ["@typedb_behaviour//driver:concept.feature"],
     crate_features = ["bazel"],
-    tags = ["manual_build"],
+    tags = ["manual_build", "exclusive"],
 )
 
 rust_test(
@@ -28,7 +28,7 @@ rust_test(
     ],
     data = ["@typedb_behaviour//driver:connection.feature"],
     crate_features = ["bazel"],
-    tags = ["manual_build"],
+    tags = ["manual_build", "exclusive"],
 )
 
 rust_test(
@@ -41,7 +41,7 @@ rust_test(
     ],
     data = ["@typedb_behaviour//driver/http:http.feature"],
     crate_features = ["bazel"],
-    tags = ["manual_build"],
+    tags = ["manual_build", "exclusive"],
 )
 
 rust_test(
@@ -54,7 +54,7 @@ rust_test(
     ],
     data = ["@typedb_behaviour//driver:query.feature"],
     crate_features = ["bazel"],
-    tags = ["manual_build"],
+    tags = ["manual_build", "exclusive"],
 )
 
 rust_test(
@@ -67,7 +67,7 @@ rust_test(
     ],
     data = ["@typedb_behaviour//driver:user.feature"],
     crate_features = ["bazel"],
-    tags = ["manual_build"],
+    tags = ["manual_build", "exclusive"],
 )
 
 rustfmt_test(


### PR DESCRIPTION
## Product change and motivation

Replace the CI Bazel `--jobs=1` flag to ensure jobs aren't running in parallel and clashing for resources with the `exclusive` bazel tag.

Note that the `exclusive` flag allows parallel builds but blocks parallel test phase execution. In addition, if we ever add it, it prevents remote execution.

## Implementation

The //tests/behaviour/service/... rust_test targets each start a TypeDB server bound to fixed ports (gRPC 0.0.0.0:1729, HTTP 0.0.0.0:8000), so two of them cannot run concurrently. CI worked around this by passing --jobs=1 on the command line, which serializes the entire invocation, throttling the build as well as the tests.

Instead, we tag each of the 8 service test targets with `exclusive`, which serializes them against each other at the Bazel level while still allowing the build (and other, non-exclusive tests) to run in parallel. The --jobs=1 flag is then removed from the CI jobs.
