### PR TITLE
doc and metadata annotations don't need validation

### DIFF
--- a/concept/type_/constraint.rs
+++ b/concept/type_/constraint.rs
@@ -173,8 +173,8 @@ impl ConstraintDescription {
         match self {
             ConstraintDescription::Cardinality(_) => false, // only commit time
             ConstraintDescription::Independent(_) => false, // never
-            ConstraintDescription::Doc(_) => false, // never
-            ConstraintDescription::Meta(_) => false, // never
+            ConstraintDescription::Doc(_) => false,         // never
+            ConstraintDescription::Meta(_) => false,        // never
             _ => true,
         }
     }

--- a/concept/type_/constraint.rs
+++ b/concept/type_/constraint.rs
@@ -163,6 +163,8 @@ impl ConstraintDescription {
         match self {
             ConstraintDescription::Cardinality(cardinality) => cardinality.requires_validation(),
             ConstraintDescription::Independent(_) => false,
+            ConstraintDescription::Doc(_) => false,
+            ConstraintDescription::Meta(_) => false,
             _ => true,
         }
     }
@@ -171,6 +173,8 @@ impl ConstraintDescription {
         match self {
             ConstraintDescription::Cardinality(_) => false, // only commit time
             ConstraintDescription::Independent(_) => false, // never
+            ConstraintDescription::Doc(_) => false, // never
+            ConstraintDescription::Meta(_) => false, // never
             _ => true,
         }
     }


### PR DESCRIPTION
## Product change and motivation

We mark `@doc` and `@meta` annotations as not requiring validation. Otherwise the operation level validation of schema queries fails in debug mode as there are unhandled constraints.

## Implementation
