### PR TITLE
Instantly cleanup transaction operator's registry on transaction close

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -190,5 +190,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "36fcf85ecdb09b42d539f9bbf4d0e2c0fa5bbea5",
+    commit = "56c893ffc90eabbf47e30f570968b4c669f148c8",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -190,5 +190,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "56c893ffc90eabbf47e30f570968b4c669f148c8",
+    commit = "d668fb0c6d42f3fa22e3c6bd8be34369c268553d",
 )

--- a/server/state/transaction_operator.rs
+++ b/server/state/transaction_operator.rs
@@ -8,15 +8,13 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
     sync::Arc,
-    time::Duration,
 };
 
 use async_trait::async_trait;
-use concurrency::{IntervalTaskParameters, TokioTaskSpawner};
+use concurrency::TokioTaskSpawner;
 use database::{database_manager::DatabaseManager, transaction::TransactionId};
 use futures::future::join_all;
 use options::TransactionOptions;
-use resource::constants::common::SECONDS_IN_MINUTE;
 use tokio::sync::{RwLock, mpsc::Sender};
 
 use crate::{
@@ -57,25 +55,12 @@ pub trait TransactionOperator: Debug + Send + Sync {
 pub struct LocalTransactionOperator {
     database_manager: Arc<DatabaseManager>,
     transactions: Arc<RwLock<HashMap<TransactionId, TransactionInfo>>>,
+    background_task_spawner: TokioTaskSpawner,
 }
 
 impl LocalTransactionOperator {
-    const CLEANUP_INTERVAL: Duration = Duration::from_secs(5 * SECONDS_IN_MINUTE);
-
     pub fn new(database_manager: Arc<DatabaseManager>, background_task_spawner: TokioTaskSpawner) -> Self {
-        let transactions: Arc<RwLock<HashMap<TransactionId, TransactionInfo>>> = Arc::new(RwLock::new(HashMap::new()));
-        let cleanup_transactions = transactions.clone();
-        background_task_spawner.spawn_interval(
-            move || {
-                let transactions = cleanup_transactions.clone();
-                async move {
-                    let mut transactions = transactions.write().await;
-                    transactions.retain(|_, info| !info.close_sender.is_closed());
-                }
-            },
-            IntervalTaskParameters::new_with_delay(Self::CLEANUP_INTERVAL, Self::CLEANUP_INTERVAL, false),
-        );
-        Self { database_manager, transactions }
+        Self { database_manager, transactions: Arc::new(RwLock::new(HashMap::new())), background_task_spawner }
     }
 
     pub async fn record(
@@ -86,8 +71,14 @@ impl LocalTransactionOperator {
         transaction_type: TransactionType,
         close_sender: Sender<()>,
     ) {
+        let close_sender_for_cleanup = close_sender.clone();
+        let transactions_for_cleanup = self.transactions.clone();
         let mut transactions = self.transactions.write().await;
         transactions.insert(transaction_id, TransactionInfo { transaction_type, database_name, owner, close_sender });
+        self.background_task_spawner.spawn(async move {
+            close_sender_for_cleanup.closed().await;
+            transactions_for_cleanup.write().await.remove(&transaction_id);
+        });
     }
 
     async fn close_matching(&self, matches: impl Fn(&TransactionInfo) -> bool) {


### PR DESCRIPTION
## Product change and motivation

Fix a bug where the transaction operator's `has` methods returned false positive answers due to stale inner caches.

## Implementation

The old design used to clean up the gracefully closed transactions from time to time, expecting no one to depend on its state. However, with the introduction of `has` methods, it required a redesign.

For simplicity, just spawn extra tokio tasks for each registered transaction to wait for the `close_sender` channel closure (which means that the other end of the channel is dropped) and remove the transaction from the cache immediately.