### PR TITLE
Allow passing UUIDs for users and credentials on creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5981,6 +5981,7 @@ dependencies = [
  "storage",
  "system",
  "typeql",
+ "uuid",
 ]
 
 [[package]]

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -5200,7 +5200,7 @@
     "@@typedb_dependencies+//distribution/artifact:rules.bzl%native_artifact_files": {
       "general": {
         "bzlTransitiveDigest": "j3hx3mUtu6z2mFVqzO+QxuHlrl18RFJ+k2KdWIGo83o=",
-        "usagesDigest": "RUei7nxuQB6vX+2g+HWOHwsfj8ImRcpwGXP/WyLCado=",
+        "usagesDigest": "cRbxW1Olzlom+1gnvoXbn0QC0d2CAR22BPgGfWlCcWg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -5209,18 +5209,18 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-arm64/versions/3.12.0-rc0/typedb-console-linux-arm64-3.12.0-rc0.tar.gz"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-arm64/versions/3.12.0-rc2/typedb-console-linux-arm64-3.12.0-rc2.tar.gz"
               ],
-              "downloaded_file_path": "typedb-console-linux-arm64-3.12.0-rc0.tar.gz"
+              "downloaded_file_path": "typedb-console-linux-arm64-3.12.0-rc2.tar.gz"
             }
           },
           "typedb_console_artifact_linux-arm64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-arm64/versions/3.12.0-rc0/typedb-console-linux-arm64-3.12.0-rc0.tar.gz"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-arm64/versions/3.12.0-rc2/typedb-console-linux-arm64-3.12.0-rc2.tar.gz"
               ],
-              "strip_prefix": "typedb-console-linux-arm64-3.12.0-rc0",
+              "strip_prefix": "typedb-console-linux-arm64-3.12.0-rc2",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
             }
           },
@@ -5228,18 +5228,18 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-x86_64/versions/3.12.0-rc0/typedb-console-linux-x86_64-3.12.0-rc0.tar.gz"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-x86_64/versions/3.12.0-rc2/typedb-console-linux-x86_64-3.12.0-rc2.tar.gz"
               ],
-              "downloaded_file_path": "typedb-console-linux-x86_64-3.12.0-rc0.tar.gz"
+              "downloaded_file_path": "typedb-console-linux-x86_64-3.12.0-rc2.tar.gz"
             }
           },
           "typedb_console_artifact_linux-x86_64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-x86_64/versions/3.12.0-rc0/typedb-console-linux-x86_64-3.12.0-rc0.tar.gz"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-x86_64/versions/3.12.0-rc2/typedb-console-linux-x86_64-3.12.0-rc2.tar.gz"
               ],
-              "strip_prefix": "typedb-console-linux-x86_64-3.12.0-rc0",
+              "strip_prefix": "typedb-console-linux-x86_64-3.12.0-rc2",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
             }
           },
@@ -5247,18 +5247,18 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-arm64/versions/3.12.0-rc0/typedb-console-mac-arm64-3.12.0-rc0.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-arm64/versions/3.12.0-rc2/typedb-console-mac-arm64-3.12.0-rc2.zip"
               ],
-              "downloaded_file_path": "typedb-console-mac-arm64-3.12.0-rc0.zip"
+              "downloaded_file_path": "typedb-console-mac-arm64-3.12.0-rc2.zip"
             }
           },
           "typedb_console_artifact_mac-arm64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-arm64/versions/3.12.0-rc0/typedb-console-mac-arm64-3.12.0-rc0.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-arm64/versions/3.12.0-rc2/typedb-console-mac-arm64-3.12.0-rc2.zip"
               ],
-              "strip_prefix": "typedb-console-mac-arm64-3.12.0-rc0",
+              "strip_prefix": "typedb-console-mac-arm64-3.12.0-rc2",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
             }
           },
@@ -5266,18 +5266,18 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-x86_64/versions/3.12.0-rc0/typedb-console-mac-x86_64-3.12.0-rc0.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-x86_64/versions/3.12.0-rc2/typedb-console-mac-x86_64-3.12.0-rc2.zip"
               ],
-              "downloaded_file_path": "typedb-console-mac-x86_64-3.12.0-rc0.zip"
+              "downloaded_file_path": "typedb-console-mac-x86_64-3.12.0-rc2.zip"
             }
           },
           "typedb_console_artifact_mac-x86_64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-x86_64/versions/3.12.0-rc0/typedb-console-mac-x86_64-3.12.0-rc0.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-x86_64/versions/3.12.0-rc2/typedb-console-mac-x86_64-3.12.0-rc2.zip"
               ],
-              "strip_prefix": "typedb-console-mac-x86_64-3.12.0-rc0",
+              "strip_prefix": "typedb-console-mac-x86_64-3.12.0-rc2",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
             }
           },
@@ -5285,18 +5285,18 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-windows-x86_64/versions/3.12.0-rc0/typedb-console-windows-x86_64-3.12.0-rc0.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-windows-x86_64/versions/3.12.0-rc2/typedb-console-windows-x86_64-3.12.0-rc2.zip"
               ],
-              "downloaded_file_path": "typedb-console-windows-x86_64-3.12.0-rc0.zip"
+              "downloaded_file_path": "typedb-console-windows-x86_64-3.12.0-rc2.zip"
             }
           },
           "typedb_console_artifact_windows-x86_64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-windows-x86_64/versions/3.12.0-rc0/typedb-console-windows-x86_64-3.12.0-rc0.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-windows-x86_64/versions/3.12.0-rc2/typedb-console-windows-x86_64-3.12.0-rc2.zip"
               ],
-              "strip_prefix": "typedb-console-windows-x86_64-3.12.0-rc0",
+              "strip_prefix": "typedb-console-windows-x86_64-3.12.0-rc2",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
             }
           },
@@ -5304,16 +5304,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-linux-arm64/versions/3.12.0-rc0/typedb-loader-linux-arm64-3.12.0-rc0.tar.gz"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-linux-arm64/versions/3.12.0-rc2/typedb-loader-linux-arm64-3.12.0-rc2.tar.gz"
               ],
-              "downloaded_file_path": "typedb-loader-linux-arm64-3.12.0-rc0.tar.gz"
+              "downloaded_file_path": "typedb-loader-linux-arm64-3.12.0-rc2.tar.gz"
             }
           },
           "typedb_loader_artifact_linux-arm64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-linux-arm64/versions/3.12.0-rc0/typedb-loader-linux-arm64-3.12.0-rc0.tar.gz"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-linux-arm64/versions/3.12.0-rc2/typedb-loader-linux-arm64-3.12.0-rc2.tar.gz"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
@@ -5323,16 +5323,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-linux-x86_64/versions/3.12.0-rc0/typedb-loader-linux-x86_64-3.12.0-rc0.tar.gz"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-linux-x86_64/versions/3.12.0-rc2/typedb-loader-linux-x86_64-3.12.0-rc2.tar.gz"
               ],
-              "downloaded_file_path": "typedb-loader-linux-x86_64-3.12.0-rc0.tar.gz"
+              "downloaded_file_path": "typedb-loader-linux-x86_64-3.12.0-rc2.tar.gz"
             }
           },
           "typedb_loader_artifact_linux-x86_64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-linux-x86_64/versions/3.12.0-rc0/typedb-loader-linux-x86_64-3.12.0-rc0.tar.gz"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-linux-x86_64/versions/3.12.0-rc2/typedb-loader-linux-x86_64-3.12.0-rc2.tar.gz"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
@@ -5342,16 +5342,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-mac-arm64/versions/3.12.0-rc0/typedb-loader-mac-arm64-3.12.0-rc0.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-mac-arm64/versions/3.12.0-rc2/typedb-loader-mac-arm64-3.12.0-rc2.zip"
               ],
-              "downloaded_file_path": "typedb-loader-mac-arm64-3.12.0-rc0.zip"
+              "downloaded_file_path": "typedb-loader-mac-arm64-3.12.0-rc2.zip"
             }
           },
           "typedb_loader_artifact_mac-arm64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-mac-arm64/versions/3.12.0-rc0/typedb-loader-mac-arm64-3.12.0-rc0.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-mac-arm64/versions/3.12.0-rc2/typedb-loader-mac-arm64-3.12.0-rc2.zip"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
@@ -5361,16 +5361,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-mac-x86_64/versions/3.12.0-rc0/typedb-loader-mac-x86_64-3.12.0-rc0.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-mac-x86_64/versions/3.12.0-rc2/typedb-loader-mac-x86_64-3.12.0-rc2.zip"
               ],
-              "downloaded_file_path": "typedb-loader-mac-x86_64-3.12.0-rc0.zip"
+              "downloaded_file_path": "typedb-loader-mac-x86_64-3.12.0-rc2.zip"
             }
           },
           "typedb_loader_artifact_mac-x86_64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-mac-x86_64/versions/3.12.0-rc0/typedb-loader-mac-x86_64-3.12.0-rc0.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-mac-x86_64/versions/3.12.0-rc2/typedb-loader-mac-x86_64-3.12.0-rc2.zip"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
@@ -5380,16 +5380,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-windows-x86_64/versions/3.12.0-rc0/typedb-loader-windows-x86_64-3.12.0-rc0.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-windows-x86_64/versions/3.12.0-rc2/typedb-loader-windows-x86_64-3.12.0-rc2.zip"
               ],
-              "downloaded_file_path": "typedb-loader-windows-x86_64-3.12.0-rc0.zip"
+              "downloaded_file_path": "typedb-loader-windows-x86_64-3.12.0-rc2.zip"
             }
           },
           "typedb_loader_artifact_windows-x86_64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-windows-x86_64/versions/3.12.0-rc0/typedb-loader-windows-x86_64-3.12.0-rc0.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-loader-windows-x86_64/versions/3.12.0-rc2/typedb-loader-windows-x86_64-3.12.0-rc2.zip"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -27,12 +27,8 @@ use database::query::{
     StreamQueryOutputDescriptor, WriteQueryAnswer, WriteQueryResult, execute_schema_query,
     execute_write_query_in_schema, execute_write_query_in_write,
 };
-use diagnostics::{
-    diagnostics_manager::DiagnosticsManager,
-    metrics::{
-        ActionKind, ClientEndpoint, LoadKind, ReadQueryMetrics, SchemaQueryMetrics, TransactionMetrics,
-        WriteQueryMetrics,
-    },
+use diagnostics::metrics::{
+    ActionKind, ClientEndpoint, ReadQueryMetrics, SchemaQueryMetrics, TransactionMetrics, WriteQueryMetrics,
 };
 use encoding::graph::thing::{ThingVertex, vertex_attribute::AttributeVertex, vertex_object::ObjectVertex};
 use executor::{

--- a/server/service/grpc/typedb_service.rs
+++ b/server/service/grpc/typedb_service.rs
@@ -300,7 +300,7 @@ impl typedb_protocol::type_db_server::TypeDb for GRPCTypeDBService {
 
                 self.server_state
                     .users()
-                    .create(accessor, user, credential)
+                    .create(accessor, user, credential, None, None)
                     .await
                     .map(|_| Response::new(user_create_res()))
                     .map_err(|err| err.into_status())

--- a/server/service/http/typedb_service.rs
+++ b/server/service/http/typedb_service.rs
@@ -479,7 +479,7 @@ impl HTTPTypeDBService {
                 service
                     .server_state
                     .users()
-                    .create(accessor, user, credential)
+                    .create(accessor, user, credential, None, None)
                     .await
                     .map_err(|typedb_source| HttpServiceError::State { typedb_source })
             },

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -6,11 +6,7 @@
 use std::{sync::Arc, time::Duration};
 
 use concept::error::ConceptDecodeError;
-use database::transaction::{
-    CommitIntent, DataCommitError, SchemaCommitError, TransactionError, TransactionRead, TransactionSchema,
-    TransactionWrite,
-};
-use diagnostics::metrics::LoadKind;
+use database::transaction::{CommitIntent, TransactionError, TransactionSchema, TransactionWrite};
 use error::typedb_error;
 use executor::{InterruptType, pipeline::PipelineExecutionError};
 use query::error::QueryError;

--- a/server/state/user_operator.rs
+++ b/server/state/user_operator.rs
@@ -14,6 +14,7 @@ use database::database_manager::DatabaseManager;
 use resource::constants::server::DEFAULT_USER_NAME;
 use system::concepts::{Credential, User};
 use user::{permission_manager::PermissionManager, user_manager::UserManager};
+use uuid::Uuid;
 
 use super::TransactionOperator;
 use crate::{
@@ -30,7 +31,14 @@ pub trait UserOperator: Debug + Send + Sync {
 
     async fn get(&self, accessor: Accessor, name: &str) -> Result<User, ArcServerStateError>;
 
-    async fn create(&self, accessor: Accessor, user: User, credential: Credential) -> Result<(), ArcServerStateError>;
+    async fn create(
+        &self,
+        accessor: Accessor,
+        user: User,
+        credential: Credential,
+        user_uuid: Option<Uuid>,
+        credential_uuid: Option<Uuid>,
+    ) -> Result<(), ArcServerStateError>;
 
     async fn update(
         &self,
@@ -147,14 +155,23 @@ impl UserOperator for LocalUserOperator {
         }
     }
 
-    async fn create(&self, accessor: Accessor, user: User, credential: Credential) -> Result<(), ArcServerStateError> {
+    async fn create(
+        &self,
+        accessor: Accessor,
+        user: User,
+        credential: Credential,
+        user_uuid: Option<Uuid>,
+        credential_uuid: Option<Uuid>,
+    ) -> Result<(), ArcServerStateError> {
         if !PermissionManager::exec_user_create_permitted(accessor.as_str()) {
             return Err(Arc::new(LocalServerStateError::OperationNotPermitted {}));
         }
 
         let user_manager = self.get_user_manager().map_err(arc_server_state_err)?;
+        let user_uuid = user_uuid.unwrap_or_else(Uuid::new_v4).to_string();
+        let credential_uuid = credential_uuid.unwrap_or_else(Uuid::new_v4).to_string();
         user_manager
-            .create(&user, &credential)
+            .create(&user, &credential, &user_uuid, &credential_uuid)
             .map_err(|typedb_source| arc_server_state_err(LocalServerStateError::UserCannotBeCreated { typedb_source }))
     }
 

--- a/server/state/user_operator.rs
+++ b/server/state/user_operator.rs
@@ -168,10 +168,10 @@ impl UserOperator for LocalUserOperator {
         }
 
         let user_manager = self.get_user_manager().map_err(arc_server_state_err)?;
-        let user_uuid = user_uuid.unwrap_or_else(Uuid::new_v4).to_string();
-        let credential_uuid = credential_uuid.unwrap_or_else(Uuid::new_v4).to_string();
+        let user_uuid = user_uuid.unwrap_or_else(Uuid::new_v4);
+        let credential_uuid = credential_uuid.unwrap_or_else(Uuid::new_v4);
         user_manager
-            .create(&user, &credential, &user_uuid, &credential_uuid)
+            .create(&user, &credential, user_uuid, credential_uuid)
             .map_err(|typedb_source| arc_server_state_err(LocalServerStateError::UserCannotBeCreated { typedb_source }))
     }
 

--- a/server/system_init.rs
+++ b/server/system_init.rs
@@ -66,6 +66,8 @@ pub async fn initialise_default_user(server_state: &ServerState) -> Result<(), A
                 accessor,
                 User::new(DEFAULT_USER_NAME.to_string()),
                 Credential::PasswordType { password_hash: PasswordHash::from_password(DEFAULT_USER_PASSWORD) },
+                None,
+                None,
             )
             .await?;
     }

--- a/system/repositories.rs
+++ b/system/repositories.rs
@@ -18,6 +18,7 @@ pub mod user_repository {
     use storage::{durability_client::WALClient, snapshot::WriteSnapshot};
     use thing_manager::ThingManager;
     use typeql::{common::identifier::is_valid_label, parse_query};
+    use uuid::Uuid;
 
     use crate::{
         concepts::{Credential, PasswordHash, User},
@@ -74,8 +75,8 @@ pub mod user_repository {
         query_manager: &QueryManager,
         user: &User,
         credentials: &Credential,
-        user_uuid: &str,
-        credential_uuid: &str,
+        user_uuid: Uuid,
+        credential_uuid: Uuid,
     ) -> (Result<(), SystemDBError>, Arc<WriteSnapshot<WALClient>>) {
         if !is_valid_typeql_value(&user.name) {
             return (Err(SystemDBError::IllegalQueryInput {}), Arc::new(snapshot));

--- a/system/repositories.rs
+++ b/system/repositories.rs
@@ -18,7 +18,6 @@ pub mod user_repository {
     use storage::{durability_client::WALClient, snapshot::WriteSnapshot};
     use thing_manager::ThingManager;
     use typeql::{common::identifier::is_valid_label, parse_query};
-    use uuid::Uuid;
 
     use crate::{
         concepts::{Credential, PasswordHash, User},
@@ -75,6 +74,8 @@ pub mod user_repository {
         query_manager: &QueryManager,
         user: &User,
         credentials: &Credential,
+        user_uuid: &str,
+        credential_uuid: &str,
     ) -> (Result<(), SystemDBError>, Arc<WriteSnapshot<WALClient>>) {
         if !is_valid_typeql_value(&user.name) {
             return (Err(SystemDBError::IllegalQueryInput {}), Arc::new(snapshot));
@@ -82,14 +83,12 @@ pub mod user_repository {
         let unexpected_error_msg = "An unexpected error occurred when attempting to create a new user";
         let (query, query_string) = match credentials {
             Credential::PasswordType { password_hash: PasswordHash { value: hash } } => {
-                let user_uuid = Uuid::new_v4().to_string();
-                let cred_uuid = Uuid::new_v4().to_string();
                 let query_string = format!(
                     "insert $u isa user, has uuid '{user_uuid}', has name '{name}';
                         $p isa password, has uuid '{cred_uuid}', has hash '{hash}';
                         (user: $u, credentials: $p) isa user-credentials;",
                     user_uuid = user_uuid,
-                    cred_uuid = cred_uuid,
+                    cred_uuid = credential_uuid,
                     name = user.name,
                     hash = hash
                 );

--- a/user/BUILD
+++ b/user/BUILD
@@ -23,6 +23,7 @@ rust_library(
         "//storage",
         "//system",
         "@typeql//rust:typeql",
+        "@crates//:uuid",
     ]
 )
 

--- a/user/Cargo.toml
+++ b/user/Cargo.toml
@@ -42,6 +42,9 @@ features = {}
 	[dependencies.error]
 		workspace = true
 
+	[dependencies.uuid]
+		workspace = true
+
 	[dependencies.lending_iterator]
 		workspace = true
 

--- a/user/user_manager.rs
+++ b/user/user_manager.rs
@@ -44,7 +44,13 @@ impl UserManager {
         self.get(username).map(|opt| opt.is_some())
     }
 
-    pub fn create(&self, user: &User, credential: &Credential) -> Result<(), UserCreateError> {
+    pub fn create(
+        &self,
+        user: &User,
+        credential: &Credential,
+        user_uuid: &str,
+        credential_uuid: &str,
+    ) -> Result<(), UserCreateError> {
         if self.contains(&user.name)? {
             return Err(UserCreateError::UserAlreadyExist {});
         }
@@ -59,6 +65,8 @@ impl UserManager {
                     &query_mgr,
                     user,
                     credential,
+                    user_uuid,
+                    credential_uuid,
                 )
             })
             .1;

--- a/user/user_manager.rs
+++ b/user/user_manager.rs
@@ -14,6 +14,7 @@ use system::{
     repositories::{user_repository, user_repository::SystemDBError},
     util::transaction_util::TransactionUtil,
 };
+use uuid::Uuid;
 
 use crate::errors::{UserCreateError, UserDeleteError, UserGetError, UserUpdateError};
 
@@ -48,8 +49,8 @@ impl UserManager {
         &self,
         user: &User,
         credential: &Credential,
-        user_uuid: &str,
-        credential_uuid: &str,
+        user_uuid: Uuid,
+        credential_uuid: Uuid,
     ) -> Result<(), UserCreateError> {
         if self.contains(&user.name)? {
             return Err(UserCreateError::UserAlreadyExist {});


### PR DESCRIPTION
## Product change and motivation

Allow passing pre-created UUIDs for users and credentials when creating a new user. This is valuable in multiple situations: e.g., in a distributed environment, where the inner state of the server must be shared 1-to-1 with the other members of a cluster (before, the UUIDs were strictly generated locally, leading to different states).

## Implementation

Add the respective optional fields everywhere starting from `UserOperator` and ending with `repositories` in `user_manager`.