### PR TITLE
Only attempt to cleanup each attribute once when owner deleted

### DIFF
--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -120,7 +120,7 @@ impl VariableModes {
 
 impl fmt::Display for VariableModes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (key, group) in &self.modes.iter().sorted_by_key(|(_, value)| *value).group_by(|(_, value)| *value) {
+        for (key, group) in &self.modes.iter().sorted_by_key(|(_, value)| *value).chunk_by(|(_, value)| *value) {
             write!(f, "{key}s=")?;
             for (var, _) in group {
                 write!(f, "{}, ", var)?;
@@ -137,7 +137,7 @@ pub struct VarMappedVariableModes {
 
 impl fmt::Display for VarMappedVariableModes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (key, group) in &self.modes.iter().sorted_by_key(|(_, value)| *value).group_by(|(_, value)| *value) {
+        for (key, group) in &self.modes.iter().sorted_by_key(|(_, value)| *value).chunk_by(|(_, value)| *value) {
             write!(f, "{key}s=")?;
             for (var, _) in group {
                 write!(f, "{}, ", var)?;

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -2097,7 +2097,7 @@ impl ThingManager {
                 Prefix::VertexAttribute.fixed_width_keys(),
             )),
             snapshot.iterate_writes_range(&KeyRange::new_within(
-                AttributeVertex::prefix_short(),
+                AttributeVertex::prefix_long(),
                 Prefix::VertexAttribute.fixed_width_keys(),
             )),
         )

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -1797,7 +1797,7 @@ impl ThingManager {
         storage_counters: StorageCounters,
     ) -> Result<(), Vec<ConceptWriteError>> {
         let cardinality_change_tracker =
-            CardinalityChangeTracker::build(snapshot, self.type_manager(), &self, storage_counters.clone())
+            CardinalityChangeTracker::build(snapshot, self.type_manager(), self, storage_counters.clone())
                 .map_err(|typedb_source| vec![ConceptWriteError::ConceptRead { typedb_source }])?;
 
         self.validate_cardinalities(snapshot, &cardinality_change_tracker, storage_counters.clone())?;
@@ -2167,7 +2167,7 @@ impl ThingManager {
                 snapshot,
                 self,
                 *object,
-                &modified_owns,
+                modified_owns,
                 &mut errors,
                 storage_counters.clone(),
             );
@@ -2179,7 +2179,7 @@ impl ThingManager {
                 snapshot,
                 self,
                 *object,
-                &modified_plays,
+                modified_plays,
                 &mut errors,
                 storage_counters.clone(),
             );
@@ -2191,7 +2191,7 @@ impl ThingManager {
                 snapshot,
                 self,
                 *relation,
-                &modified_relates,
+                modified_relates,
                 &mut errors,
                 storage_counters.clone(),
             );
@@ -2223,7 +2223,7 @@ impl ThingManager {
             self.update_relation_index_on_schema_commit(
                 snapshot,
                 *relation,
-                &modified_relates,
+                modified_relates,
                 qualifies_for_relation_index,
                 storage_counters.clone(),
             )?;
@@ -2263,8 +2263,7 @@ impl ThingManager {
         storage_counters: StorageCounters,
     ) -> Result<(), Box<ConceptWriteError>> {
         for role_type in affected_role_types {
-            let mut it = relation.get_players_by_role(snapshot, &self, *role_type, storage_counters.clone());
-            while let Some(player) = it.next() {
+            for player in relation.get_players_by_role(snapshot, self, *role_type, storage_counters.clone()) {
                 let (player, count) =
                     player.map_err(|typedb_source| Box::new(ConceptWriteError::ConceptRead { typedb_source }))?;
                 if qualifies_for_relation_index {

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -7,7 +7,7 @@
 use std::{
     borrow::Cow,
     collections::{Bound, HashMap, HashSet},
-    iter::{Map, once},
+    iter::{self, Map, once},
     ops::RangeBounds,
     sync::Arc,
 };
@@ -2065,12 +2065,22 @@ impl ThingManager {
         snapshot: &mut impl WritableSnapshot,
         storage_counters: StorageCounters,
     ) -> Result<(), Box<ConceptWriteError>> {
-        for (key, _write) in snapshot
-            .iterate_writes_range(&KeyRange::new_within(ThingEdgeHas::prefix(), ThingEdgeHas::FIXED_WIDTH_ENCODING))
-            .filter(|(_, write)| matches!(write, Write::Delete))
+        let deleted_reverse_has = iter::chain(
+            snapshot.iterate_writes_range(&KeyRange::new_within(
+                ThingEdgeHasReverse::prefix_short(),
+                ThingEdgeHasReverse::FIXED_WIDTH_ENCODING,
+            )),
+            snapshot.iterate_writes_range(&KeyRange::new_within(
+                ThingEdgeHasReverse::prefix_long(),
+                ThingEdgeHasReverse::FIXED_WIDTH_ENCODING,
+            )),
+        )
+        .filter(|(_, write)| matches!(write, Write::Delete));
+        for attribute_vertex in deleted_reverse_has
+            .map(|(key, _)| ThingEdgeHasReverse::decode(Bytes::Reference(key.byte_array())).from())
+            .dedup()
         {
-            let edge = ThingEdgeHas::decode(Bytes::Reference(key.byte_array()));
-            let attribute = Attribute::new(edge.to());
+            let attribute = Attribute::new(attribute_vertex);
             let is_independent = attribute.type_().is_independent(snapshot, self.type_manager())?;
             if attribute.get_status(snapshot, self, storage_counters.clone())? == ConceptStatus::Deleted {
                 continue;
@@ -2081,26 +2091,18 @@ impl ThingManager {
         }
 
         // link together long and short attributes
-        for (key, _value) in snapshot
-            .iterate_writes_range(&KeyRange::new_within(
-                StorageKey::new(
-                    AttributeVertex::keyspace_for_is_short(true),
-                    Bytes::inline(Prefix::VertexAttribute.prefix_id().to_bytes(), 1),
-                ),
+        let new_attributes = iter::chain(
+            snapshot.iterate_writes_range(&KeyRange::new_within(
+                AttributeVertex::prefix_short(),
                 Prefix::VertexAttribute.fixed_width_keys(),
-            ))
-            .chain(snapshot.iterate_writes_range(&KeyRange::new_within(
-                StorageKey::new(
-                    AttributeVertex::keyspace_for_is_short(false),
-                    Bytes::inline(Prefix::VertexAttribute.prefix_id().to_bytes(), 1),
-                ),
+            )),
+            snapshot.iterate_writes_range(&KeyRange::new_within(
+                AttributeVertex::prefix_short(),
                 Prefix::VertexAttribute.fixed_width_keys(),
-            )))
-            .filter_map(|(key, write)| match write {
-                Write::Put { value, .. } => Some((key, value)),
-                _ => None,
-            })
-        {
+            )),
+        )
+        .filter(|(_, write)| matches!(write, Write::Put { .. }));
+        for (key, _write) in new_attributes {
             let attribute = Attribute::new(AttributeVertex::decode(key.bytes()));
             let is_independent = attribute.type_().is_independent(snapshot, self.type_manager())?;
             if !is_independent && !attribute.has_owners(snapshot, self, storage_counters.clone())? {

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -324,7 +324,7 @@ impl ThingManager {
         let range = KeyRange::new_within(has_reverse_start, Prefix::VertexAttribute.fixed_width_keys());
         let has_reverse_iterator = HasReverseIterator::new(snapshot.iterate_range(&range, storage_counters.clone()));
         Ok(AttributeIterator::new(
-            self.get_instances::<Attribute>(AttributeVertex::keyspace_for_long_encoding(), snapshot, storage_counters),
+            self.get_instances::<Attribute>(AttributeVertex::keyspace_for_short_encoding(), snapshot, storage_counters),
             has_reverse_iterator,
             self.type_manager().get_independent_attribute_types(snapshot)?,
         ))
@@ -339,7 +339,7 @@ impl ThingManager {
         let range = KeyRange::new_within(has_reverse_start, Prefix::VertexAttribute.fixed_width_keys());
         let has_reverse_iterator = HasReverseIterator::new(snapshot.iterate_range(&range, storage_counters.clone()));
         Ok(AttributeIterator::new(
-            self.get_instances::<Attribute>(AttributeVertex::keyspace_for_short_encoding(), snapshot, storage_counters),
+            self.get_instances::<Attribute>(AttributeVertex::keyspace_for_long_encoding(), snapshot, storage_counters),
             has_reverse_iterator,
             self.type_manager().get_independent_attribute_types(snapshot)?,
         ))

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -2067,11 +2067,11 @@ impl ThingManager {
     ) -> Result<(), Box<ConceptWriteError>> {
         let deleted_reverse_has = iter::chain(
             snapshot.iterate_writes_range(&KeyRange::new_within(
-                ThingEdgeHasReverse::prefix_short(),
+                ThingEdgeHasReverse::prefix_key_short(),
                 ThingEdgeHasReverse::FIXED_WIDTH_ENCODING,
             )),
             snapshot.iterate_writes_range(&KeyRange::new_within(
-                ThingEdgeHasReverse::prefix_long(),
+                ThingEdgeHasReverse::prefix_key_long(),
                 ThingEdgeHasReverse::FIXED_WIDTH_ENCODING,
             )),
         )
@@ -2093,11 +2093,11 @@ impl ThingManager {
         // link together long and short attributes
         let new_attributes = iter::chain(
             snapshot.iterate_writes_range(&KeyRange::new_within(
-                AttributeVertex::prefix_short(),
+                AttributeVertex::prefix_key_short(),
                 Prefix::VertexAttribute.fixed_width_keys(),
             )),
             snapshot.iterate_writes_range(&KeyRange::new_within(
-                AttributeVertex::prefix_long(),
+                AttributeVertex::prefix_key_long(),
                 Prefix::VertexAttribute.fixed_width_keys(),
             )),
         )

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -324,7 +324,7 @@ impl ThingManager {
         let range = KeyRange::new_within(has_reverse_start, Prefix::VertexAttribute.fixed_width_keys());
         let has_reverse_iterator = HasReverseIterator::new(snapshot.iterate_range(&range, storage_counters.clone()));
         Ok(AttributeIterator::new(
-            self.get_instances::<Attribute>(AttributeVertex::keyspace_for_is_short(true), snapshot, storage_counters),
+            self.get_instances::<Attribute>(AttributeVertex::keyspace_for_long_encoding(), snapshot, storage_counters),
             has_reverse_iterator,
             self.type_manager().get_independent_attribute_types(snapshot)?,
         ))
@@ -339,7 +339,7 @@ impl ThingManager {
         let range = KeyRange::new_within(has_reverse_start, Prefix::VertexAttribute.fixed_width_keys());
         let has_reverse_iterator = HasReverseIterator::new(snapshot.iterate_range(&range, storage_counters.clone()));
         Ok(AttributeIterator::new(
-            self.get_instances::<Attribute>(AttributeVertex::keyspace_for_is_short(false), snapshot, storage_counters),
+            self.get_instances::<Attribute>(AttributeVertex::keyspace_for_short_encoding(), snapshot, storage_counters),
             has_reverse_iterator,
             self.type_manager().get_independent_attribute_types(snapshot)?,
         ))

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -24,7 +24,7 @@ use crate::{
         Typed,
         thing::{
             THING_VERTEX_LENGTH_PREFIX_TYPE, ThingVertex,
-            vertex_attribute::{AttributeID, AttributeVertex},
+            vertex_attribute::{AttributeID, AttributeVertex, ValueEncodingLength},
             vertex_object::{ObjectID, ObjectVertex},
         },
         type_::vertex::{TypeID, TypeVertex},
@@ -245,13 +245,13 @@ impl ThingEdgeHasReverse {
     pub fn prefix_from_prefix_short(
         from_prefix: Prefix,
     ) -> StorageKey<'static, { ThingEdgeHasReverse::LENGTH_PREFIX_FROM_PREFIX }> {
-        Self::prefix_from_prefix(from_prefix, Self::keyspace_for_is_short(true))
+        Self::prefix_from_prefix(from_prefix, Self::keyspace_for_short_encoding())
     }
 
     pub fn prefix_from_prefix_long(
         from_prefix: Prefix,
     ) -> StorageKey<'static, { ThingEdgeHasReverse::LENGTH_PREFIX_FROM_PREFIX }> {
-        Self::prefix_from_prefix(from_prefix, Self::keyspace_for_is_short(false))
+        Self::prefix_from_prefix(from_prefix, Self::keyspace_for_long_encoding())
     }
 
     fn prefix_from_prefix(
@@ -276,7 +276,9 @@ impl ThingEdgeHasReverse {
         let from_type_id_end = from_prefix_end + TypeID::LENGTH;
         bytes[from_prefix_end..from_type_id_end].copy_from_slice(&from_type_id.to_bytes());
         StorageKey::new_owned(
-            Self::keyspace_for_is_short(AttributeVertex::is_category_short_encoding(from_type_value_type_category)),
+            Self::keyspace_for_encoding_length(AttributeVertex::category_encoding_length(
+                from_type_value_type_category,
+            )),
             bytes,
         )
     }
@@ -292,8 +294,8 @@ impl ThingEdgeHasReverse {
         bytes[Self::INDEX_PREFIX] = Self::PREFIX.prefix_id().byte;
         bytes[Self::INDEX_PREFIX + 1..Self::INDEX_PREFIX + 1 + attribute_vertex_prefix.len()]
             .copy_from_slice(attribute_vertex_prefix);
-        let is_short_attribute = AttributeVertex::is_category_short_encoding(attribute_vertex_value_type_category);
-        StorageKey::new_owned(Self::keyspace_for_is_short(is_short_attribute), bytes)
+        let encoding_length = AttributeVertex::category_encoding_length(attribute_vertex_value_type_category);
+        StorageKey::new_owned(Self::keyspace_for_encoding_length(encoding_length), bytes)
     }
 
     // TODO cleanup
@@ -304,7 +306,7 @@ impl ThingEdgeHasReverse {
         bytes[Self::INDEX_PREFIX] = Self::PREFIX.prefix_id().byte;
         bytes[Self::range_from_for_vertex(from)].copy_from_slice(&from.to_bytes());
         bytes.truncate(Self::range_from_for_vertex(from).end);
-        StorageKey::new_owned(Self::keyspace_for_is_short(from.is_short_encoding()), bytes)
+        StorageKey::new_owned(Self::keyspace_for_encoding_length(from.encoding_length()), bytes)
     }
 
     pub fn prefix_from_attribute_to_type(
@@ -330,8 +332,8 @@ impl ThingEdgeHasReverse {
             to_type_id,
         );
         bytes.truncate(range_from.end + TypeVertex::LENGTH);
-        let is_from_short_encoding = from.is_short_encoding();
-        StorageKey::new_owned(Self::keyspace_for_is_short(is_from_short_encoding), bytes)
+        let from_encoding_length = from.encoding_length();
+        StorageKey::new_owned(Self::keyspace_for_encoding_length(from_encoding_length), bytes)
     }
 
     pub fn prefix_from_attribute_to_type_range(
@@ -347,11 +349,14 @@ impl ThingEdgeHasReverse {
     // end TODO
 
     pub fn prefix_short() -> StorageKey<'static, { PrefixID::LENGTH }> {
-        StorageKey::new_owned(Self::keyspace_for_is_short(true), ByteArray::copy(&Self::PREFIX.prefix_id().to_bytes()))
+        StorageKey::new_owned(
+            Self::keyspace_for_short_encoding(),
+            ByteArray::copy(&Self::PREFIX.prefix_id().to_bytes()),
+        )
     }
 
     pub fn prefix_long() -> StorageKey<'static, { PrefixID::LENGTH }> {
-        StorageKey::new_owned(Self::keyspace_for_is_short(false), ByteArray::copy(&Self::PREFIX.prefix_id().to_bytes()))
+        StorageKey::new_owned(Self::keyspace_for_long_encoding(), ByteArray::copy(&Self::PREFIX.prefix_id().to_bytes()))
     }
 
     pub fn is_has_reverse(key: StorageKeyReference<'_>) -> bool {
@@ -363,12 +368,24 @@ impl ThingEdgeHasReverse {
         }
     }
 
-    pub fn keyspace_for_is_short(is_short_attribute: bool) -> EncodingKeyspace {
-        if is_short_attribute { EncodingKeyspace::OptimisedPrefix16 } else { EncodingKeyspace::OptimisedPrefix25 }
+    fn keyspace_for_encoding_length(encoding_length: ValueEncodingLength) -> EncodingKeyspace {
+        if encoding_length.is_short() {
+            Self::keyspace_for_short_encoding()
+        } else {
+            Self::keyspace_for_long_encoding()
+        }
+    }
+
+    pub fn keyspace_for_short_encoding() -> EncodingKeyspace {
+        EncodingKeyspace::OptimisedPrefix16
+    }
+
+    pub fn keyspace_for_long_encoding() -> EncodingKeyspace {
+        EncodingKeyspace::OptimisedPrefix25
     }
 
     pub fn keyspace(&self) -> EncodingKeyspace {
-        Self::keyspace_for_is_short(self.from().is_short_encoding())
+        Self::keyspace_for_encoding_length(self.from().encoding_length())
     }
 
     pub fn from(self) -> AttributeVertex {

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -346,6 +346,14 @@ impl ThingEdgeHasReverse {
     }
     // end TODO
 
+    pub fn prefix_short() -> StorageKey<'static, { PrefixID::LENGTH }> {
+        StorageKey::new_owned(Self::keyspace_for_is_short(true), ByteArray::copy(&Self::PREFIX.prefix_id().to_bytes()))
+    }
+
+    pub fn prefix_long() -> StorageKey<'static, { PrefixID::LENGTH }> {
+        StorageKey::new_owned(Self::keyspace_for_is_short(false), ByteArray::copy(&Self::PREFIX.prefix_id().to_bytes()))
+    }
+
     pub fn is_has_reverse(key: StorageKeyReference<'_>) -> bool {
         if !key.bytes().is_empty() && key.bytes()[Self::INDEX_PREFIX] == Self::PREFIX.prefix_id().byte {
             let edge = ThingEdgeHasReverse::decode(Bytes::Reference(key.bytes()));

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -348,14 +348,14 @@ impl ThingEdgeHasReverse {
     }
     // end TODO
 
-    pub fn prefix_short() -> StorageKey<'static, { PrefixID::LENGTH }> {
+    pub fn prefix_key_short() -> StorageKey<'static, { PrefixID::LENGTH }> {
         StorageKey::new_owned(
             Self::keyspace_for_short_encoding(),
             ByteArray::copy(&Self::PREFIX.prefix_id().to_bytes()),
         )
     }
 
-    pub fn prefix_long() -> StorageKey<'static, { PrefixID::LENGTH }> {
+    pub fn prefix_key_long() -> StorageKey<'static, { PrefixID::LENGTH }> {
         StorageKey::new_owned(Self::keyspace_for_long_encoding(), ByteArray::copy(&Self::PREFIX.prefix_id().to_bytes()))
     }
 

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -111,12 +111,12 @@ impl AttributeVertex {
         self.attribute_id
     }
 
-    pub(crate) fn is_category_short_encoding(value_type_category: ValueTypeCategory) -> bool {
-        AttributeID::value_type_encoded_value_length(value_type_category).is_short()
+    pub(crate) fn category_encoding_length(value_type_category: ValueTypeCategory) -> ValueEncodingLength {
+        AttributeID::value_type_encoded_value_length(value_type_category)
     }
 
-    pub(crate) fn is_short_encoding(&self) -> bool {
-        Self::is_category_short_encoding(self.value_type_category())
+    pub(crate) fn encoding_length(&self) -> ValueEncodingLength {
+        Self::category_encoding_length(self.value_type_category())
     }
 
     fn range_of_attribute_id(&self) -> Range<usize> {
@@ -133,28 +133,40 @@ impl AttributeVertex {
 
     pub fn prefix_short() -> StorageKey<'static, { PrefixID::LENGTH }> {
         StorageKey::new(
-            AttributeVertex::keyspace_for_is_short(true),
+            AttributeVertex::keyspace_for_short_encoding(),
             Bytes::copy(&Prefix::VertexAttribute.prefix_id().to_bytes()),
         )
     }
 
     pub fn prefix_long() -> StorageKey<'static, { PrefixID::LENGTH }> {
         StorageKey::new(
-            AttributeVertex::keyspace_for_is_short(false),
+            AttributeVertex::keyspace_for_long_encoding(),
             Bytes::copy(&Prefix::VertexAttribute.prefix_id().to_bytes()),
         )
     }
 
-    pub fn keyspace_for_is_short(is_short_encoding: bool) -> EncodingKeyspace {
-        if is_short_encoding { EncodingKeyspace::DefaultOptimisedPrefix11 } else { EncodingKeyspace::OptimisedPrefix17 }
+    fn keyspace_for_encoding_length(encoding_length: ValueEncodingLength) -> EncodingKeyspace {
+        if encoding_length.is_short() {
+            Self::keyspace_for_short_encoding()
+        } else {
+            Self::keyspace_for_long_encoding()
+        }
+    }
+
+    pub fn keyspace_for_short_encoding() -> EncodingKeyspace {
+        EncodingKeyspace::DefaultOptimisedPrefix11
+    }
+
+    pub fn keyspace_for_long_encoding() -> EncodingKeyspace {
+        EncodingKeyspace::OptimisedPrefix17
     }
 
     pub fn keyspace_for_category(value_type_category: ValueTypeCategory) -> EncodingKeyspace {
-        Self::keyspace_for_is_short(AttributeID::value_type_encoded_value_length(value_type_category).is_short())
+        Self::keyspace_for_encoding_length(AttributeID::value_type_encoded_value_length(value_type_category))
     }
 
     pub(crate) fn keyspace(&self) -> EncodingKeyspace {
-        Self::keyspace_for_is_short(self.is_short_encoding())
+        Self::keyspace_for_encoding_length(self.encoding_length())
     }
 
     pub(crate) fn is_valid_keyspace(keyspace_id: KeyspaceId) -> bool {
@@ -219,7 +231,7 @@ impl ValueEncodingLength {
         }
     }
 
-    const fn is_short(&self) -> bool {
+    pub(crate) const fn is_short(&self) -> bool {
         matches!(self, Self::Short)
     }
 

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -131,6 +131,20 @@ impl AttributeVertex {
         PrefixID::LENGTH + TypeID::LENGTH + self.attribute_id.length()
     }
 
+    pub fn prefix_short() -> StorageKey<'static, { PrefixID::LENGTH }> {
+        StorageKey::new(
+            AttributeVertex::keyspace_for_is_short(true),
+            Bytes::copy(&Prefix::VertexAttribute.prefix_id().to_bytes()),
+        )
+    }
+
+    pub fn prefix_long() -> StorageKey<'static, { PrefixID::LENGTH }> {
+        StorageKey::new(
+            AttributeVertex::keyspace_for_is_short(false),
+            Bytes::copy(&Prefix::VertexAttribute.prefix_id().to_bytes()),
+        )
+    }
+
     pub fn keyspace_for_is_short(is_short_encoding: bool) -> EncodingKeyspace {
         if is_short_encoding { EncodingKeyspace::DefaultOptimisedPrefix11 } else { EncodingKeyspace::OptimisedPrefix17 }
     }

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -131,14 +131,14 @@ impl AttributeVertex {
         PrefixID::LENGTH + TypeID::LENGTH + self.attribute_id.length()
     }
 
-    pub fn prefix_short() -> StorageKey<'static, { PrefixID::LENGTH }> {
+    pub fn prefix_key_short() -> StorageKey<'static, { PrefixID::LENGTH }> {
         StorageKey::new(
             AttributeVertex::keyspace_for_short_encoding(),
             Bytes::copy(&Prefix::VertexAttribute.prefix_id().to_bytes()),
         )
     }
 
-    pub fn prefix_long() -> StorageKey<'static, { PrefixID::LENGTH }> {
+    pub fn prefix_key_long() -> StorageKey<'static, { PrefixID::LENGTH }> {
         StorageKey::new(
             AttributeVertex::keyspace_for_long_encoding(),
             Bytes::copy(&Prefix::VertexAttribute.prefix_id().to_bytes()),


### PR DESCRIPTION
## Product change and motivation

During a commit, we delete all dependent attributes that have no owners. To do that, we iterate through all deleted `has` edges and check whether the previously owned attribute has any remaining owners, and if not, delete it. This check involves querying the state of the DB on disk.
This PR ensures each attribute is checked only once.

## Implementation

