### PR TITLE
Fix writes deadlock for huge commits

### DIFF
--- a/storage/keyspace/rocks_resources.rs
+++ b/storage/keyspace/rocks_resources.rs
@@ -21,9 +21,7 @@ impl RocksResources {
     /// it is possible to exceed it with pinned index and filter blocks
     pub fn new(cache_limit: ByteSize, write_buffers_limit: ByteSize) -> Self {
         let cache = Cache::new_lru_cache(cache_limit.as_usize());
-        // `allow_stall=true` lets RocksDB pause writes when the buffer manager
-        // is over budget, instead of OOM'ing the process.
-        let write_buffer_manager = WriteBufferManager::new_write_buffer_manager(write_buffers_limit.as_usize(), true);
+        let write_buffer_manager = WriteBufferManager::new_write_buffer_manager(write_buffers_limit.as_usize(), false);
         Self { cache, write_buffer_manager, cache_limit, write_buffers_limit }
     }
 


### PR DESCRIPTION
## Product change and motivation

Fix a deadlock in large (> configured RocksDB write buffer manager limit) commits, by undoing the `allow_stall` parameter in the write buffer manager. This means that write buffers can now temporarily exceed the configured memory budget.

## Implementation

RocksDB's WriteBufferManager schedules extra flushes on the write path of a RocksDB memtable when a write finds the memory budget reached. This design works when the write buffer manager spans a single RocksDB instance containing multiple column families - all managed memory is reachable from any write.

However, TypeDB shards across multiple independent RocksDB instances (keyspaces) instead of column families, and applies a commit's write batches to them sequentially from one thread. The memory therefore accumulates in the keyspaces written earlier in the commit - which receive no further writes and are never flushed [not reachable by the manager] - until the write to the next keyspace finds the budget exceeded and stalls. Since the stalled thread is the only writer, nothing can ever trigger the flush in another DB that would free memory and lift the stall: the commit deadlocks permanently. 

Rather than addressing the underlying cause here, we treat the write buffer limit as advisory - it triggers an early flush on each keyspace's RocksDB instance as we write to it - rather than as a hard cap.

