### PR TITLE
Fix admin tool's RPC error representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5801,6 +5801,7 @@ dependencies = [
  "test_utils",
  "tokio",
  "tonic",
+ "tonic-types",
  "tower 0.4.13",
  "typeql",
 ]

--- a/admin/client/BUILD
+++ b/admin/client/BUILD
@@ -25,6 +25,7 @@ rust_library(
         "@crates//:hyper-util",
         "@crates//:tokio",
         "@crates//:tonic",
+        "@crates//:tonic-types",
         "@crates//:tower",
         "@typeql//rust:typeql",
     ],

--- a/admin/client/Cargo.toml
+++ b/admin/client/Cargo.toml
@@ -26,6 +26,9 @@ features = {}
 	[dependencies.hyper-util]
 		workspace = true
 
+	[dependencies.tonic-types]
+		workspace = true
+
 	[dependencies.rustyline]
 		workspace = true
 

--- a/admin/client/error.rs
+++ b/admin/client/error.rs
@@ -12,7 +12,7 @@ use tonic_types::StatusExt;
 typedb_error! {
     pub AdminError(component = "Admin", prefix = "ADM") {
         ConnectionFailed(1, "Failed to connect to '{address}'.", address: String, source: Arc<tonic::transport::Error>),
-        RpcFailed(2, "{message}", message: String),
+        RpcFailed(2, "Request failed.\n{cause}", cause: String),
         InvalidArgCount(3, "Invalid number of arguments. Usage: {usage}", usage: String),
         InvalidArgument(4, "Invalid argument '{name}': {reason}", name: String, reason: String),
         UnknownCommand(5, "Unknown command: '{input}'. Type 'help' for available commands.", input: String),
@@ -33,19 +33,16 @@ impl From<tonic::Status> for AdminError {
     fn from(status: tonic::Status) -> Self {
         if let Ok(details) = status.check_error_details() {
             if let Some(error_info) = details.error_info() {
-                let stack_trace =
-                    details.debug_info().map(|debug_info| debug_info.stack_entries.clone()).unwrap_or_default();
-                let message = if stack_trace.is_empty() {
-                    format!("[{}] {}", error_info.reason, error_info.domain)
-                } else {
-                    stack_trace.join("\nCaused: ")
+                let cause = match details.debug_info() {
+                    Some(debug_info) if !debug_info.stack_entries.is_empty() => debug_info.stack_entries.join("\n"),
+                    _ => format!("[{}] {}", error_info.reason, error_info.domain),
                 };
-                return Self::RpcFailed { message };
+                return Self::RpcFailed { cause };
             }
         }
         let code = status.code();
         let message = status.message();
-        let formatted = if message.is_empty() { format!("{code}") } else { format!("{code}: {message}") };
-        Self::RpcFailed { message: formatted }
+        let cause = if message.is_empty() { format!("{code}") } else { format!("{code}: {message}") };
+        Self::RpcFailed { cause }
     }
 }

--- a/admin/client/error.rs
+++ b/admin/client/error.rs
@@ -7,6 +7,7 @@
 use std::sync::Arc;
 
 use error::typedb_error;
+use tonic_types::StatusExt;
 
 typedb_error! {
     pub AdminError(component = "Admin", prefix = "ADM") {
@@ -30,6 +31,18 @@ typedb_error! {
 
 impl From<tonic::Status> for AdminError {
     fn from(status: tonic::Status) -> Self {
+        if let Ok(details) = status.check_error_details() {
+            if let Some(error_info) = details.error_info() {
+                let stack_trace =
+                    details.debug_info().map(|debug_info| debug_info.stack_entries.clone()).unwrap_or_default();
+                let message = if stack_trace.is_empty() {
+                    format!("[{}] {}", error_info.reason, error_info.domain)
+                } else {
+                    stack_trace.join("\nCaused: ")
+                };
+                return Self::RpcFailed { message };
+            }
+        }
         let code = status.code();
         let message = status.message();
         let formatted = if message.is_empty() { format!("{code}") } else { format!("{code}: {message}") };


### PR DESCRIPTION
## Product change and motivation

`RpcFailed` error of the admin tool used to swallow the details of the error message by ignoring the error details that are used excessively by the server.  

Now, we print the errors with all the details nicely, following the usual TypeDB's error stack trace style.

Before (totally inaccurate: there were no invalid arguments):
```
[ADM2] Client specified an invalid argument: Request generated error
```

Now:
```
[ADM2] Request failed.
[CSV5] Unable to register replica....
```

## Implementation

Parse error details in the `Status` handler of `AdminError`