### PR TITLE
Fix protocol extension mismatch error handling

### DIFF
--- a/server/service/grpc/error.rs
+++ b/server/service/grpc/error.rs
@@ -10,6 +10,8 @@ use error::{TypeDBError, typedb_error};
 use tonic::{Code, Status};
 use tonic_types::{ErrorDetails, StatusExt};
 
+use crate::service::grpc::GrpcProtocolVersion;
+
 // Errors caused by incorrect implementation or usage of the network protocol.
 // Note: NOT a typedb_error!(), since we want go directly to Status
 #[derive(Debug)]
@@ -24,8 +26,8 @@ pub(crate) enum ProtocolError {
         enum_variant: i32,
     },
     IncompatibleProtocolVersion {
-        server_protocol_version: i32,
-        driver_protocol_version: i32,
+        server_protocol_version: GrpcProtocolVersion,
+        driver_protocol_version: GrpcProtocolVersion,
         driver_lang: String,
         driver_version: String,
     },

--- a/server/service/grpc/mod.rs
+++ b/server/service/grpc/mod.rs
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+use std::fmt;
 
 pub use error::{IntoGrpcStatus, IntoProtocolErrorMessage};
 
@@ -21,3 +22,27 @@ mod row;
 pub(crate) mod transaction_service;
 pub(crate) mod typedb_service;
 pub(crate) type ConnectionID = uuid::Bytes;
+
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd)]
+pub struct GrpcProtocolVersion {
+    version: i32,
+    extension: i32,
+}
+
+impl GrpcProtocolVersion {
+    pub(crate) fn new(version: i32, extension: i32) -> GrpcProtocolVersion {
+        Self { version, extension }
+    }
+}
+
+impl fmt::Display for GrpcProtocolVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl fmt::Debug for GrpcProtocolVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.version as i32, self.extension as i32)
+    }
+}

--- a/server/service/grpc/typedb_service.rs
+++ b/server/service/grpc/typedb_service.rs
@@ -24,7 +24,7 @@ use crate::{
     error::LocalServerStateError,
     service::{
         grpc::{
-            ConnectionID,
+            ConnectionID, GrpcProtocolVersion,
             diagnostics::run_with_diagnostics_async,
             error::{GrpcServiceError, IntoGrpcStatus, IntoProtocolErrorMessage, ProtocolError},
             migration::{
@@ -85,8 +85,11 @@ impl typedb_protocol::type_db_server::TypeDb for GRPCTypeDBService {
                     && message.extension_version <= typedb_protocol::ExtensionVersion::Extension as i32;
                 if !versions_compatible {
                     let err = ProtocolError::IncompatibleProtocolVersion {
-                        server_protocol_version: typedb_protocol::Version::Version as i32,
-                        driver_protocol_version: message.version,
+                        server_protocol_version: GrpcProtocolVersion::new(
+                            typedb_protocol::Version::Version as i32,
+                            typedb_protocol::ExtensionVersion::Extension as i32,
+                        ),
+                        driver_protocol_version: GrpcProtocolVersion::new(message.version, message.extension_version),
                         driver_lang: message.driver_lang.clone(),
                         driver_version: message.driver_version.clone(),
                     };


### PR DESCRIPTION
## Product change and motivation
Fix how errors are handled when the driver protocol extension is ahead of the server - it previously crashed, now returns an error as expected. Sample message:

## Implementation
```
typedb.common.exception.TypeDBDriverException: 
                    Incompatible driver version. This 'python' driver version '0.0.0' implements protocol version 8.2,
                    while the server supports network protocol version 8.1. Please use an older driver that is compatible with this server.
```                    
