### PR TITLE
Fix 'given' HTTP api bugs

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -190,5 +190,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "c07e412aaddfd0a07e0a8350a55f969ae8610925",
+    commit = "4b09ab8f7f5fcb27b4926a1707ddd11402502f07",
 )

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -175,9 +175,9 @@ pub enum TaggedEntryPayload {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum GivenEntryPayload {
-    PlainString(String),
-    PlainNumber(serde_json::Number),
-    PlainBool(bool),
+    RawString(String),
+    RawNumber(serde_json::Number),
+    RawBool(bool),
     Concept(TaggedEntryPayload),
 }
 
@@ -225,7 +225,7 @@ impl GivenRows for GivenRowsHttp {
     ) -> Result<GivenRowEntry, GivenRowDecodeError> {
         if let Some(item) = item {
             match item {
-                GivenEntryPayload::PlainNumber(value) => {
+                GivenEntryPayload::RawNumber(value) => {
                     let FunctionParameterAnnotation::Value(expected_type) = expected_type else {
                         return Err(GivenRowDecodeError::ExpectedInstanceReceivedValue {});
                     };
@@ -241,7 +241,7 @@ impl GivenRows for GivenRowsHttp {
                     })?;
                     Ok(GivenRowEntry::Value(decoded_value))
                 }
-                GivenEntryPayload::PlainBool(value) => {
+                GivenEntryPayload::RawBool(value) => {
                     let FunctionParameterAnnotation::Value(expected_type) = expected_type else {
                         return Err(GivenRowDecodeError::ExpectedInstanceReceivedValue {});
                     };
@@ -254,7 +254,7 @@ impl GivenRows for GivenRowsHttp {
                         }),
                     }
                 }
-                GivenEntryPayload::PlainString(value) => match expected_type {
+                GivenEntryPayload::RawString(value) => match expected_type {
                     FunctionParameterAnnotation::AnyConcept => unreachable!("Can't be"),
                     FunctionParameterAnnotation::Concept(expected_type) => decode_string_as_iid(value, expected_type),
                     FunctionParameterAnnotation::Value(expected_type) => decode_string_as_value(value, expected_type),
@@ -338,9 +338,10 @@ fn decode_string_as_iid(iid_string: String, _types: &BTreeSet<Type>) -> Result<G
 }
 
 fn decode_string_as_value(value: String, expected_type: &ValueType) -> Result<GivenRowEntry, GivenRowDecodeError> {
-    let parsed_value = if expected_type == &ValueType::String {
-        parse_value(format!("\"{value}\"").as_str())
-    } else if expected_type == &ValueType::Decimal && !value.as_str().ends_with("dec") {
+    if expected_type == &ValueType::String {
+        return Ok(GivenRowEntry::Value(Value::String(value.into())));
+    }
+    let parsed_value = if expected_type == &ValueType::Decimal && !value.as_str().ends_with("dec") {
         parse_value(format!("{value}dec").as_str())
     } else {
         parse_value(value.as_str())
@@ -374,7 +375,10 @@ pub fn decode_value(value: ValueResponse) -> Result<Value<'static>, GivenRowDeco
     }
     let as_str = value.value.to_string();
     match value.value_type.as_str() {
-        "decimal" => decode(&format!("{}dec", &as_str[1..as_str.len() - 1])),
+        "decimal" => {
+            let literal = &as_str[1..as_str.len() - 1];
+            decode(&if literal.ends_with("dec") { literal.to_owned() } else { format!("{literal}dec") })
+        }
         "date" | "datetime" | "datetime-tz" | "duration" => decode(&as_str[1..as_str.len() - 1]),
         _ => decode(&as_str),
     }

--- a/tests/behaviour/service/http/http_steps/query.rs
+++ b/tests/behaviour/service/http/http_steps/query.rs
@@ -23,7 +23,7 @@ use server::service::{
                 encode_pipeline_structure_as_functor,
             },
         },
-        query::{GivenEntryPayload, GivenRowsPayload, QueryAnswerResponse},
+        query::{GivenEntryPayload, GivenRowsPayload, QueryAnswerResponse, TaggedEntryPayload, concept::ValueResponse},
     },
 };
 
@@ -159,7 +159,7 @@ fn check_is_value(
 #[cucumber::when(expr = "set answers of typeql read query as given rows with order: {variable_list}")]
 #[cucumber::given(expr = "set answers of typeql read query as given rows dictionary with variables: {variable_list}")]
 #[cucumber::when(expr = "set answers of typeql read query as given rows dictionary with variables: {variable_list}")]
-async fn set_given_rows(context: &mut Context, var_list: VariableList, step: &Step) {
+async fn set_answers_of_typeql_read_query_as_given_rows(context: &mut Context, var_list: VariableList, step: &Step) {
     let result = (transactions_query(
         context.http_client(),
         context.auth_token(),
@@ -190,6 +190,55 @@ async fn set_given_rows(context: &mut Context, var_list: VariableList, step: &St
     }
 
     context.given_rows = Some(GivenRowsPayload(given_rows))
+}
+
+#[cucumber::given("set query given rows")]
+#[cucumber::when("set query given rows")]
+async fn set_query_given_rows(context: &mut Context, step: &Step) {
+    let table = step.table().expect("Expected a data table for 'set query given rows'");
+    let variables: Vec<String> =
+        table.rows[0].iter().map(|cell| cell.split(':').next().unwrap().trim().to_owned()).collect();
+    let mut given_rows = Vec::with_capacity(table.rows.len().saturating_sub(1));
+    for row in &table.rows[1..] {
+        let entry = variables
+            .iter()
+            .cloned()
+            .zip(row.iter().map(|cell| parse_literal_given_entry(cell.trim())))
+            .collect::<BTreeMap<String, Option<GivenEntryPayload>>>();
+        given_rows.push(entry);
+    }
+    context.given_rows = Some(GivenRowsPayload(given_rows));
+}
+
+fn parse_literal_given_entry(cell: &str) -> Option<GivenEntryPayload> {
+    if cell == "none" {
+        return None;
+    }
+    let mut parts = cell.splitn(3, ':');
+    let encoding = parts.next().unwrap();
+    let value_type = parts.next().expect("expected <encoding>:<type>:<value>");
+    let value = parts.next().expect("expected <encoding>:<type>:<value>");
+    Some(match encoding {
+        "raw" => match value_type {
+            "boolean" => GivenEntryPayload::RawBool(value.parse().unwrap()),
+            "integer" => GivenEntryPayload::RawNumber(value.parse::<i64>().unwrap().into()),
+            "double" => GivenEntryPayload::RawNumber(serde_json::Number::from_f64(value.parse().unwrap()).unwrap()),
+            _ => GivenEntryPayload::RawString(value.to_owned()),
+        },
+        "value" => {
+            let json_value = match value_type {
+                "boolean" => serde_json::Value::Bool(value.parse().unwrap()),
+                "integer" => serde_json::json!(value.parse::<i64>().unwrap()),
+                "double" => serde_json::json!(value.parse::<f64>().unwrap()),
+                _ => serde_json::Value::String(value.to_owned()),
+            };
+            GivenEntryPayload::Concept(TaggedEntryPayload::Value(ValueResponse {
+                value: json_value,
+                value_type: value_type.to_owned(),
+            }))
+        }
+        other => panic!("Unknown given-entry encoding '{other}', expected 'raw', 'value', or 'none'"),
+    })
 }
 
 #[apply(generic_step)]

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -246,9 +246,9 @@ fn may_take_given_rows(context: &mut Context, with_given: params::WithGiven) -> 
     (with_given == params::WithGiven::True).then(|| context.take_given_rows().expect("Expected given rows available"))
 }
 
-#[cucumber::given("query is given rows")]
-#[cucumber::when("query is given rows")]
-async fn given_rows(context: &mut Context, step: &Step) {
+#[cucumber::given("set query given rows")]
+#[cucumber::when("set query given rows")]
+async fn set_query_given_rows(context: &mut Context, step: &Step) {
     let table = step.table.as_ref().expect("Expected table for given rows");
     let length = table.rows.len();
     let width = table.rows.first().unwrap().len() as u32;
@@ -786,9 +786,9 @@ fn parse_query_given_row_entry(entry: &String) -> GivenRowEntry {
         "none" => GivenRowEntry::None,
         "value" => {
             let value_type_str = parts.next().expect("value:<value-type>:<value>");
-            let value_str = parts.next().expect("value:<value-type>:<value>");
+            let value_str = parts.collect::<Vec<&str>>().join(":");
             let expected_value_type = parse_value_type(value_type_str);
-            let value = params::Value::from_str(value_str).unwrap().into_typedb(expected_value_type);
+            let value = params::Value::from_str(&value_str).unwrap().into_typedb(expected_value_type);
             GivenRowEntry::Value(value)
         }
         "iid" => {


### PR DESCRIPTION
## Product change and motivation

We fix bugs discovered by implementing BDD tests for HTTP requests using raw values for 'given' input rows.

## Implementation

- Add new step 'set given rows to'
- Fix Decimal and String acceptance bugs in the raw HTTP api
