### PR TITLE
Fix global log level overshadowing

### DIFF
--- a/common/logger/logger.rs
+++ b/common/logger/logger.rs
@@ -23,8 +23,9 @@ pub mod result;
 
 pub fn initialise_logging_global(logdir: &PathBuf) {
     debug_assert!(logdir.is_absolute());
-    let filter = EnvFilter::from_default_env()
-        .add_directive(LevelFilter::INFO.into())
+    let filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy()
         // .add_directive("database=trace".parse().unwrap())
         // .add_directive("server=trace".parse().unwrap())
         // .add_directive("storage=trace".parse().unwrap())


### PR DESCRIPTION
## Product change and motivation

Now, you can run the server binary with `RUST_LOG=debug`, switching all the packages to the global logging level. Previously, the provided global value was overridden by the constant set to `info`.

This also allows other libs using `typedb` crate to conventionally use this env var, which was blocked before. 

## Implementation

Use the `EnvFilter` builder to set the default global filter value instead of forcing it.