### PR TITLE
Fix git patch file for Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ executors:
     working_directory: ~/typedb
 
   win-x86_64:
-    resource_class: windows.xlarge
+    resource_class: windows.small
     machine:
       image: windows-server-2022-gui:2024.01.1
     shell: cmd.exe
@@ -222,9 +222,6 @@ jobs:
     steps:
       - checkout
       - run: .circleci\windows\prepare.bat
-      - run: .circleci\windows\test_assembly.bat
-      - run: .circleci\windows\test_admin.bat
-      - run: .circleci\windows\deploy_snapshot.bat
 
   deploy-docker-snapshot-x86_64:
     executor: linux-x86_64-amazonlinux-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ executors:
     working_directory: ~/typedb
 
   win-x86_64:
-    resource_class: windows.medium
+    resource_class: windows.xlarge
     machine:
       image: windows-server-2022-gui:2024.01.1
     shell: cmd.exe
@@ -222,6 +222,9 @@ jobs:
     steps:
       - checkout
       - run: .circleci\windows\prepare.bat
+      - run: .circleci\windows\test_assembly.bat
+      - run: .circleci\windows\test_admin.bat
+      - run: .circleci\windows\deploy_snapshot.bat
 
   deploy-docker-snapshot-x86_64:
     executor: linux-x86_64-amazonlinux-2
@@ -434,7 +437,7 @@ workflows:
       - test-deploy-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [ master, fix-git-patch ]
+              only: [ master ]
 
       - deploy-docker-snapshot-x86_64:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,7 +437,7 @@ workflows:
       - test-deploy-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, fix-git-patch ]
 
       - deploy-docker-snapshot-x86_64:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ executors:
     working_directory: ~/typedb
 
   win-x86_64:
-    resource_class: windows.small
+    resource_class: windows.medium
     machine:
       image: windows-server-2022-gui:2024.01.1
     shell: cmd.exe

--- a/.circleci/windows/git.patch
+++ b/.circleci/windows/git.patch
@@ -1,11 +1,11 @@
 diff --git a/BUILD b/BUILD
-index bb3d50325e..814c752450 100644
+index 3f8848f..501dbff 100644
 --- a/BUILD
 +++ b/BUILD
 @@ -80,13 +80,23 @@ alias(
      })
  )
-
+ 
 -# The directory structure for distribution (Unix)
 +filegroup(
 +    name = "typedb_server_bin_release",
@@ -37,7 +37,7 @@ index bb3d50325e..814c752450 100644
 -    subpath = "console/typedb_console_bin",
 +    subpath = "console/typedb_console_bin.exe",
  )
-
+ 
  pkg_files(
 @@ -168,7 +178,7 @@ pkg_files(
  select_file(
@@ -46,5 +46,5 @@ index bb3d50325e..814c752450 100644
 -    subpath = "loader/typedb_loader_bin",
 +    subpath = "loader/typedb_loader_bin.exe",
  )
-
+ 
  pkg_files(


### PR DESCRIPTION
## Product change and motivation

Fix the `git.patch` file used to enable Windows builds

## Implementation

Add leading spaces to empty lines
