### PR TITLE
String comparison fix

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -190,5 +190,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "5a964ec2004ec2af1e6df528234a3214ae7c75e0",
+    commit = "c07e412aaddfd0a07e0a8350a55f969ae8610925",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -190,5 +190,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "d668fb0c6d42f3fa22e3c6bd8be34369c268553d",
+    commit = "5a964ec2004ec2af1e6df528234a3214ae7c75e0",
 )

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -573,11 +573,13 @@ impl ThingManager {
                     lower_value,
                     self.vertex_generator.hasher(),
                 );
-                let storage_key_prefix = match vertex_or_prefix {
-                    Either::First(vertex) => vertex.into_storage_key(),
-                    Either::Second(incomplete_attribute_prefix) => incomplete_attribute_prefix,
-                };
-                RangeStart::Inclusive(storage_key_prefix)
+                match vertex_or_prefix {
+                    Either::First(vertex) => RangeStart::ExcludePrefix(vertex.into_storage_key()),
+                    Either::Second(incomplete_attribute_prefix) => {
+                        // we have to include values above the bound which may share prefix
+                        RangeStart::Inclusive(incomplete_attribute_prefix)
+                    }
+                }
             }
             Bound::Unbounded => RangeStart::Inclusive(
                 AttributeVertex::build_prefix_type(
@@ -615,11 +617,13 @@ impl ThingManager {
                     upper_value,
                     self.vertex_generator.hasher(),
                 );
-                let storage_key_prefix = match vertex_or_prefix {
-                    Either::First(vertex) => vertex.into_storage_key(),
-                    Either::Second(incomplete_attribute_prefix) => incomplete_attribute_prefix,
-                };
-                RangeEnd::EndPrefixInclusive(storage_key_prefix)
+                match vertex_or_prefix {
+                    Either::First(vertex) => RangeEnd::EndPrefixExclusive(vertex.into_storage_key()),
+                    Either::Second(incomplete_attribute_prefix) => {
+                        // we have to include values below the bound which may share prefix
+                        RangeEnd::EndPrefixInclusive(incomplete_attribute_prefix)
+                    }
+                }
             }
             Bound::Unbounded => {
                 let prefix = AttributeVertex::build_prefix_type(

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -577,7 +577,7 @@ impl ThingManager {
                     Either::First(vertex) => vertex.into_storage_key(),
                     Either::Second(incomplete_attribute_prefix) => incomplete_attribute_prefix,
                 };
-                RangeStart::ExcludePrefix(storage_key_prefix)
+                RangeStart::Inclusive(storage_key_prefix)
             }
             Bound::Unbounded => RangeStart::Inclusive(
                 AttributeVertex::build_prefix_type(
@@ -619,7 +619,7 @@ impl ThingManager {
                     Either::First(vertex) => vertex.into_storage_key(),
                     Either::Second(incomplete_attribute_prefix) => incomplete_attribute_prefix,
                 };
-                RangeEnd::EndPrefixExclusive(storage_key_prefix)
+                RangeEnd::EndPrefixInclusive(storage_key_prefix)
             }
             Bound::Unbounded => {
                 let prefix = AttributeVertex::build_prefix_type(

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -743,8 +743,8 @@ impl StringAttributeID {
         bytes: &mut [u8],
     ) -> usize {
         debug_assert!(bytes.len() >= Self::LENGTH);
-        bytes.fill(0);
         bytes[0..Self::VALUE_TYPE_LENGTH].copy_from_slice(&ValueTypeCategory::String.to_bytes());
+        bytes[Self::HASHED_PREFIX_RANGE].fill(0);
         let prefix_len = usize::min(Self::HASHED_PREFIX_LENGTH, string.len());
         bytes[Self::HASHED_PREFIX_RANGE.start..][..prefix_len].copy_from_slice(&string.bytes()[..prefix_len]);
         Self::VALUE_TYPE_LENGTH + Self::HASHED_PREFIX_LENGTH

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -280,10 +280,9 @@ impl AttributeID {
             ValueTypeCategory::DateTime => (DateTimeAttributeID::write(value.encode_date_time(), bytes), true),
             ValueTypeCategory::DateTimeTZ => (DateTimeTZAttributeID::write(value.encode_date_time_tz(), bytes), true),
             ValueTypeCategory::Duration => (DurationAttributeID::write(value.encode_duration(), bytes), true),
-            ValueTypeCategory::String => (
-                StringAttributeID::write_deterministic_prefix(value.encode_string::<64>(), large_value_hasher, bytes),
-                false,
-            ),
+            ValueTypeCategory::String => {
+                (StringAttributeID::write_deterministic_prefix(value.encode_string::<64>(), bytes), false)
+            }
             ValueTypeCategory::Struct => (
                 StructAttributeID::write_hashed_id_deterministic_prefix(
                     value.encode_struct::<64>(),
@@ -741,20 +740,14 @@ impl StringAttributeID {
     // write the deterministic prefix of the hash ID, and return the length of the prefix written
     pub(crate) fn write_deterministic_prefix<const INLINE_LENGTH: usize>(
         string: StringBytes<INLINE_LENGTH>,
-        hasher: &impl Fn(&[u8]) -> u64,
         bytes: &mut [u8],
     ) -> usize {
         debug_assert!(bytes.len() >= Self::LENGTH);
-        if Self::is_inlineable(string.as_reference()) {
-            let bytes_range = &mut bytes[0..Self::LENGTH];
-            Self::write_inline_id(bytes_range.try_into().unwrap(), string);
-            Self::LENGTH
-        } else {
-            bytes[0..Self::VALUE_TYPE_LENGTH].copy_from_slice(&ValueTypeCategory::String.to_bytes());
-            bytes[Self::HASHED_PREFIX_RANGE].copy_from_slice(&string.bytes()[0..{ Self::HASHED_PREFIX_LENGTH }]);
-            let hash_length = Self::write_hash(&mut bytes[Self::HASHED_HASH_RANGE], hasher, string.bytes());
-            Self::VALUE_TYPE_LENGTH + Self::HASHED_PREFIX_LENGTH + hash_length
-        }
+        bytes.fill(0);
+        bytes[0..Self::VALUE_TYPE_LENGTH].copy_from_slice(&ValueTypeCategory::String.to_bytes());
+        let prefix_len = usize::min(Self::HASHED_PREFIX_LENGTH, string.len());
+        bytes[Self::HASHED_PREFIX_RANGE.start..][..prefix_len].copy_from_slice(&string.bytes()[..prefix_len]);
+        Self::VALUE_TYPE_LENGTH + Self::HASHED_PREFIX_LENGTH
     }
 
     ///

--- a/executor/tests/efficiency.rs
+++ b/executor/tests/efficiency.rs
@@ -223,7 +223,7 @@ fn setup_database(storage: &mut Arc<MVCCStorage<WALClient>>) {
            has name "abby",
            has name "bolton",
            has name "longy-mc-long-face-uninlineable"
-           has name "willa";
+           has name "willow";
 
          $person_3 isa person,
            has age 10,
@@ -276,7 +276,7 @@ fn setup_database(storage: &mut Arc<MVCCStorage<WALClient>>) {
     let name_uninlineable = thing_manager
         .create_attribute(&mut snapshot, name_type, Value::String(Cow::Borrowed(VALUE_STRING_LONG_UNINLINEABLE)))
         .unwrap();
-    let name_willa = thing_manager
+    let name_willow = thing_manager
         .create_attribute(&mut snapshot, name_type, Value::String(Cow::Borrowed(VALUE_STRING_WILLOW)))
         .unwrap();
 
@@ -292,7 +292,7 @@ fn setup_database(storage: &mut Arc<MVCCStorage<WALClient>>) {
     person_2.set_has_unordered(&mut snapshot, &thing_manager, &name_abby, StorageCounters::DISABLED).unwrap();
     person_2.set_has_unordered(&mut snapshot, &thing_manager, &name_bolton, StorageCounters::DISABLED).unwrap();
     person_2.set_has_unordered(&mut snapshot, &thing_manager, &name_uninlineable, StorageCounters::DISABLED).unwrap();
-    person_2.set_has_unordered(&mut snapshot, &thing_manager, &name_willa, StorageCounters::DISABLED).unwrap();
+    person_2.set_has_unordered(&mut snapshot, &thing_manager, &name_willow, StorageCounters::DISABLED).unwrap();
 
     let person_3 = thing_manager.create_entity(&mut snapshot, person_type).unwrap();
     person_3.set_has_unordered(&mut snapshot, &thing_manager, &age_10, StorageCounters::DISABLED).unwrap();

--- a/executor/tests/efficiency.rs
+++ b/executor/tests/efficiency.rs
@@ -1222,8 +1222,13 @@ fn value_string_inequality_reduces_has_reads_bound_owner() {
     // 2 seeks: each of the 2 comparison check filters get the value of the Attribute repeatedly...
     //      TODO: if we embed the Value cache into the AttributeVertex, this could be avoided? Note: only expensive for un-inlined values!
     assert_eq!(storage_counters.get_raw_seek().unwrap(), 8);
-    // 2 advance: the iterator matching person 1 will advance twice (once to find the second name, then to fail)
-    assert_eq!(storage_counters.get_raw_advance().unwrap(), 2)
+    // 3 advance: the iterator matching person 1 will advance three times:
+    // - once to find the second name "longy-etc",
+    // - once to find "willow", which has the same prefix as the upper bound so we continue
+    // - once to find the next prefix (end of `name`s in this case)
+    // Note that it is impossible in this case to have a match past "willow" but we do not have the information that we may
+    // stop the search.
+    assert_eq!(storage_counters.get_raw_advance().unwrap(), 3)
 }
 
 #[test]


### PR DESCRIPTION
## Product change and motivation

Fix the bug where during retrieval of a string attribute, the comparison bounds were applied incorrectly, discarding more answers than expected.

## Implementation

String values are encoded as follows:
- `[VVVVVVVVVVVVVVVVL]` if the string can fit in 16 bytes,
- `[VVVVVVVVHHHHHHHHD]` if it's 17 bytes or longer.
Where `V` is a value byte, `L` is the length, `H` is a hash byte, and `D` is a disambiguator byte in case of collisions.

When constructing the lookup prefix, we must keep it to the first 8 bytes of the string value. Otherwise, the value bytes from the 9th onwards will filter the longer strings by the first bytes of their _hash_ which is incorrect.

We also fix the bound handling when a value range uses prefixes rather than full values.

Closes #7869 
