### PR TITLE
Show sub annotations in schema dump

### DIFF
--- a/concept/type_/annotation.rs
+++ b/concept/type_/annotation.rs
@@ -649,6 +649,15 @@ macro_rules! FromAnnotation {
                 }
             }
         }
+
+        impl std::fmt::Display for $Enum {
+            #[allow(unused_variables, reason = "`f` is unused for empty enums")]
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match *self {
+                    $($Enum::$Variant(ref annotation) => std::fmt::Display::fmt(annotation, f),)*
+                }
+            }
+        }
     };
 
     (@cat $vis:vis $Enum:ident { $($inner:tt)* } Meta $($tail:tt)*) => { FromAnnotation! { @cat $vis $Enum { $($inner)* Meta(String), } $($tail)* } };

--- a/concept/type_/attribute_type.rs
+++ b/concept/type_/attribute_type.rs
@@ -35,7 +35,7 @@ use crate::{
     error::{ConceptReadError, ConceptWriteError},
     thing::{attribute::Attribute, thing_manager::ThingManager},
     type_::{
-        KindAPI, ThingTypeAPI, TypeAPI, TypeQLSyntax,
+        Capability, KindAPI, ThingTypeAPI, TypeAPI, TypeQLSyntax,
         annotation::{
             Annotation, AnnotationAbstract, AnnotationCategory, AnnotationDoc, AnnotationError, AnnotationIndependent,
             AnnotationMeta, AnnotationRange, AnnotationRegex, AnnotationValues, FromAnnotation, HasAnnotationCategory,
@@ -44,6 +44,7 @@ use crate::{
         constraint::{CapabilityConstraint, TypeConstraint},
         object_type::ObjectType,
         owns::Owns,
+        sub::Sub,
         type_manager::TypeManager,
     },
 };
@@ -206,6 +207,7 @@ impl KindAPI for AttributeType {
     ) -> Result<MaybeOwns<'m, HashSet<TypeConstraint<AttributeType>>>, Box<ConceptReadError>> {
         type_manager.get_attribute_type_constraints(snapshot, self)
     }
+
     fn capabilities_syntax(
         &self,
         f: &mut impl std::fmt::Write,
@@ -241,6 +243,27 @@ impl KindAPI for AttributeType {
             .sorted_by_key(|annotation| annotation.category())
         {
             write!(f, " {}", annotation).map_err(|err| Box::new(err.into()))?;
+        }
+        Ok(())
+    }
+
+    fn sub_syntax(
+        &self,
+        f: &mut impl std::fmt::Write,
+        snapshot: &impl ReadableSnapshot,
+        type_manager: &TypeManager,
+    ) -> Result<(), Box<ConceptReadError>> {
+        if let Some(supertype) = self.get_supertype(snapshot, type_manager)? {
+            let supertype_label = supertype.get_label(snapshot, type_manager)?;
+            write!(f, ",\n  {} {}", typeql::token::Keyword::Sub, supertype_label.name.as_str())
+                .map_err(|err| Box::new(err.into()))?;
+            for annotation in Sub::<Self>::new(*self, supertype)
+                .get_annotations_declared(snapshot, type_manager)?
+                .iter()
+                .sorted_by_key(|annotation| annotation.category())
+            {
+                write!(f, " {}", annotation).map_err(|err| Box::new(err.into()))?;
+            }
         }
         Ok(())
     }

--- a/concept/type_/entity_type.rs
+++ b/concept/type_/entity_type.rs
@@ -19,6 +19,7 @@ use encoding::{
     layout::prefix::{Prefix, Prefix::VertexEntityType},
     value::label::Label,
 };
+use itertools::Itertools;
 use lending_iterator::higher_order::Hkt;
 use macro_rules_attribute::derive;
 use primitive::maybe_owns::MaybeOwns;
@@ -44,6 +45,7 @@ use crate::{
         owns::Owns,
         plays::Plays,
         role_type::RoleType,
+        sub::Sub,
         type_manager::TypeManager,
     },
 };
@@ -210,6 +212,27 @@ impl KindAPI for EntityType {
     ) -> Result<(), Box<ConceptReadError>> {
         self.owns_syntax(f, snapshot, type_manager)?;
         self.plays_syntax(f, snapshot, type_manager)?;
+        Ok(())
+    }
+
+    fn sub_syntax(
+        &self,
+        f: &mut impl std::fmt::Write,
+        snapshot: &impl ReadableSnapshot,
+        type_manager: &TypeManager,
+    ) -> Result<(), Box<ConceptReadError>> {
+        if let Some(supertype) = self.get_supertype(snapshot, type_manager)? {
+            let supertype_label = supertype.get_label(snapshot, type_manager)?;
+            write!(f, ",\n  {} {}", typeql::token::Keyword::Sub, supertype_label.name.as_str())
+                .map_err(|err| Box::new(err.into()))?;
+            for annotation in Sub::<Self>::new(*self, supertype)
+                .get_annotations_declared(snapshot, type_manager)?
+                .iter()
+                .sorted_by_key(|annotation| annotation.category())
+            {
+                write!(f, " {}", annotation).map_err(|err| Box::new(err.into()))?;
+            }
+        }
         Ok(())
     }
 }

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -228,13 +228,16 @@ pub trait KindAPI: TypeAPI {
         let label = self.get_label(snapshot, type_manager)?;
         write!(f, "\n{} {}", Self::KIND, label.scoped_name().as_str()).map_err(|err| Box::new(err.into()))?;
         self.type_annotations_syntax(f, snapshot, type_manager)?;
-        if let Some(supertype) = self.get_supertype(snapshot, type_manager)? {
-            let supertype_label = supertype.get_label(snapshot, type_manager)?;
-            write!(f, ",\n  {} {}", typeql::token::Keyword::Sub, supertype_label.name.as_str())
-                .map_err(|err| Box::new(err.into()))?;
-        }
+        self.sub_syntax(f, snapshot, type_manager)?;
         Ok(())
     }
+
+    fn sub_syntax(
+        &self,
+        f: &mut impl std::fmt::Write,
+        snapshot: &impl ReadableSnapshot,
+        type_manager: &TypeManager,
+    ) -> Result<(), Box<ConceptReadError>>;
 
     fn type_annotations_syntax(
         &self,

--- a/concept/type_/relation_type.rs
+++ b/concept/type_/relation_type.rs
@@ -46,6 +46,7 @@ use crate::{
         plays::Plays,
         relates::Relates,
         role_type::RoleType,
+        sub::Sub,
         type_manager::TypeManager,
     },
 };
@@ -206,6 +207,27 @@ impl KindAPI for RelationType {
         self.relates_syntax(f, snapshot, type_manager)?;
         self.owns_syntax(f, snapshot, type_manager)?;
         self.plays_syntax(f, snapshot, type_manager)?;
+        Ok(())
+    }
+
+    fn sub_syntax(
+        &self,
+        f: &mut impl std::fmt::Write,
+        snapshot: &impl ReadableSnapshot,
+        type_manager: &TypeManager,
+    ) -> Result<(), Box<ConceptReadError>> {
+        if let Some(supertype) = self.get_supertype(snapshot, type_manager)? {
+            let supertype_label = supertype.get_label(snapshot, type_manager)?;
+            write!(f, ",\n  {} {}", typeql::token::Keyword::Sub, supertype_label.name.as_str())
+                .map_err(|err| Box::new(err.into()))?;
+            for annotation in Sub::<Self>::new(*self, supertype)
+                .get_annotations_declared(snapshot, type_manager)?
+                .iter()
+                .sorted_by_key(|annotation| annotation.category())
+            {
+                write!(f, " {}", annotation).map_err(|err| Box::new(err.into()))?;
+            }
+        }
         Ok(())
     }
 }

--- a/concept/type_/role_type.rs
+++ b/concept/type_/role_type.rs
@@ -203,6 +203,15 @@ impl KindAPI for RoleType {
     ) -> Result<(), Box<ConceptReadError>> {
         Ok(())
     }
+
+    fn sub_syntax(
+        &self,
+        _f: &mut impl std::fmt::Write,
+        _snapshot: &impl ReadableSnapshot,
+        _type_manager: &TypeManager,
+    ) -> Result<(), Box<ConceptReadError>> {
+        Ok(())
+    }
 }
 
 impl RoleType {


### PR DESCRIPTION
## Product change and motivation

Fix a bug where `sub` annotations (`@doc` and `@meta`) would not be retrieved when retrieving database schema.

## Implementation

