### PR TITLE
Implement ability to rename types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5871,7 +5871,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=9f9cd1ed54043b01e833161609c4c22bed3fa722#9f9cd1ed54043b01e833161609c4c22bed3fa722"
+source = "git+https://github.com/typedb/typeql?rev=9bd7d56a907e8bf60ac5a5a7ca609131bf1b24f3#9bd7d56a907e8bf60ac5a5a7ca609131bf1b24f3"
 dependencies = [
  "chrono",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5871,7 +5871,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?tag=3.12.0#5174b3af3557fb3ccb98d87249576831da83c586"
+source = "git+https://github.com/typedb/typeql?rev=9f9cd1ed54043b01e833161609c4c22bed3fa722#9f9cd1ed54043b01e833161609c4c22bed3fa722"
 dependencies = [
  "chrono",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,7 +222,7 @@ features = {}
 
 		[workspace.dependencies.typeql]
 			features = []
-			rev = "9f9cd1ed54043b01e833161609c4c22bed3fa722"
+			rev = "9bd7d56a907e8bf60ac5a5a7ca609131bf1b24f3"
 			git = "https://github.com/typedb/typeql"
 			default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,8 +222,8 @@ features = {}
 
 		[workspace.dependencies.typeql]
 			features = []
+			rev = "9f9cd1ed54043b01e833161609c4c22bed3fa722"
 			git = "https://github.com/typedb/typeql"
-			tag = "3.12.0"
 			default-features = false
 
 		[workspace.dependencies.cache]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -190,5 +190,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "656f5e0cc8ec7c1a09dcd549dc261ab88b938aaa",
+    commit = "3aebfbf7f9d4fe3e055180d0165408c7b0db79d5",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -190,5 +190,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "b6bf16d7c31e97340ee04b35f0e2e3d551d9f763",
+    commit = "656f5e0cc8ec7c1a09dcd549dc261ab88b938aaa",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -107,7 +107,7 @@ workspace_refs(
     name = "typedb_workspace_refs",
     workspace_commit_dict = {
 #        "typedb_protocol+": "3a39f0b94fd7ea316ba5a4f74d44d5afc454cedf",
-        "typeql+": "9f9cd1ed54043b01e833161609c4c22bed3fa722",
+        "typeql+": "9bd7d56a907e8bf60ac5a5a7ca609131bf1b24f3",
     },
     workspace_tag_dict = {
         "typedb_protocol+": "3.12.0",
@@ -175,8 +175,8 @@ git_override(
 bazel_dep(name = "typeql", version = "0.0.0")
 git_override(
     module_name = "typeql",
-    remote = "https://github.com/krishnangovindraj/typeql",
-    commit = "9f9cd1ed54043b01e833161609c4c22bed3fa722",
+    remote = "https://github.com/typedb/typeql",
+    commit = "9bd7d56a907e8bf60ac5a5a7ca609131bf1b24f3",
 )
 
 bazel_dep(name = "typedb_protocol", version = "0.0.0")
@@ -189,6 +189,6 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "c3f345bfdbc1c18a4b2f89cc86fcd161c6a2969a",
+    remote = "https://github.com/typedb/typedb-behaviour",
+    commit = "60841abfb8e4239b48a43789fcde7159c50bfaa6",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -107,11 +107,11 @@ workspace_refs(
     name = "typedb_workspace_refs",
     workspace_commit_dict = {
 #        "typedb_protocol+": "3a39f0b94fd7ea316ba5a4f74d44d5afc454cedf",
-#        "typeql+": "556db69efc01936442d0579e2ed7ef0f0d84d27e",
+        "typeql+": "9f9cd1ed54043b01e833161609c4c22bed3fa722",
     },
     workspace_tag_dict = {
         "typedb_protocol+": "3.12.0",
-        "typeql+": "3.12.0",
+#        "typeql+": "3.12.0",
     },
 )
 
@@ -175,8 +175,8 @@ git_override(
 bazel_dep(name = "typeql", version = "0.0.0")
 git_override(
     module_name = "typeql",
-    remote = "https://github.com/typedb/typeql",
-    tag = "3.12.0",
+    remote = "https://github.com/krishnangovindraj/typeql",
+    commit = "9f9cd1ed54043b01e833161609c4c22bed3fa722",
 )
 
 bazel_dep(name = "typedb_protocol", version = "0.0.0")
@@ -189,6 +189,6 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "4b09ab8f7f5fcb27b4926a1707ddd11402502f07",
+    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+    commit = "b6bf16d7c31e97340ee04b35f0e2e3d551d9f763",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -190,5 +190,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "3aebfbf7f9d4fe3e055180d0165408c7b0db79d5",
+    commit = "c3f345bfdbc1c18a4b2f89cc86fcd161c6a2969a",
 )

--- a/query/redefine.rs
+++ b/query/redefine.rs
@@ -87,10 +87,12 @@ pub(crate) fn execute(
         return Ok(());
     }
     let redefined_structs = process_struct_redefinitions(snapshot, type_manager, thing_manager, &redefine.definables)?;
+    let renamed_roles = process_role_type_renamings(snapshot, type_manager, &redefine.definables)?;
+    let renamed_types = process_type_renamings(snapshot, type_manager, &redefine.definables)?;
     let redefined_types =
         process_type_redefinitions(snapshot, type_manager, thing_manager, &redefine.definables, storage_counters)?;
     let redefined_functions = process_function_redefinitions(snapshot, function_manager, &redefine.definables)?;
-    if !redefined_structs && !redefined_types && !redefined_functions {
+    if !redefined_structs && !renamed_roles && !renamed_types && !redefined_types && !redefined_functions {
         Err(RedefineError::NothingRedefined {})
     } else {
         Ok(())
@@ -106,6 +108,66 @@ fn process_struct_redefinitions(
     let mut anything_redefined = false;
     filter_variants!(Definable::Struct : definables).try_for_each(|struct_| {
         redefine_struct_fields(snapshot, type_manager, thing_manager, &mut anything_redefined, struct_)
+    })?;
+    Ok(anything_redefined)
+}
+
+fn process_role_type_renamings(
+    snapshot: &mut impl WritableSnapshot,
+    type_manager: &TypeManager,
+    definables: &[Definable],
+) -> Result<bool, RedefineError> {
+    let mut anything_redefined = false;
+    filter_variants!(Definable::RoleTypeRename : definables).try_for_each(|declaration| {
+        let from = Label::build_scoped(
+            checked_identifier(&declaration.from.name.ident)?,
+            checked_identifier(&declaration.from.scope.ident)?,
+            declaration.from.scope.span(),
+        );
+        let to = Label::parse_from(checked_identifier(&declaration.to.ident)?, declaration.to.span());
+        let role_type = resolve_role_type(snapshot, type_manager, &from)
+            .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
+
+        debug_assert!(to.scope.is_none());
+        role_type.set_name(snapshot, type_manager, to.name.as_str()).map_err(|typedb_source| {
+            RedefineError::TypeRenameError { from, to, source_span: declaration.span(), typedb_source }
+        })?;
+        anything_redefined = true;
+        Ok(())
+    })?;
+    Ok(anything_redefined)
+}
+
+fn process_type_renamings(
+    snapshot: &mut impl WritableSnapshot,
+    type_manager: &TypeManager,
+    definables: &[Definable],
+) -> Result<bool, RedefineError> {
+    let mut anything_redefined = false;
+    filter_variants!(Definable::TypeRename : definables).try_for_each(|declaration| {
+        let from = Label::parse_from(checked_identifier(&declaration.from.ident)?, declaration.from.span());
+        let to = Label::parse_from(checked_identifier(&declaration.to.ident)?, declaration.to.span());
+        let type_ = resolve_typeql_type(snapshot, type_manager, &from)
+            .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
+
+        match type_ {
+            TypeEnum::Entity(entity_type) => entity_type.set_label(snapshot, type_manager, &to),
+            TypeEnum::Relation(relation_type) => relation_type.set_label(snapshot, type_manager, &to),
+            TypeEnum::Attribute(attribute_type) => attribute_type.set_label(snapshot, type_manager, &to),
+            TypeEnum::RoleType(_) => {
+                debug_assert!(false, "Should be unreachable with an unscoped role");
+                let source_span = to.source_span();
+                return Err(RedefineError::ThingTypeRenameResolvedToRole { label: from, source_span });
+            }
+        }
+        .map_err(|typedb_source| RedefineError::TypeRenameError {
+            from,
+            to,
+            source_span: declaration.span(),
+            typedb_source,
+        })?;
+        anything_redefined = true;
+        Ok(())
     })?;
     Ok(anything_redefined)
 }
@@ -1325,6 +1387,20 @@ typedb_error! {
             39,
             "The reserved keyword '{identifier}' cannot be used as an identifier.",
             identifier: typeql::Identifier,
+            source_span: Option<Span>,
+        ),
+        TypeRenameError(
+            40,
+            "Renaming the type '{from}' to '{to}' failed.",
+            from: Label,
+            to: Label,
+            source_span: Option<Span>,
+            typedb_source: Box<ConceptWriteError>,
+        ),
+        ThingTypeRenameResolvedToRole(
+            41,
+            "When resolving the type to rename, the unscoped label '{label}' resolved to a role-type.",
+            label: Label,
             source_span: Option<Span>,
         ),
     }


### PR DESCRIPTION
## Product change and motivation
Entity, relation and attribute types can be renamed by doing `redefine old-label label new-label;`. Role types can be renamed by doing `redefine declaration-relation:old-role label new-role;`.
