### PR TITLE
Fix 'function not found' for built-in functions in fetch

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -189,6 +189,6 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "2ed86fa588c97848982229ca5b681580f16701ff",
+    remote = "https://github.com/typedb/typedb-behaviour",
+    commit = "36fcf85ecdb09b42d539f9bbf4d0e2c0fa5bbea5",
 )

--- a/ir/translation/expression.rs
+++ b/ir/translation/expression.rs
@@ -177,7 +177,7 @@ fn add_user_defined_function_call(
     Ok(())
 }
 
-pub fn add_function_call(
+pub(crate) fn add_function_call(
     function_index: &impl FunctionSignatureIndex,
     constraints: &mut ConstraintsBuilder<'_, '_>,
     function_name: &str,

--- a/ir/translation/fetch.rs
+++ b/ir/translation/fetch.rs
@@ -28,7 +28,7 @@ use typeql::{
 
 use crate::{
     RepresentationError,
-    pattern::{AssignedVariable, ParameterID},
+    pattern::{AssignedVariable, ParameterID, expression::BuiltinConceptFunctionID},
     pipeline::{
         FunctionReadError, FunctionRepresentationError, ParameterRegistry,
         block::{Block, BlockBuilder, BlockBuilderContext},
@@ -337,7 +337,7 @@ fn translate_inline_user_function_call_single(
     function_name: &str,
 ) -> Result<FetchSome, Box<FetchRepresentationError>> {
     let (local_context, stage, assign_vars, signature) =
-        translate_inline_user_function_call(context, value_parameters, function_index, call, function_name)?;
+        translate_inline_function_call(context, value_parameters, function_index, call, function_name)?;
     if signature.return_is_stream {
         Err(Box::new(FetchRepresentationError::ExpectedSingleInlineFunctionCall { declaration: call.clone() }))
     } else {
@@ -357,7 +357,7 @@ fn translate_inline_user_function_call_stream(
     function_name: &str,
 ) -> Result<FetchSome, Box<FetchRepresentationError>> {
     let (local_context, stage, assign_vars, _) =
-        translate_inline_user_function_call(context, value_parameters, function_index, call, function_name)?;
+        translate_inline_function_call(context, value_parameters, function_index, call, function_name)?;
     let parameters = value_parameters.clone();
     let return_ = ReturnOperation::Stream(assign_vars, call.span());
     let body = FunctionBody::new(vec![stage], return_);
@@ -365,7 +365,7 @@ fn translate_inline_user_function_call_stream(
     Ok(FetchSome::ListFunction(create_anonymous_function(local_context, parameters, args, body)))
 }
 
-fn translate_inline_user_function_call<'a>(
+fn translate_inline_function_call<'a>(
     context: &mut PipelineTranslationContext,
     value_parameters: &mut ParameterRegistry,
     function_index: &'a impl FunctionSignatureIndex,
@@ -375,16 +375,20 @@ fn translate_inline_user_function_call<'a>(
     (PipelineTranslationContext, TranslatedStage, Vec<Variable>, MaybeOwns<'a, FunctionSignature>),
     Box<FetchRepresentationError>,
 > {
-    let signature = function_index
-        .get_function_signature(function_name)
-        .map_err(|err| FetchRepresentationError::FunctionRetrieval {
-            name: function_name.to_owned(),
-            typedb_source: err,
-        })?
-        .ok_or_else(|| FetchRepresentationError::FunctionNotFound {
-            name: function_name.to_owned(),
-            declaration: call.clone(),
-        })?;
+    let signature = if let Some(std_function_id) = BuiltinConceptFunctionID::from_str(function_name) {
+        MaybeOwns::Owned(std_function_id.signature())
+    } else {
+        function_index
+            .get_function_signature(function_name)
+            .map_err(|err| FetchRepresentationError::FunctionRetrieval {
+                name: function_name.to_owned(),
+                typedb_source: err,
+            })?
+            .ok_or_else(|| FetchRepresentationError::FunctionNotFound {
+                name: function_name.to_owned(),
+                declaration: call.clone(),
+            })?
+    };
 
     if signature.returns.len() > 1 {
         return Err(Box::new(FetchRepresentationError::ExpectedScalarInlineFunctionCall { declaration: call.clone() }));


### PR DESCRIPTION
## Product change and motivation

Built-in functions that are not explicitly enumerated in the grammar need to be resolved during translation. There was a leftover check that a function name not included in the typeql grammar must be in the index of user-defined functions, which of course does not hold for built-in functions. We modify that check to account for non-grammar built-ins.

## Implementation

