### PR TITLE
Distribute typedb-all as signed mac installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,7 @@ commands:
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
           bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+          # If you see a `security` command timing out, the keychain may have timed out and locked. Consider prebuilding the zip.
           bazel run --config=ci --compilation_mode=opt --define version=$(cat VERSION) //:setup-mac-signing-keychain
           bazel run --config=ci --compilation_mode=opt --define version=$(cat VERSION) --//server:mode=published //:deploy-mac-installer-pkg -- release  
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,30 @@ commands:
           bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --config=ci --jobs=8 --define version=$(cat VERSION) //:deploy-apt --compilation_mode=opt --//server:mode=published -- release
 
+  deploy-snapshot-installer-mac:
+    steps:
+      - run: |
+          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD 
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+          bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+          bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:setup-mac-signing-keychain
+          bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:deploy-mac-installer-pkg -- snapshot  
+
+  deploy-release-installer-mac:
+    steps:
+      - run: |
+          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD 
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+          bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+          bazel run --config=ci --compilation_mode=opt --define version=$(cat VERSION) //:setup-mac-signing-keychain
+          bazel run --config=ci --compilation_mode=opt --define version=$(cat VERSION) --//server:mode=published //:deploy-mac-installer-pkg -- release  
+
   deploy-docker-snapshot-for-arch:
     parameters:
       image-arch:
@@ -332,24 +356,15 @@ jobs:
           echo "$(git rev-parse HEAD)" > VERSION 
           bazel run --config=ci --define version=$(cat VERSION) //:deploy-brew-snapshot --//:checksum-mac-arm64=:checksum-arm64 --//:checksum-mac-x86_64=:checksum-x86_64 --compilation_mode=opt -- snapshot
 
-  deploy-snapshot-signed-mac-arm64:
+  deploy-snapshot-installer-mac-arm64:
     executor: mac-arm64
     steps:
       - checkout
       - install-deps-brew:
           bazel-arch: arm64
-      - run: |
-          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD 
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-          bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
-          bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-          bazel build --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:assemble-all-mac-arm64-zip
-          bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:setup-mac-signing-keychain
-          bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-installer-pkg -- snapshot
+      - deploy-snapshot-installer-mac
 
-  deploy-snapshot-signed-mac-x86_64:
+  deploy-snapshot-installer-mac-x86_64:
     executor: mac-arm64
     steps:
       - macos/install-rosetta
@@ -357,16 +372,7 @@ jobs:
       - install-brew-rosetta
       - install-deps-brew:
           bazel-arch: amd64
-      - run: |
-          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD 
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-          bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
-          bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-          bazel build --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:assemble-all-mac-x86_64-zip
-          bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:setup-mac-signing-keychain
-          bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:deploy-mac-x86_64-installer-pkg -- snapshot  
+      - deploy-snapshot-installer-mac
 
   deploy-snapshot-apt-x86_64:
     executor: linux-x86_64-amazonlinux-2
@@ -453,6 +459,24 @@ jobs:
           sha256sum ~/dist/typedb-all-mac-x86_64.zip | awk '{print $1}' > checksum-x86_64
           bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --config=ci --define version=$(cat VERSION) //:deploy-brew-release --//:checksum-mac-arm64=:checksum-arm64 --//:checksum-mac-x86_64=:checksum-x86_64 --compilation_mode=opt -- release
+
+  deploy-release-installer-mac-arm64:
+    executor: mac-arm64
+    steps:
+      - checkout
+      - install-deps-brew:
+          bazel-arch: arm64
+      - deploy-release-installer-mac
+
+  deploy-release-installer-mac-x86_64:
+    executor: mac-arm64
+    steps:
+      - macos/install-rosetta
+      - checkout
+      - install-brew-rosetta
+      - install-deps-brew:
+          bazel-arch: amd64
+      - deploy-release-installer-mac
 
   deploy-release-apt-x86_64:
     executor: linux-x86_64-amazonlinux-2
@@ -691,14 +715,14 @@ workflows:
             - test-deploy-snapshot-mac-arm64
             - test-deploy-snapshot-mac-x86_64
 
-      - deploy-snapshot-signed-mac-arm64:
+      - deploy-snapshot-installer-mac-arm64:
           filters:
             branches:
               only: [ master, mac-signing ]
           requires:
             - test-deploy-snapshot-mac-arm64
 
-      - deploy-snapshot-signed-mac-x86_64:
+      - deploy-snapshot-installer-mac-x86_64:
           filters:
             branches:
               only: [ master, mac-signing ]
@@ -787,6 +811,20 @@ workflows:
               only: [ release ]
           requires:
             - deploy-release-mac-arm64
+            - deploy-release-mac-x86_64
+
+      - deploy-release-installer-mac-arm64:
+          filters:
+            branches:
+              only: [ release ]
+          requires:
+            - deploy-release-mac-arm64
+
+      - deploy-release-installer-mac-x86_64:
+          filters:
+            branches:
+              only: [ release ]
+          requires:
             - deploy-release-mac-x86_64
 
       - deploy-release-apt-x86_64:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,6 +340,7 @@ jobs:
           bazel-arch: arm64
       - run: |
           ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+          bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel build --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:assemble-all-mac-arm64-zip
           bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:setup-mac-signing-keychain
           bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-installer-pkg -- snapshot
@@ -354,6 +355,7 @@ jobs:
           bazel-arch: amd64
       - run: |
           ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+          bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel build --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:assemble-all-mac-x86_64-zip
           bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:setup-mac-signing-keychain
           bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:deploy-mac-x86_64-installer-pkg -- snapshot  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,11 @@ jobs:
       - install-deps-brew:
           bazel-arch: arm64
       - run: |
-          ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD 
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
           bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel build --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:assemble-all-mac-arm64-zip
           bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:setup-mac-signing-keychain
@@ -354,7 +358,11 @@ jobs:
       - install-deps-brew:
           bazel-arch: amd64
       - run: |
-          ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD 
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
           bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel build --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:assemble-all-mac-x86_64-zip
           bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:setup-mac-signing-keychain

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,7 @@ jobs:
       - install-deps-brew:
           bazel-arch: arm64
       - run: |
+          bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
           bazel run //:setup-mac-signing-keychain
           bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-installer-pkg -- snapshot
 
@@ -351,6 +352,7 @@ jobs:
       - install-deps-brew:
           bazel-arch: amd64
       - run: |
+          bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
           bazel run //:setup-mac-signing-keychain
           bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:deploy-mac-x86_64-installer-pkg -- snapshot  
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,6 +332,28 @@ jobs:
           echo "$(git rev-parse HEAD)" > VERSION 
           bazel run --config=ci --define version=$(cat VERSION) //:deploy-brew-snapshot --//:checksum-mac-arm64=:checksum-arm64 --//:checksum-mac-x86_64=:checksum-x86_64 --compilation_mode=opt -- snapshot
 
+  deploy-snapshot-signed-mac-arm64:
+    executor: mac-arm64
+    steps:
+      - checkout
+      - install-deps-brew:
+          bazel-arch: arm64
+      - run: |
+          bazel run //:setup-mac-signing-keychain
+          bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-installer-pkg -- snapshot
+
+  deploy-snapshot-signed-mac-x86_64:
+    executor: mac-arm64
+    steps:
+      - macos/install-rosetta
+      - checkout
+      - install-brew-rosetta
+      - install-deps-brew:
+          bazel-arch: amd64
+      - run: |
+          bazel run //:setup-mac-signing-keychain
+          bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:deploy-mac-x86_64-installer-pkg -- snapshot  
+
   deploy-snapshot-apt-x86_64:
     executor: linux-x86_64-amazonlinux-2
     steps:
@@ -653,6 +675,20 @@ workflows:
               only: [ master ]
           requires:
             - test-deploy-snapshot-mac-arm64
+            - test-deploy-snapshot-mac-x86_64
+
+      - deploy-snapshot-signed-mac-arm64:
+          filters:
+            branches:
+              only: [ master ]
+          requires:
+            - test-deploy-snapshot-mac-arm64
+
+      - deploy-snapshot-signed-mac-x86_64:
+          filters:
+            branches:
+              only: [ master ]
+          requires:
             - test-deploy-snapshot-mac-x86_64
 
       - test-distribution-apt-snapshot-x86_64:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -629,12 +629,12 @@ workflows:
       - test-deploy-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, mac-signing ]
 
       - test-deploy-snapshot-mac-arm64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, mac-signing ]
 
       - test-deploy-snapshot-windows-x86_64:
           filters:
@@ -680,14 +680,14 @@ workflows:
       - deploy-snapshot-signed-mac-arm64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, mac-signing ]
           requires:
             - test-deploy-snapshot-mac-arm64
 
       - deploy-snapshot-signed-mac-x86_64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, mac-signing ]
           requires:
             - test-deploy-snapshot-mac-x86_64
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,7 @@ jobs:
       - install-deps-brew:
           bazel-arch: arm64
       - run: |
-          bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+          ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
           bazel run //:setup-mac-signing-keychain
           bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-installer-pkg -- snapshot
 
@@ -352,7 +352,7 @@ jobs:
       - install-deps-brew:
           bazel-arch: amd64
       - run: |
-          bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+          ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
           bazel run //:setup-mac-signing-keychain
           bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:deploy-mac-x86_64-installer-pkg -- snapshot  
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,8 @@ jobs:
           bazel-arch: arm64
       - run: |
           ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
-          bazel run //:setup-mac-signing-keychain
+          bazel build --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:assemble-all-mac-arm64-zip
+          bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:setup-mac-signing-keychain
           bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-installer-pkg -- snapshot
 
   deploy-snapshot-signed-mac-x86_64:
@@ -353,7 +354,8 @@ jobs:
           bazel-arch: amd64
       - run: |
           ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
-          bazel run //:setup-mac-signing-keychain
+          bazel build --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:assemble-all-mac-x86_64-zip
+          bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:setup-mac-signing-keychain
           bazel run --config=ci --compilation_mode=opt --define version=$(git rev-parse HEAD) //:deploy-mac-x86_64-installer-pkg -- snapshot  
 
   deploy-snapshot-apt-x86_64:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -667,12 +667,12 @@ workflows:
       - test-deploy-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [ master, mac-signing ]
+              only: [ master ]
 
       - test-deploy-snapshot-mac-arm64:
           filters:
             branches:
-              only: [ master, mac-signing ]
+              only: [ master ]
 
       - test-deploy-snapshot-windows-x86_64:
           filters:
@@ -718,14 +718,14 @@ workflows:
       - deploy-snapshot-installer-mac-arm64:
           filters:
             branches:
-              only: [ master, mac-signing ]
+              only: [ master ]
           requires:
             - test-deploy-snapshot-mac-arm64
 
       - deploy-snapshot-installer-mac-x86_64:
           filters:
             branches:
-              only: [ master, mac-signing ]
+              only: [ master ]
           requires:
             - test-deploy-snapshot-mac-x86_64
 

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -1,266 +1,266 @@
-## This Source Code Form is subject to the terms of the Mozilla Public
-## License, v. 2.0. If a copy of the MPL was not distributed with this
-## file, You can obtain one at https://mozilla.org/MPL/2.0/.
-#
-#config:
-#  version-candidate: VERSION
-#  dependencies:
-#    dependencies: [build]
-#    typeql: [build, release]
-#    typedb-protocol: [build, release]
-#    typedb-behaviour: [build]
-#
-#build:
-#  correctness:
-#    build:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+config:
+  version-candidate: VERSION
+  dependencies:
+    dependencies: [build]
+    typeql: [build, release]
+    typedb-protocol: [build, release]
+    typedb-behaviour: [build]
+
+build:
+  correctness:
+    build:
+      image: typedb-ubuntu-22.04
+      command: |
+        sudo apt update
+        sudo apt install -y libclang-dev
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel build --config=ci --build_tag_filters=-manual_build //...
+        bazel run --config=ci @typedb_dependencies//tool/checkstyle:test-coverage
+        bazel test --config=ci $(bazel query 'kind(checkstyle_test, //...)')
+        bazel test --config=ci $(bazel query 'kind(rustfmt_test, //...)')
+
+    cargo-check:
+      image: typedb-ubuntu-22.04
+      command: |
+        sudo apt update
+        sudo apt install -y libclang-dev
+        curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip
+        mkdir protoc
+        unzip protoc-21.12-linux-x86_64.zip -d protoc
+        export PROTOC=$PWD/protoc/bin/protoc
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+        source ~/.cargo/env
+        cargo check --all --profile=ci-check
+
+# TODO: Cannot be run because the sync tool does not guarantee a specific order of targets
+#    cargo-toml-sync:
 #      image: typedb-ubuntu-22.04
 #      command: |
-#        sudo apt update
-#        sudo apt install -y libclang-dev
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
+#        export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#        export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        tool/rust/sync.sh
+#        git add .
+#        git diff --exit-code HEAD || {
+#          echo "Failed to verify toml files: please update them manually and verify the changes"
+#          exit 1
+#        }
+
+    test-unit:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci //common/cache:test_crate_cache --test_output=streamed
+        bazel test --config=ci //common/concurrency:test_crate_concurrency --test_output=streamed
+        bazel test --config=ci //common/lending_iterator:test_crate_lending_iterator --test_output=streamed
+        bazel test --config=ci //common/logger:test_crate_logger --test_output=streamed
+        bazel test --config=ci //compiler:test_crate_compiler --test_output=streamed
+        bazel test --config=ci //concept:test_crate_concept --test_output=streamed
+        bazel test --config=ci //database:test_crate_database --test_output=streamed
+        bazel test --config=ci //durability:test_crate_durability  --test_output=streamed
+        bazel test --config=ci //encoding:test_crate_encoding --test_output=streamed
+        bazel test --config=ci //executor:test_crate_executor --test_output=streamed
+        bazel test --config=ci //function:test_crate_function --test_output=streamed
+        bazel test --config=ci //ir:test_crate_ir --test_output=streamed
+        bazel test --config=ci //query:test_crate_query --test_output=streamed
+        bazel test --config=ci //server:test_crate_server --test_output=streamed
+        bazel test --config=ci //server:test_admin_service --test_output=streamed
+        bazel test --config=ci //admin/client:test_crate_client --test_output=streamed
+        bazel test --config=ci //storage:test_crate_storage --test_output=streamed
+
+    test-integration:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci $(bazel query 'kind(rust_test, //compiler/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //concept/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //database/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //durability/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //encoding/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //executor/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //function/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //ir/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //query/tests/...)') --test_output=streamed
+        # TODO: Uncomment!
+        # bazel test --config=ci $(bazel query 'kind(rust_test, //storage/tests/...)') --test_output=streamed
+        bazel test --config=ci //storage/tests:test_mvcc //storage/tests:test_snapshot //storage/tests:test_isolation //storage/tests:test_storage --test_output=streamed
+
+        bazel test --config=ci --config=stress //database/tests:test_statistics_synchronization
+
+#    tests-commented-out-which-fail:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [ build ]
+#      command: |
+#        export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#        export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
 #        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel build --config=ci --build_tag_filters=-manual_build //...
-#        bazel run --config=ci @typedb_dependencies//tool/checkstyle:test-coverage
-#        bazel test --config=ci $(bazel query 'kind(checkstyle_test, //...)')
-#        bazel test --config=ci $(bazel query 'kind(rustfmt_test, //...)')
-#
-#    cargo-check:
-#      image: typedb-ubuntu-22.04
-#      command: |
-#        sudo apt update
-#        sudo apt install -y libclang-dev
-#        curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip
-#        mkdir protoc
-#        unzip protoc-21.12-linux-x86_64.zip -d protoc
-#        export PROTOC=$PWD/protoc/bin/protoc
-#        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-#        source ~/.cargo/env
-#        cargo check --all --profile=ci-check
-#
-## TODO: Cannot be run because the sync tool does not guarantee a specific order of targets
-##    cargo-toml-sync:
-##      image: typedb-ubuntu-22.04
-##      command: |
-##        export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-##        export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-##        tool/rust/sync.sh
-##        git add .
-##        git diff --exit-code HEAD || {
-##          echo "Failed to verify toml files: please update them manually and verify the changes"
-##          exit 1
-##        }
-#
-#    test-unit:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci //common/cache:test_crate_cache --test_output=streamed
-#        bazel test --config=ci //common/concurrency:test_crate_concurrency --test_output=streamed
-#        bazel test --config=ci //common/lending_iterator:test_crate_lending_iterator --test_output=streamed
-#        bazel test --config=ci //common/logger:test_crate_logger --test_output=streamed
-#        bazel test --config=ci //compiler:test_crate_compiler --test_output=streamed
-#        bazel test --config=ci //concept:test_crate_concept --test_output=streamed
-#        bazel test --config=ci //database:test_crate_database --test_output=streamed
-#        bazel test --config=ci //durability:test_crate_durability  --test_output=streamed
-#        bazel test --config=ci //encoding:test_crate_encoding --test_output=streamed
-#        bazel test --config=ci //executor:test_crate_executor --test_output=streamed
-#        bazel test --config=ci //function:test_crate_function --test_output=streamed
-#        bazel test --config=ci //ir:test_crate_ir --test_output=streamed
-#        bazel test --config=ci //query:test_crate_query --test_output=streamed
-#        bazel test --config=ci //server:test_crate_server --test_output=streamed
-#        bazel test --config=ci //server:test_admin_service --test_output=streamed
-#        bazel test --config=ci //admin/client:test_crate_client --test_output=streamed
-#        bazel test --config=ci //storage:test_crate_storage --test_output=streamed
-#
-#    test-integration:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci $(bazel query 'kind(rust_test, //compiler/tests/...)') --test_output=streamed
-#        bazel test --config=ci $(bazel query 'kind(rust_test, //concept/tests/...)') --test_output=streamed
-#        bazel test --config=ci $(bazel query 'kind(rust_test, //database/tests/...)') --test_output=streamed
-#        bazel test --config=ci $(bazel query 'kind(rust_test, //durability/tests/...)') --test_output=streamed
-#        bazel test --config=ci $(bazel query 'kind(rust_test, //encoding/tests/...)') --test_output=streamed
-#        bazel test --config=ci $(bazel query 'kind(rust_test, //executor/tests/...)') --test_output=streamed
-#        bazel test --config=ci $(bazel query 'kind(rust_test, //function/tests/...)') --test_output=streamed
-#        bazel test --config=ci $(bazel query 'kind(rust_test, //ir/tests/...)') --test_output=streamed
-#        bazel test --config=ci $(bazel query 'kind(rust_test, //query/tests/...)') --test_output=streamed
-#        # TODO: Uncomment!
-#        # bazel test --config=ci $(bazel query 'kind(rust_test, //storage/tests/...)') --test_output=streamed
-#        bazel test --config=ci //storage/tests:test_mvcc //storage/tests:test_snapshot //storage/tests:test_isolation //storage/tests:test_storage --test_output=streamed
-#
-#        bazel test --config=ci --config=stress //database/tests:test_statistics_synchronization
-#
-##    tests-commented-out-which-fail:
-##      image: typedb-ubuntu-22.04
-##      dependencies: [ build ]
-##      command: |
-##        export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-##        export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-##        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-##        bazel test --config=ci //storage/tests/... --test_output=streamed
-#
-#    test-behaviour-connection:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci //tests/behaviour/connection:test_connection --test_output=streamed  --test_arg="--test-threads=1"
-#
-#    test-behaviour-concept:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci //tests/behaviour/concept:test_concept --test_output=errors
-#
-#    test-behaviour-query-read:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_read"
-#
-#    test-behaviour-query-write:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_write"
-#
-#    test-behaviour-query-analyze:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_analyze"
-#
-#    test-behaviour-query-definable:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_definable"
-#
-#    test-behaviour-functions:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="functions::"
-#
-#    test-assembly:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci //tests/assembly:test_assembly
-#
-#    test-admin-assembly:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci //admin:test_admin_assembly --test_output=errors
-#
-#    test-fail-points-deterministic:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci //tests/assembly:test_fail_points --test_arg="test_fail_point_always" --test_output=streamed
-#
-#    test-fail-points-randomized:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci //tests/assembly:test_fail_points --test_arg="test_fail_point_chance" --test_output=streamed
-#
-#    test-behaviour-service:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        fi
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci $(bazel query 'kind(rust_test, //tests/behaviour/service/...)') --test_output=streamed
-#
-#release:
-#  filter:
-#    owner: typedb
-#    branch: [master]
-#  validation:
-#    validate-dependencies:
-#      image: typedb-ubuntu-22.04
-#      command: |
-#        bazel test --config=ci //:release-validate-deps --test_output=streamed
-#
-#    validate-release-notes:
-#      image: typedb-ubuntu-22.04
-#      command: |
-#        export NOTES_VALIDATE_TOKEN=$REPO_GITHUB_TOKEN
-#        bazel run --config=ci @typedb_dependencies//tool/release/notes:validate --test_output=streamed -- $FACTORY_OWNER $FACTORY_REPO RELEASE_NOTES_LATEST.md
-#
-#  deployment:
-#    trigger-release-circleci:
-#      image: typedb-ubuntu-22.04
-#      command: |
-#        git checkout -b release
-#        git push -f origin release
-#        echo "Successfully pushed branch 'release', which triggers a release workflow in CircleCI. The progress of the release can be tracked there."
+#        bazel test --config=ci //storage/tests/... --test_output=streamed
+
+    test-behaviour-connection:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci //tests/behaviour/connection:test_connection --test_output=streamed  --test_arg="--test-threads=1"
+
+    test-behaviour-concept:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci //tests/behaviour/concept:test_concept --test_output=errors
+
+    test-behaviour-query-read:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_read"
+
+    test-behaviour-query-write:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_write"
+
+    test-behaviour-query-analyze:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_analyze"
+
+    test-behaviour-query-definable:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_definable"
+
+    test-behaviour-functions:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="functions::"
+
+    test-assembly:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci //tests/assembly:test_assembly
+
+    test-admin-assembly:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci //admin:test_admin_assembly --test_output=errors
+
+    test-fail-points-deterministic:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci //tests/assembly:test_fail_points --test_arg="test_fail_point_always" --test_output=streamed
+
+    test-fail-points-randomized:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci //tests/assembly:test_fail_points --test_arg="test_fail_point_chance" --test_output=streamed
+
+    test-behaviour-service:
+      image: typedb-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test --config=ci $(bazel query 'kind(rust_test, //tests/behaviour/service/...)') --test_output=streamed
+
+release:
+  filter:
+    owner: typedb
+    branch: [master]
+  validation:
+    validate-dependencies:
+      image: typedb-ubuntu-22.04
+      command: |
+        bazel test --config=ci //:release-validate-deps --test_output=streamed
+
+    validate-release-notes:
+      image: typedb-ubuntu-22.04
+      command: |
+        export NOTES_VALIDATE_TOKEN=$REPO_GITHUB_TOKEN
+        bazel run --config=ci @typedb_dependencies//tool/release/notes:validate --test_output=streamed -- $FACTORY_OWNER $FACTORY_REPO RELEASE_NOTES_LATEST.md
+
+  deployment:
+    trigger-release-circleci:
+      image: typedb-ubuntu-22.04
+      command: |
+        git checkout -b release
+        git push -f origin release
+        echo "Successfully pushed branch 'release', which triggers a release workflow in CircleCI. The progress of the release can be tracked there."

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -1,266 +1,266 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-config:
-  version-candidate: VERSION
-  dependencies:
-    dependencies: [build]
-    typeql: [build, release]
-    typedb-protocol: [build, release]
-    typedb-behaviour: [build]
-
-build:
-  correctness:
-    build:
-      image: typedb-ubuntu-22.04
-      command: |
-        sudo apt update
-        sudo apt install -y libclang-dev
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel build --config=ci --build_tag_filters=-manual_build //... 
-        bazel run --config=ci @typedb_dependencies//tool/checkstyle:test-coverage
-        bazel test --config=ci $(bazel query 'kind(checkstyle_test, //...)') 
-        bazel test --config=ci $(bazel query 'kind(rustfmt_test, //...)')
-
-    cargo-check:
-      image: typedb-ubuntu-22.04
-      command: |
-        sudo apt update
-        sudo apt install -y libclang-dev
-        curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip
-        mkdir protoc
-        unzip protoc-21.12-linux-x86_64.zip -d protoc
-        export PROTOC=$PWD/protoc/bin/protoc
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-        source ~/.cargo/env
-        cargo check --all --profile=ci-check
-
-# TODO: Cannot be run because the sync tool does not guarantee a specific order of targets
-#    cargo-toml-sync:
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+#config:
+#  version-candidate: VERSION
+#  dependencies:
+#    dependencies: [build]
+#    typeql: [build, release]
+#    typedb-protocol: [build, release]
+#    typedb-behaviour: [build]
+#
+#build:
+#  correctness:
+#    build:
 #      image: typedb-ubuntu-22.04
 #      command: |
-#        export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#        export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-#        tool/rust/sync.sh
-#        git add .
-#        git diff --exit-code HEAD || {
-#          echo "Failed to verify toml files: please update them manually and verify the changes"
-#          exit 1
-#        }
-
-    test-unit:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci //common/cache:test_crate_cache --test_output=streamed
-        bazel test --config=ci //common/concurrency:test_crate_concurrency --test_output=streamed
-        bazel test --config=ci //common/lending_iterator:test_crate_lending_iterator --test_output=streamed
-        bazel test --config=ci //common/logger:test_crate_logger --test_output=streamed
-        bazel test --config=ci //compiler:test_crate_compiler --test_output=streamed
-        bazel test --config=ci //concept:test_crate_concept --test_output=streamed
-        bazel test --config=ci //database:test_crate_database --test_output=streamed
-        bazel test --config=ci //durability:test_crate_durability  --test_output=streamed
-        bazel test --config=ci //encoding:test_crate_encoding --test_output=streamed
-        bazel test --config=ci //executor:test_crate_executor --test_output=streamed
-        bazel test --config=ci //function:test_crate_function --test_output=streamed
-        bazel test --config=ci //ir:test_crate_ir --test_output=streamed
-        bazel test --config=ci //query:test_crate_query --test_output=streamed
-        bazel test --config=ci //server:test_crate_server --test_output=streamed
-        bazel test --config=ci //server:test_admin_service --test_output=streamed
-        bazel test --config=ci //admin/client:test_crate_client --test_output=streamed
-        bazel test --config=ci //storage:test_crate_storage --test_output=streamed
-
-    test-integration:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci $(bazel query 'kind(rust_test, //compiler/tests/...)') --test_output=streamed
-        bazel test --config=ci $(bazel query 'kind(rust_test, //concept/tests/...)') --test_output=streamed
-        bazel test --config=ci $(bazel query 'kind(rust_test, //database/tests/...)') --test_output=streamed
-        bazel test --config=ci $(bazel query 'kind(rust_test, //durability/tests/...)') --test_output=streamed
-        bazel test --config=ci $(bazel query 'kind(rust_test, //encoding/tests/...)') --test_output=streamed
-        bazel test --config=ci $(bazel query 'kind(rust_test, //executor/tests/...)') --test_output=streamed
-        bazel test --config=ci $(bazel query 'kind(rust_test, //function/tests/...)') --test_output=streamed
-        bazel test --config=ci $(bazel query 'kind(rust_test, //ir/tests/...)') --test_output=streamed
-        bazel test --config=ci $(bazel query 'kind(rust_test, //query/tests/...)') --test_output=streamed
-        # TODO: Uncomment!
-        # bazel test --config=ci $(bazel query 'kind(rust_test, //storage/tests/...)') --test_output=streamed
-        bazel test --config=ci //storage/tests:test_mvcc //storage/tests:test_snapshot //storage/tests:test_isolation //storage/tests:test_storage --test_output=streamed
-        
-        bazel test --config=ci --config=stress //database/tests:test_statistics_synchronization
-
-#    tests-commented-out-which-fail:
-#      image: typedb-ubuntu-22.04
-#      dependencies: [ build ]
-#      command: |
-#        export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-#        export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        sudo apt update
+#        sudo apt install -y libclang-dev
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
 #        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test --config=ci //storage/tests/... --test_output=streamed
-
-    test-behaviour-connection:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci //tests/behaviour/connection:test_connection --test_output=streamed  --test_arg="--test-threads=1"
-
-    test-behaviour-concept:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci //tests/behaviour/concept:test_concept --test_output=errors
-
-    test-behaviour-query-read:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_read"
-
-    test-behaviour-query-write:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_write"
-
-    test-behaviour-query-analyze:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_analyze"
-
-    test-behaviour-query-definable:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_definable"
-
-    test-behaviour-functions:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="functions::"
-
-    test-assembly:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci //tests/assembly:test_assembly
-
-    test-admin-assembly:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci //admin:test_admin_assembly --test_output=errors
-
-    test-fail-points-deterministic:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci //tests/assembly:test_fail_points --test_arg="test_fail_point_always" --test_output=streamed
-
-    test-fail-points-randomized:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci //tests/assembly:test_fail_points --test_arg="test_fail_point_chance" --test_output=streamed
-
-    test-behaviour-service:
-      image: typedb-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
-            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
-            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
-        fi
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test --config=ci $(bazel query 'kind(rust_test, //tests/behaviour/service/...)') --test_output=streamed
-
-release:
-  filter:
-    owner: typedb
-    branch: [master]
-  validation:
-    validate-dependencies:
-      image: typedb-ubuntu-22.04
-      command: |
-        bazel test --config=ci //:release-validate-deps --test_output=streamed
-
-    validate-release-notes:
-      image: typedb-ubuntu-22.04
-      command: |
-        export NOTES_VALIDATE_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run --config=ci @typedb_dependencies//tool/release/notes:validate --test_output=streamed -- $FACTORY_OWNER $FACTORY_REPO RELEASE_NOTES_LATEST.md
-
-  deployment:
-    trigger-release-circleci:
-      image: typedb-ubuntu-22.04
-      command: |
-        git checkout -b release
-        git push -f origin release
-        echo "Successfully pushed branch 'release', which triggers a release workflow in CircleCI. The progress of the release can be tracked there."
+#        bazel build --config=ci --build_tag_filters=-manual_build //...
+#        bazel run --config=ci @typedb_dependencies//tool/checkstyle:test-coverage
+#        bazel test --config=ci $(bazel query 'kind(checkstyle_test, //...)')
+#        bazel test --config=ci $(bazel query 'kind(rustfmt_test, //...)')
+#
+#    cargo-check:
+#      image: typedb-ubuntu-22.04
+#      command: |
+#        sudo apt update
+#        sudo apt install -y libclang-dev
+#        curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip
+#        mkdir protoc
+#        unzip protoc-21.12-linux-x86_64.zip -d protoc
+#        export PROTOC=$PWD/protoc/bin/protoc
+#        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+#        source ~/.cargo/env
+#        cargo check --all --profile=ci-check
+#
+## TODO: Cannot be run because the sync tool does not guarantee a specific order of targets
+##    cargo-toml-sync:
+##      image: typedb-ubuntu-22.04
+##      command: |
+##        export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+##        export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+##        tool/rust/sync.sh
+##        git add .
+##        git diff --exit-code HEAD || {
+##          echo "Failed to verify toml files: please update them manually and verify the changes"
+##          exit 1
+##        }
+#
+#    test-unit:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci //common/cache:test_crate_cache --test_output=streamed
+#        bazel test --config=ci //common/concurrency:test_crate_concurrency --test_output=streamed
+#        bazel test --config=ci //common/lending_iterator:test_crate_lending_iterator --test_output=streamed
+#        bazel test --config=ci //common/logger:test_crate_logger --test_output=streamed
+#        bazel test --config=ci //compiler:test_crate_compiler --test_output=streamed
+#        bazel test --config=ci //concept:test_crate_concept --test_output=streamed
+#        bazel test --config=ci //database:test_crate_database --test_output=streamed
+#        bazel test --config=ci //durability:test_crate_durability  --test_output=streamed
+#        bazel test --config=ci //encoding:test_crate_encoding --test_output=streamed
+#        bazel test --config=ci //executor:test_crate_executor --test_output=streamed
+#        bazel test --config=ci //function:test_crate_function --test_output=streamed
+#        bazel test --config=ci //ir:test_crate_ir --test_output=streamed
+#        bazel test --config=ci //query:test_crate_query --test_output=streamed
+#        bazel test --config=ci //server:test_crate_server --test_output=streamed
+#        bazel test --config=ci //server:test_admin_service --test_output=streamed
+#        bazel test --config=ci //admin/client:test_crate_client --test_output=streamed
+#        bazel test --config=ci //storage:test_crate_storage --test_output=streamed
+#
+#    test-integration:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci $(bazel query 'kind(rust_test, //compiler/tests/...)') --test_output=streamed
+#        bazel test --config=ci $(bazel query 'kind(rust_test, //concept/tests/...)') --test_output=streamed
+#        bazel test --config=ci $(bazel query 'kind(rust_test, //database/tests/...)') --test_output=streamed
+#        bazel test --config=ci $(bazel query 'kind(rust_test, //durability/tests/...)') --test_output=streamed
+#        bazel test --config=ci $(bazel query 'kind(rust_test, //encoding/tests/...)') --test_output=streamed
+#        bazel test --config=ci $(bazel query 'kind(rust_test, //executor/tests/...)') --test_output=streamed
+#        bazel test --config=ci $(bazel query 'kind(rust_test, //function/tests/...)') --test_output=streamed
+#        bazel test --config=ci $(bazel query 'kind(rust_test, //ir/tests/...)') --test_output=streamed
+#        bazel test --config=ci $(bazel query 'kind(rust_test, //query/tests/...)') --test_output=streamed
+#        # TODO: Uncomment!
+#        # bazel test --config=ci $(bazel query 'kind(rust_test, //storage/tests/...)') --test_output=streamed
+#        bazel test --config=ci //storage/tests:test_mvcc //storage/tests:test_snapshot //storage/tests:test_isolation //storage/tests:test_storage --test_output=streamed
+#
+#        bazel test --config=ci --config=stress //database/tests:test_statistics_synchronization
+#
+##    tests-commented-out-which-fail:
+##      image: typedb-ubuntu-22.04
+##      dependencies: [ build ]
+##      command: |
+##        export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+##        export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+##        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+##        bazel test --config=ci //storage/tests/... --test_output=streamed
+#
+#    test-behaviour-connection:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci //tests/behaviour/connection:test_connection --test_output=streamed  --test_arg="--test-threads=1"
+#
+#    test-behaviour-concept:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci //tests/behaviour/concept:test_concept --test_output=errors
+#
+#    test-behaviour-query-read:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_read"
+#
+#    test-behaviour-query-write:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_write"
+#
+#    test-behaviour-query-analyze:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_analyze"
+#
+#    test-behaviour-query-definable:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="test_definable"
+#
+#    test-behaviour-functions:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="functions::"
+#
+#    test-assembly:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci //tests/assembly:test_assembly
+#
+#    test-admin-assembly:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci //admin:test_admin_assembly --test_output=errors
+#
+#    test-fail-points-deterministic:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci //tests/assembly:test_fail_points --test_arg="test_fail_point_always" --test_output=streamed
+#
+#    test-fail-points-randomized:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci //tests/assembly:test_fail_points --test_arg="test_fail_point_chance" --test_output=streamed
+#
+#    test-behaviour-service:
+#      image: typedb-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+#            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+#            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+#        fi
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test --config=ci $(bazel query 'kind(rust_test, //tests/behaviour/service/...)') --test_output=streamed
+#
+#release:
+#  filter:
+#    owner: typedb
+#    branch: [master]
+#  validation:
+#    validate-dependencies:
+#      image: typedb-ubuntu-22.04
+#      command: |
+#        bazel test --config=ci //:release-validate-deps --test_output=streamed
+#
+#    validate-release-notes:
+#      image: typedb-ubuntu-22.04
+#      command: |
+#        export NOTES_VALIDATE_TOKEN=$REPO_GITHUB_TOKEN
+#        bazel run --config=ci @typedb_dependencies//tool/release/notes:validate --test_output=streamed -- $FACTORY_OWNER $FACTORY_REPO RELEASE_NOTES_LATEST.md
+#
+#  deployment:
+#    trigger-release-circleci:
+#      image: typedb-ubuntu-22.04
+#      command: |
+#        git checkout -b release
+#        git push -f origin release
+#        echo "Successfully pushed branch 'release', which triggers a release workflow in CircleCI. The progress of the release can be tracked there."

--- a/BUILD
+++ b/BUILD
@@ -452,6 +452,7 @@ label_flag(
 alias(
     name = "developer-id-certs",
     actual = "@vaticle_developer_id_combined//file",
+    tags = ["manual"],
 )
 
 keychain_setup(

--- a/BUILD
+++ b/BUILD
@@ -469,7 +469,8 @@ mac_pkg_installer(
     identifier = "typedb",
     host_architecture = "x86_64",
     version_file = ":VERSION",
-    symlinks = ["/usr/local/bin/typedb:/usr/local/typedb/bin/typedb"],
+    # These don't work because we install in the users home, but the script runs as root or something
+    # symlinks = ["~/usr/local/typedb/typedb:~/usr/local/bin/typedb"],
 
     keychain_name = "typedb-apple-signing-keychain",
     sign_binaries = [
@@ -493,7 +494,8 @@ mac_pkg_installer(
     identifier = "typedb",
     host_architecture = "arm64",
     version_file = ":VERSION",
-    symlinks = ["/usr/local/bin/typedb:/usr/local/typedb/bin/typedb"],
+    # These don't work because we install in the users home, but the script runs as root or something
+#     symlinks = ["~/usr/local/typedb/typedb:~/usr/local/bin/typedb"],
 
     keychain_name = "typedb-apple-signing-keychain",
     sign_binaries = [

--- a/BUILD
+++ b/BUILD
@@ -7,7 +7,7 @@ load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@typedb_dependencies//tool/release/deps:rules.bzl", "release_validate_deps")
 
 load("@typedb_bazel_distribution//artifact:rules.bzl", "deploy_artifact")
-load("@typedb_bazel_distribution//common:rules.bzl", "package_version_vars")
+load("@typedb_bazel_distribution//common:rules.bzl", "keychain_setup", "mac_pkg_installer", "package_version_vars")
 load("@typedb_dependencies//distribution/artifact:rules.bzl", "artifact_repackage")
 load("@typedb_bazel_distribution//platform:constraints.bzl", "constraint_linux_arm64", "constraint_linux_x86_64",
      "constraint_mac_arm64", "constraint_mac_x86_64", "constraint_win_x86_64")
@@ -447,6 +447,84 @@ label_flag(
     name = "checksum-mac-x86_64",
     build_setting_default = ":invalid-checksum",
 )
+
+# Signed mac installer
+alias(
+    name = "developer-id-certs",
+    actual = "@vaticle_developer_id_combined//file",
+)
+keychain_setup(
+    name = "setup-mac-signing-keychain",
+    signing_identities = ":developer-id-certs",
+    keychain_name = "typedb-apple-signing-keychain",
+    # This is the app-specific one that looks like: xxxx-xxxx-xxxx-xxxx .
+    passwords = ["bot@vaticle.com:APPLE_NOTARIZATION_PASSWORD"],
+)
+
+mac_pkg_installer(
+    name = "assemble-all-mac-x86_64-installer-pkg",
+    src = ":assemble-all-mac-x86_64-zip",
+    pkg_name = "typedb-all-mac-x86_64-installer",
+    identifier = "typedb",
+    host_architecture = "x86_64",
+    version_file = ":VERSION",
+
+    keychain_name = "typedb-apple-signing-keychain",
+    sign_binaries = [
+        "typedb", "server/typedb_server_bin", "console/typedb_console_bin", "admin/typedb_admin_bin", "loader/typedb_loader_bin"
+    ],
+    application_cert_subject = "Developer ID Application: Vaticle LTD (RHKH8FP9SX)",
+    installer_cert_subject = "Developer ID Installer: Vaticle LTD (RHKH8FP9SX)",
+
+    notarize = True,
+    apple_id = "bot@vaticle.com",
+    apple_team_id = "RHKH8FP9SX",
+
+    verbose = False, # True for debugging
+    target_compatible_with = constraint_mac_x86_64,
+)
+
+mac_pkg_installer(
+    name = "assemble-all-mac-arm64-installer-pkg",
+    src = ":assemble-all-mac-arm64-zip",
+    pkg_name = "typedb-all-mac-arm64-installer",
+    identifier = "typedb",
+    host_architecture = "arm64",
+    version_file = ":VERSION",
+
+    keychain_name = "typedb-apple-signing-keychain",
+    sign_binaries = [
+        "typedb", "server/typedb_server_bin", "console/typedb_console_bin", "admin/typedb_admin_bin", "loader/typedb_loader_bin"
+    ],
+    application_cert_subject = "Developer ID Application: Vaticle LTD (RHKH8FP9SX)",
+    installer_cert_subject = "Developer ID Installer: Vaticle LTD (RHKH8FP9SX)",
+
+    notarize = True,
+    apple_id = "bot@vaticle.com",
+    apple_team_id = "RHKH8FP9SX",
+
+    verbose = True,
+    target_compatible_with = constraint_mac_arm64,
+)
+
+deploy_artifact(
+    name = "deploy-mac-x86_64-installer-pkg",
+    artifact_group = "typedb-all-mac-x86_64-installer",
+    artifact_name = "typedb-all-mac-x86_64-installer-{version}.pkg",
+    release = deployment["artifact"]["release"]["upload"],
+    snapshot = deployment["artifact"]["snapshot"]["upload"],
+    target = ":assemble-all-mac-x86_64-installer-pkg",
+)
+
+deploy_artifact(
+    name = "deploy-mac-arm64-installer-pkg",
+    artifact_group = "typedb-all-mac-arm64-installer",
+    artifact_name = "typedb-all-mac-arm64-installer-{version}.pkg",
+    release = deployment["artifact"]["release"]["upload"],
+    snapshot = deployment["artifact"]["snapshot"]["upload"],
+    target = ":assemble-all-mac-arm64-installer-pkg",
+)
+
 
 # apt
 apt_depends = []

--- a/BUILD
+++ b/BUILD
@@ -492,7 +492,7 @@ mac_pkg_installer(
     host_architecture = "arm64",
     version_file = ":VERSION",
 
-    keychain_name = "s",
+    keychain_name = "typedb-apple-signing-keychain",
     sign_binaries = [
         "typedb", "server/typedb_server_bin", "console/typedb_console_bin", "admin/typedb_admin_bin", "loader/typedb_loader_bin"
     ],

--- a/BUILD
+++ b/BUILD
@@ -456,8 +456,14 @@ alias(
 
 keychain_setup(
     name = "setup-mac-signing-keychain",
-    signing_identities = ":developer-id-certs",
     keychain_name = "typedb-apple-signing-keychain",
+
+    signing_identities = ":developer-id-certs",
+    signing_identities_password_env = "APPLE_SIGNING_IDENTITIES_PASSWORD",
+
+    partition_list = "apple-tool:,apple:,codesign:",
+    trusted_apps = ["/usr/bin/codesign", "/usr/bin/productsign"],
+
     # This is the app-specific one that looks like: xxxx-xxxx-xxxx-xxxx .
     passwords = ["bot@vaticle.com:APPLE_NOTARIZATION_PASSWORD"],
 )
@@ -472,7 +478,7 @@ mac_pkg_installer(
     install_location = "/.typedb/{IDENTIFIER}-{VERSION}",
     version_file = ":VERSION",
     # These don't work because we install in the users home, but the script runs as root or something
-    # symlinks = ["~/usr/local/typedb/typedb:~/usr/local/bin/typedb"],
+    symlinks = ["~/usr/local/typedb/typedb:~/usr/local/bin/typedb"],
 
     keychain_name = "typedb-apple-signing-keychain",
     sign_binaries = [

--- a/BUILD
+++ b/BUILD
@@ -467,6 +467,7 @@ keychain_setup(
 
     # This is the app-specific one that looks like: xxxx-xxxx-xxxx-xxxx .
     passwords = ["bot@vaticle.com:APPLE_NOTARIZATION_PASSWORD"],
+    tags = ["manual"],
 )
 
 mac_pkg_installer(

--- a/BUILD
+++ b/BUILD
@@ -453,6 +453,7 @@ alias(
     name = "developer-id-certs",
     actual = "@vaticle_developer_id_combined//file",
 )
+
 keychain_setup(
     name = "setup-mac-signing-keychain",
     signing_identities = ":developer-id-certs",
@@ -525,6 +526,13 @@ deploy_artifact(
     target = ":assemble-all-mac-arm64-installer-pkg",
 )
 
+alias(
+    name = "deploy-mac-installer-pkg",
+    actual = select({
+        "@typedb_bazel_distribution//platform:is_mac_arm64" : ":deploy-mac-arm64-installer-pkg",
+        "@typedb_bazel_distribution//platform:is_mac_x86_64" : ":deploy-mac-x86_64-installer-pkg",
+    }),
+)
 
 # apt
 apt_depends = []

--- a/BUILD
+++ b/BUILD
@@ -475,10 +475,10 @@ mac_pkg_installer(
     identifier = "typedb",
     host_architecture = "x86_64",
     enable_current_user_home = True,
-    install_location = "/.typedb/{IDENTIFIER}-{VERSION}",
+    install_location = "/.typedb/typedb-{VERSION}",
     version_file = ":VERSION",
     # These don't work because we install in the users home, but the script runs as root or something
-    symlinks = ["~/usr/local/typedb/typedb:~/usr/local/bin/typedb"],
+    # symlinks = ["~/usr/local/bin/typedb:~/.typedb/typedb-{VERSION}/typedb"],
 
     keychain_name = "typedb-apple-signing-keychain",
     sign_binaries = [
@@ -502,10 +502,10 @@ mac_pkg_installer(
     identifier = "typedb",
     host_architecture = "arm64",
     enable_current_user_home = True,
-    install_location = "/.typedb/{IDENTIFIER}-{VERSION}",
+    install_location = "/.typedb/typedb-{VERSION}",
     version_file = ":VERSION",
     # These don't work because we install in the users home, but the script runs as root or something
-    # symlinks = ["~/usr/local/typedb/typedb:~/usr/local/bin/typedb"],
+    # symlinks = ["~/usr/local/bin/typedb:~/.typedb/typedb-{VERSION}/typedb"],
 
     keychain_name = "typedb-apple-signing-keychain",
     sign_binaries = [

--- a/BUILD
+++ b/BUILD
@@ -467,8 +467,9 @@ mac_pkg_installer(
     src = ":assemble-all-mac-x86_64-zip",
     pkg_name = "typedb-all-mac-x86_64-installer",
     identifier = "typedb",
-    install_location = "/usr/local/{IDENTIFIER}-{VERSION}",
     host_architecture = "x86_64",
+    enable_current_user_home = True,
+    install_location = "/.typedb/{IDENTIFIER}-{VERSION}",
     version_file = ":VERSION",
     # These don't work because we install in the users home, but the script runs as root or something
     # symlinks = ["~/usr/local/typedb/typedb:~/usr/local/bin/typedb"],
@@ -494,7 +495,8 @@ mac_pkg_installer(
     pkg_name = "typedb-all-mac-arm64-installer",
     identifier = "typedb",
     host_architecture = "arm64",
-    install_location = "/usr/local/{IDENTIFIER}-{VERSION}",
+    enable_current_user_home = True,
+    install_location = "/.typedb/{IDENTIFIER}-{VERSION}",
     version_file = ":VERSION",
     # These don't work because we install in the users home, but the script runs as root or something
     # symlinks = ["~/usr/local/typedb/typedb:~/usr/local/bin/typedb"],

--- a/BUILD
+++ b/BUILD
@@ -469,6 +469,7 @@ mac_pkg_installer(
     identifier = "typedb",
     host_architecture = "x86_64",
     version_file = ":VERSION",
+    symlinks = ["/usr/local/bin/typedb:/usr/local/typedb/bin/typedb"],
 
     keychain_name = "typedb-apple-signing-keychain",
     sign_binaries = [
@@ -492,6 +493,7 @@ mac_pkg_installer(
     identifier = "typedb",
     host_architecture = "arm64",
     version_file = ":VERSION",
+    symlinks = ["/usr/local/bin/typedb:/usr/local/typedb/bin/typedb"],
 
     keychain_name = "typedb-apple-signing-keychain",
     sign_binaries = [

--- a/BUILD
+++ b/BUILD
@@ -492,7 +492,7 @@ mac_pkg_installer(
     host_architecture = "arm64",
     version_file = ":VERSION",
 
-    keychain_name = "typedb-apple-signing-keychain",
+    keychain_name = "s",
     sign_binaries = [
         "typedb", "server/typedb_server_bin", "console/typedb_console_bin", "admin/typedb_admin_bin", "loader/typedb_loader_bin"
     ],

--- a/BUILD
+++ b/BUILD
@@ -546,6 +546,7 @@ alias(
         "@typedb_bazel_distribution//platform:is_mac_arm64" : ":deploy-mac-arm64-installer-pkg",
         "@typedb_bazel_distribution//platform:is_mac_x86_64" : ":deploy-mac-x86_64-installer-pkg",
     }),
+    tags = ["manual"],
 )
 
 # apt

--- a/BUILD
+++ b/BUILD
@@ -467,6 +467,7 @@ mac_pkg_installer(
     src = ":assemble-all-mac-x86_64-zip",
     pkg_name = "typedb-all-mac-x86_64-installer",
     identifier = "typedb",
+    install_location = "/usr/local/{IDENTIFIER}-{VERSION}",
     host_architecture = "x86_64",
     version_file = ":VERSION",
     # These don't work because we install in the users home, but the script runs as root or something
@@ -493,9 +494,10 @@ mac_pkg_installer(
     pkg_name = "typedb-all-mac-arm64-installer",
     identifier = "typedb",
     host_architecture = "arm64",
+    install_location = "/usr/local/{IDENTIFIER}-{VERSION}",
     version_file = ":VERSION",
     # These don't work because we install in the users home, but the script runs as root or something
-#     symlinks = ["~/usr/local/typedb/typedb:~/usr/local/bin/typedb"],
+    # symlinks = ["~/usr/local/typedb/typedb:~/usr/local/bin/typedb"],
 
     keychain_name = "typedb-apple-signing-keychain",
     sign_binaries = [

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -162,7 +162,7 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "8789c5721c6314510ef22c77100fbffbf39df9a2",
+    commit = "c838b28aa019388ff89a93b336559fdd28a7bfa7",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -162,7 +162,7 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "f9e8a3608b79323c7cf208171360022a29a91f00",
+    commit = "4fcbbcde8bfd6d4de2f5786d0d4e9df24baa851f",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -162,7 +162,7 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "8241c8586278078754f6bc86500c75ca27f4fb2c",
+    commit = "f9e8a3608b79323c7cf208171360022a29a91f00",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -162,7 +162,7 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "19cc470ae2097496a6385cd58f6bbaf90fba9a02",
+    commit = "8241c8586278078754f6bc86500c75ca27f4fb2c",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -161,8 +161,8 @@ use_repo(
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
-    remote = "https://github.com/typedb/bazel-distribution",
-    commit = "dd811cf28715bbce8374e5e0f9defaf772e7dd36",
+    remote = "https://github.com/krishnangovindraj/bazel-distribution",
+    commit = "00c7f729e0b71a91c0f8459595805e6b370ef020",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")
@@ -191,4 +191,12 @@ git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
     commit = "c07e412aaddfd0a07e0a8350a55f969ae8610925",
+)
+
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+http_file(
+    name = "vaticle_developer_id_combined",
+    url = "https://repo.typedb.com/basic/private-tools/raw/files/VaticleDeveloperIDCombined.p12",
+    sha256 = "e6da59e0698ea876c89ac2a19c87ac6e6936df98ee5df31d8895a09ef26b15c7",
+    downloaded_file_path = "VaticleDeveloperIDCombined.p12",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -162,7 +162,7 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "73678519eb33ba77af9b70dc829c5a78405f4fa9",
+    commit = "d31c266ed44018c3c0c36fed3c1d5f7fbc6cdbae",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -162,7 +162,7 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "dffaa76027dfa3c47e3130f11b31220affb631ba",
+    commit = "73678519eb33ba77af9b70dc829c5a78405f4fa9",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -162,7 +162,7 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "00c7f729e0b71a91c0f8459595805e6b370ef020",
+    commit = "1b45f7d4df2d5694c2597622a22c9577a6d52c42",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -161,8 +161,8 @@ use_repo(
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
-    remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "d31c266ed44018c3c0c36fed3c1d5f7fbc6cdbae",
+    remote = "https://github.com/typedb/bazel-distribution",
+    commit = "8756119e8ad5cd52d8a25f0d0204d6ff29dccebf",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -162,7 +162,7 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "1b45f7d4df2d5694c2597622a22c9577a6d52c42",
+    commit = "19cc470ae2097496a6385cd58f6bbaf90fba9a02",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -162,7 +162,7 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "c838b28aa019388ff89a93b336559fdd28a7bfa7",
+    commit = "dffaa76027dfa3c47e3130f11b31220affb631ba",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -162,7 +162,7 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "4fcbbcde8bfd6d4de2f5786d0d4e9df24baa851f",
+    commit = "8789c5721c6314510ef22c77100fbffbf39df9a2",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")


### PR DESCRIPTION
## Product change and motivation
Publishes a signed mac installer to cloudsmith.

## Implementation
Uses our Developer ID Application & Installer certificates to sign all the binaries in `typedb-all`, and creates a signed `.pkg` installer. The installer is then notarized and uploaded.