### PR TITLE
Add parsing and translation caches

### DIFF
--- a/database/query.rs
+++ b/database/query.rs
@@ -20,7 +20,7 @@ use options::QueryOptions;
 use query::{error::QueryError, given_rows::GivenRows, query_manager::QueryManager};
 use storage::{durability_client::WALClient, snapshot::WritableSnapshot};
 use tracing::{Level, event};
-use typeql::query::SchemaQuery;
+use typeql::query::{Pipeline, SchemaQuery};
 
 use crate::{
     transaction::{TransactionSchema, TransactionWrite},
@@ -62,7 +62,7 @@ pub fn execute_schema_query(
                 &type_manager,
                 &thing_manager,
                 &function_manager,
-                query,
+                &query,
                 &source_query,
             )
         }
@@ -72,7 +72,7 @@ pub fn execute_schema_query(
 pub fn execute_write_query_in_schema(
     transaction: TransactionSchema<WALClient>,
     query_options: QueryOptions,
-    pipeline: typeql::query::Pipeline,
+    query_pipeline: Arc<Pipeline>,
     given_rows: Option<impl GivenRows>,
     source_query: String,
     interrupt: ExecutionInterrupt,
@@ -95,7 +95,7 @@ pub fn execute_write_query_in_schema(
         function_manager.clone(),
         &query_manager,
         query_options,
-        pipeline,
+        query_pipeline,
         given_rows,
         &source_query,
         interrupt,
@@ -118,7 +118,7 @@ pub fn execute_write_query_in_schema(
 pub fn execute_write_query_in_write(
     transaction: TransactionWrite<WALClient>,
     query_options: QueryOptions,
-    pipeline: typeql::query::Pipeline,
+    query_pipeline: Arc<Pipeline>,
     given_rows: Option<impl GivenRows>,
     source_query: String,
     interrupt: ExecutionInterrupt,
@@ -141,7 +141,7 @@ pub fn execute_write_query_in_write(
         function_manager.clone(),
         &query_manager,
         query_options,
-        pipeline,
+        query_pipeline,
         given_rows,
         &source_query,
         interrupt,
@@ -168,7 +168,7 @@ pub(crate) fn execute_write_query_in<Snapshot: WritableSnapshot + 'static>(
     function_manager: Arc<FunctionManager>,
     query_manager: &QueryManager,
     query_options: QueryOptions,
-    pipeline: typeql::query::Pipeline,
+    query_pipeline: Arc<Pipeline>,
     given_rows: Option<impl GivenRows>,
     source_query: &str,
     interrupt: ExecutionInterrupt,
@@ -179,7 +179,7 @@ pub(crate) fn execute_write_query_in<Snapshot: WritableSnapshot + 'static>(
         type_manager,
         thing_manager,
         function_manager,
-        &pipeline,
+        &query_pipeline,
         given_rows,
         source_query,
     );

--- a/database/tests/statistics_synchronization.rs
+++ b/database/tests/statistics_synchronization.rs
@@ -102,7 +102,7 @@ fn run_insert_batch(database: &Arc<Database<WALClient>>, batch_id: usize) {
         let (returned_tx, result) = execute_write_query_in_write(
             tx,
             QueryOptions::default_grpc(),
-            pipeline,
+            Arc::new(pipeline),
             None::<GivenRowsSimple>,
             query_str,
             ExecutionInterrupt::new_uninterruptible(),

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -64,7 +64,7 @@ fn run_write(tx: TransactionWrite<WALClient>, query: &str) -> TransactionWrite<W
     let (tx, result) = execute_write_query_in_write(
         tx,
         QueryOptions::default_grpc(),
-        pipeline,
+        Arc::new(pipeline),
         None::<GivenRowsSimple>,
         query.to_string(),
         ExecutionInterrupt::new_uninterruptible(),

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -66,7 +66,7 @@ fn setup(
     let mut snapshot = storage.clone().open_snapshot_schema();
     let define = typeql::parse_query(schema).unwrap().into_structure().into_schema();
     query_manager
-        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, define, schema)
+        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &define, schema)
         .unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -101,7 +101,7 @@ fn setup_common(schema: &str) -> Context {
     let mut snapshot = storage.clone().open_snapshot_schema();
     let define = typeql::parse_query(schema).unwrap().into_structure().into_schema();
     query_manager
-        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, define, schema)
+        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &define, schema)
         .unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 

--- a/executor/tests/pipelines.rs
+++ b/executor/tests/pipelines.rs
@@ -56,7 +56,7 @@ fn setup_common() -> Context {
     let mut snapshot = storage.clone().open_snapshot_schema();
     let define = typeql::parse_query(schema).unwrap().into_structure().into_schema();
     query_manager
-        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, define, schema)
+        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &define, schema)
         .unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 

--- a/query/benches/bench_insert_queries_multithreaded.rs
+++ b/query/benches/bench_insert_queries_multithreaded.rs
@@ -21,6 +21,7 @@ use concept::{
 };
 use encoding::value::{label::Label, value_type::ValueType};
 use executor::{ExecutionInterrupt, pipeline::stage::StageIterator};
+use function::function_manager::FunctionManager;
 use lending_iterator::LendingIterator;
 use query::{error::QueryError, given_rows::GivenRowsSimple, query_cache::QueryCache, query_manager::QueryManager};
 use resource::profile::{CommitProfile, StorageCounters};
@@ -115,13 +116,14 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
     query_str: &str,
 ) -> Result<(Vec<HashMap<String, VariableValue<'static>>>, Snapshot), (Box<QueryError>, Snapshot)> {
     let typeql_insert = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
+    let function_manager: Arc<FunctionManager> = Arc::default();
 
     let pipeline = query_manager
         .prepare_write_pipeline(
             snapshot,
             type_manager,
             thing_manager,
-            Arc::default(),
+            function_manager,
             &typeql_insert,
             None::<GivenRowsSimple>,
             query_str,

--- a/query/define.rs
+++ b/query/define.rs
@@ -84,7 +84,7 @@ pub(crate) fn execute(
     type_manager: &TypeManager,
     thing_manager: &ThingManager,
     function_manager: &FunctionManager,
-    define: Define,
+    define: &Define,
     storage_counters: StorageCounters,
 ) -> Result<(), DefineError> {
     process_struct_definitions(snapshot, type_manager, &define.definables)?;

--- a/query/query_cache.rs
+++ b/query/query_cache.rs
@@ -14,15 +14,19 @@ use compiler::executable::pipeline::ExecutablePipeline;
 use concept::thing::statistics::Statistics;
 use ir::{
     pipeline::{fetch::FetchObject, function::Function},
-    translation::pipeline::{TranslatedGiven, TranslatedStage},
+    translation::pipeline::{TranslatedGiven, TranslatedPipeline, TranslatedStage},
 };
 use moka::sync::{Cache, CacheBuilder};
 use resource::{
-    constants::database::{QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION, QUERY_PLAN_CACHE_SIZE},
+    constants::database::{
+        QUERY_PARSE_CACHE_SIZE, QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION, QUERY_PLAN_CACHE_SIZE,
+        QUERY_TRANSLATION_CACHE_SIZE,
+    },
     perf_counters::QUERY_CACHE_FLUSH,
 };
 use storage::sequence_number::SequenceNumber;
 use structural_equality::StructuralEquality;
+use typeql::query::{Pipeline, SchemaQuery};
 
 #[derive(Debug)]
 struct ValidityRequirements {
@@ -32,19 +36,57 @@ struct ValidityRequirements {
 
 #[derive(Debug)]
 pub struct QueryCache {
-    cache: Cache<IRQuery, ExecutablePipeline>,
+    parse_cache: Cache<String, Arc<Pipeline>>,
+    translation_cache: Cache<String, TranslatedPipeline>,
+    executable_cache: Cache<IRQuery, ExecutablePipeline>,
     validity_requirements: RwLock<ValidityRequirements>,
+}
+
+#[derive(Debug)]
+pub enum ParsedQuery {
+    Schema(SchemaQuery),
+    Pipeline(Arc<Pipeline>),
 }
 
 impl QueryCache {
     pub fn new() -> Self {
-        let cache = CacheBuilder::new(QUERY_PLAN_CACHE_SIZE).support_invalidation_closures().build();
+        let parse_cache = CacheBuilder::new(QUERY_PARSE_CACHE_SIZE).build();
+        let translation_cache = CacheBuilder::new(QUERY_TRANSLATION_CACHE_SIZE).build();
+        let executable_cache = CacheBuilder::new(QUERY_PLAN_CACHE_SIZE).support_invalidation_closures().build();
         let validity_requirements =
             RwLock::new(ValidityRequirements { latest_statistics: None, latest_schema_commit: None });
-        QueryCache { cache, validity_requirements }
+        QueryCache { parse_cache, translation_cache, executable_cache, validity_requirements }
     }
 
-    pub(crate) fn get(
+    pub fn get_parsed(&self, query: &str) -> Option<Arc<Pipeline>> {
+        self.parse_cache.get(query)
+    }
+
+    pub(crate) fn insert_parsed(&self, source_query: &str, pipeline: Arc<Pipeline>) {
+        self.parse_cache.insert(source_query.to_owned(), pipeline);
+    }
+
+    pub fn get_translated(&self, query: &str) -> Option<TranslatedPipeline> {
+        self.translation_cache.get(query)
+    }
+
+    pub(crate) fn may_insert_translated(
+        &self,
+        statistics_sequence_number: SequenceNumber,
+        source_query: &str,
+        translated: TranslatedPipeline,
+    ) {
+        let read_lock = self.validity_requirements.read().unwrap();
+        let may_insert = read_lock
+            .latest_schema_commit
+            .map_or(true, |latest_schema_commit_number| statistics_sequence_number >= latest_schema_commit_number);
+        if may_insert {
+            self.translation_cache.insert(source_query.to_owned(), translated);
+        }
+        drop(read_lock);
+    }
+
+    pub(crate) fn get_executable(
         &self,
         preamble: Arc<Vec<Function>>,
         given: Arc<Option<TranslatedGiven>>,
@@ -52,14 +94,14 @@ impl QueryCache {
         fetch: Arc<Option<FetchObject>>,
     ) -> Option<ExecutablePipeline> {
         let key = IRQuery::new(preamble.clone(), given, stages, fetch);
-        self.cache.get(&key).map(|mut found| {
+        self.executable_cache.get(&key).map(|mut found| {
             let replacement = preamble.iter().map(|func| Arc::new(func.parameters.clone())).enumerate();
             found.executable_functions.replace_preamble_parameters(replacement);
             found
         })
     }
 
-    pub(crate) fn may_insert(
+    pub(crate) fn may_insert_executable(
         &self,
         statistics_sequence_number: SequenceNumber,
         preamble: Arc<Vec<Function>>,
@@ -77,7 +119,7 @@ impl QueryCache {
                 .as_ref()
                 .map_or(true, |stats| !is_pipeline_type_populations_outdated(&stats, &pipeline));
         if may_insert {
-            self.cache.insert(key, pipeline);
+            self.executable_cache.insert(key, pipeline);
         }
         drop(read_lock);
     }
@@ -87,7 +129,7 @@ impl QueryCache {
         (*write_lock).latest_statistics = Some(new_statistics.clone());
         drop(write_lock);
         let _predicate_id = self
-            .cache
+            .executable_cache
             .invalidate_entries_if(move |_, pipeline| is_pipeline_type_populations_outdated(&*new_statistics, pipeline))
             .unwrap();
     }
@@ -96,7 +138,8 @@ impl QueryCache {
         let mut write_lock = self.validity_requirements.write().unwrap();
         (*write_lock).latest_schema_commit = Some(statistics.sequence_number);
         drop(write_lock);
-        self.cache.invalidate_all();
+        self.translation_cache.invalidate_all();
+        self.executable_cache.invalidate_all();
         QUERY_CACHE_FLUSH.increment();
     }
 }

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -48,12 +48,15 @@ use ir::{
 };
 use resource::{
     constants::query::MAX_PIPELINE_STAGES,
-    perf_counters::{QUERY_CACHE_HITS, QUERY_CACHE_MISSES},
-    profile::{CompileProfile, QueryProfile},
+    perf_counters::{
+        QUERY_CACHE_HITS, QUERY_CACHE_MISSES, QUERY_PARSE_CACHE_HITS, QUERY_PARSE_CACHE_MISSES,
+        QUERY_TRANSLATION_CACHE_HITS, QUERY_TRANSLATION_CACHE_MISSES,
+    },
+    profile::{CompileIRProfile, QueryProfile},
 };
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 use tracing::{Level, event};
-use typeql::query::SchemaQuery;
+use typeql::query::{QueryStructure, SchemaQuery};
 
 use crate::{
     analyse::{
@@ -62,7 +65,7 @@ use crate::{
     define,
     error::QueryError,
     given_rows::{GivenRowDecodeError, GivenRows},
-    query_cache::QueryCache,
+    query_cache::{ParsedQuery, QueryCache},
     redefine, undefine,
 };
 
@@ -76,18 +79,58 @@ impl QueryManager {
         Self { cache }
     }
 
+    pub fn parse(&self, query: &str) -> Result<ParsedQuery, Box<QueryError>> {
+        if let Some(pipeline) = self.cache.as_ref().and_then(|cache| cache.get_parsed(query)) {
+            QUERY_PARSE_CACHE_HITS.increment();
+            return Ok(ParsedQuery::Pipeline(pipeline));
+        }
+        let parsed = typeql::parse_query(query)
+            .map_err(|err| QueryError::ParseError { source_query: query.to_owned(), typedb_source: err })?;
+        match parsed.into_structure() {
+            QueryStructure::Schema(schema_query) => Ok(ParsedQuery::Schema(schema_query)),
+            QueryStructure::Pipeline(pipeline) => {
+                QUERY_PARSE_CACHE_MISSES.increment();
+                let pipeline = Arc::new(pipeline);
+                if let Some(cache) = self.cache.as_ref() {
+                    cache.insert_parsed(query, pipeline.clone());
+                }
+                Ok(ParsedQuery::Pipeline(pipeline))
+            }
+        }
+    }
+
+    fn translate(
+        &self,
+        query: &str,
+        pipeline: &typeql::query::Pipeline,
+        snapshot: &impl ReadableSnapshot,
+        function_manager: &FunctionManager,
+        thing_manager: &ThingManager,
+    ) -> Result<TranslatedPipeline, Box<QueryError>> {
+        if let Some(translated) = self.cache.as_ref().and_then(|cache| cache.get_translated(query)) {
+            QUERY_TRANSLATION_CACHE_HITS.increment();
+            return Ok(translated);
+        }
+        QUERY_TRANSLATION_CACHE_MISSES.increment();
+        let translated = translate_pipeline(snapshot, function_manager, pipeline, query)?;
+        if let Some(cache) = self.cache.as_ref() {
+            cache.may_insert_translated(thing_manager.statistics().sequence_number, query, translated.clone());
+        }
+        Ok(translated)
+    }
+
     pub fn execute_schema(
         &self,
         snapshot: &mut impl WritableSnapshot,
         type_manager: &TypeManager,
         thing_manager: &ThingManager,
         function_manager: &FunctionManager,
-        query: SchemaQuery,
+        query: &SchemaQuery,
         source_query: &str,
     ) -> Result<(), Box<QueryError>> {
         event!(Level::TRACE, "Running schema query:\n{}", query);
         let query_profile = QueryProfile::new(tracing::enabled!(Level::TRACE));
-        let result = match query {
+        let result = match &query {
             SchemaQuery::Define(define) => {
                 let profile = query_profile.profile_stage(|| String::from("Define"), 0); // TODO executable id
                 let pattern_profile = profile.create_or_get_pattern(|| String::from("Define pattern"));
@@ -140,15 +183,15 @@ impl QueryManager {
         type_manager: &TypeManager,
         thing_manager: Arc<ThingManager>,
         function_manager: Arc<FunctionManager>,
-        query: &typeql::query::Pipeline,
+        pipeline: &typeql::query::Pipeline,
         given_rows: Option<impl GivenRows>,
         source_query: &str,
     ) -> Result<Pipeline<Snapshot, ReadPipelineStage<Snapshot>>, Box<QueryError>> {
-        event!(Level::TRACE, "Running read query:\n{}", query);
+        event!(Level::TRACE, "Running read query:\n{}", source_query);
+        let pipeline = self.translate(source_query, pipeline, snapshot.as_ref(), &function_manager, &thing_manager)?;
         let mut query_profile = QueryProfile::new(tracing::enabled!(Level::TRACE));
         let compile_profile = query_profile.compilation_profile();
         compile_profile.start();
-        // 1: Translate
         let TranslatedPipeline {
             translated_preamble,
             translated_given,
@@ -156,15 +199,14 @@ impl QueryManager {
             translated_fetch,
             mut variable_registry,
             value_parameters: parameters,
-        } = translate_pipeline(snapshot.as_ref(), &function_manager, query, source_query)?;
-        compile_profile.translation_finished();
+        } = pipeline;
         let arced_preamble = Arc::new(translated_preamble);
         let arced_given = Arc::new(translated_given);
         let arced_stages = Arc::new(translated_stages);
         let arced_fetch = Arc::new(translated_fetch);
         let arced_parameters = Arc::new(parameters);
         let executable_pipeline = match self.cache.as_ref().and_then(|cache| {
-            cache.get(arced_preamble.clone(), arced_given.clone(), arced_stages.clone(), arced_fetch.clone())
+            cache.get_executable(arced_preamble.clone(), arced_given.clone(), arced_stages.clone(), arced_fetch.clone())
         }) {
             Some(executable_pipeline) => {
                 QUERY_CACHE_HITS.increment();
@@ -187,7 +229,7 @@ impl QueryManager {
                 )?;
                 if let Some(cache) = self.cache.as_ref() {
                     let seq = thing_manager.statistics().sequence_number;
-                    cache.may_insert(
+                    cache.may_insert_executable(
                         seq,
                         arced_preamble,
                         arced_given,
@@ -237,15 +279,18 @@ impl QueryManager {
         type_manager: &TypeManager,
         thing_manager: Arc<ThingManager>,
         function_manager: Arc<FunctionManager>,
-        query: &typeql::query::Pipeline,
+        pipeline: &typeql::query::Pipeline,
         given_rows: Option<impl GivenRows>,
         source_query: &str,
     ) -> Result<Pipeline<Snapshot, WritePipelineStage<Snapshot>>, (Snapshot, Box<QueryError>)> {
-        event!(Level::TRACE, "Running write query:\n{}", query);
+        event!(Level::TRACE, "Running write query:\n{}", source_query);
+        let pipeline = match self.translate(source_query, pipeline, &snapshot, &function_manager, &thing_manager) {
+            Ok(translated) => translated,
+            Err(err) => return Err((snapshot, err)),
+        };
         let mut query_profile = QueryProfile::new(tracing::enabled!(Level::TRACE));
         let compile_profile = query_profile.compilation_profile();
         compile_profile.start();
-        // 1: Translate
         let TranslatedPipeline {
             translated_preamble,
             translated_given,
@@ -253,11 +298,7 @@ impl QueryManager {
             translated_fetch,
             mut variable_registry,
             value_parameters,
-        } = match translate_pipeline(&snapshot, &function_manager, query, source_query) {
-            Ok(translated) => translated,
-            Err(err) => return Err((snapshot, err)),
-        };
-        compile_profile.translation_finished();
+        } = pipeline;
         let arced_preamble = Arc::new(translated_preamble);
         let arced_given = Arc::new(translated_given);
         let arced_stages = Arc::new(translated_stages);
@@ -265,7 +306,7 @@ impl QueryManager {
         let arced_parameters = Arc::new(value_parameters);
 
         let executable_pipeline = match self.cache.as_ref().and_then(|cache| {
-            cache.get(arced_preamble.clone(), arced_given.clone(), arced_stages.clone(), arced_fetch.clone())
+            cache.get_executable(arced_preamble.clone(), arced_given.clone(), arced_stages.clone(), arced_fetch.clone())
         }) {
             Some(executable_pipeline) => {
                 QUERY_CACHE_HITS.increment();
@@ -289,7 +330,7 @@ impl QueryManager {
                 match executable_pipeline_result {
                     Ok(executable_pipeline) => {
                         if let Some(cache) = self.cache.as_ref() {
-                            cache.may_insert(
+                            cache.may_insert_executable(
                                 thing_manager.statistics().sequence_number,
                                 arced_preamble,
                                 arced_given,
@@ -342,16 +383,16 @@ impl QueryManager {
         &self,
         snapshot: Arc<Snapshot>,
         type_manager: &TypeManager,
-        _thing_manager: Arc<ThingManager>,
         function_manager: &FunctionManager,
-        query: &typeql::query::Pipeline,
+        thing_manager: &ThingManager,
+        pipeline: &typeql::query::Pipeline,
         source_query: &str,
     ) -> Result<AnalysedQuery, Box<QueryError>> {
-        event!(Level::TRACE, "Running analyse query:\n{}", query);
+        event!(Level::TRACE, "Running analyse query:\n{}", source_query);
+        let pipeline = self.translate(source_query, pipeline, snapshot.as_ref(), function_manager, thing_manager)?;
         let mut query_profile = QueryProfile::new(tracing::enabled!(Level::TRACE));
         let compile_profile = query_profile.compilation_profile();
         compile_profile.start();
-        // 1: Translate
         let TranslatedPipeline {
             translated_preamble,
             translated_given,
@@ -359,8 +400,7 @@ impl QueryManager {
             translated_fetch,
             mut variable_registry,
             value_parameters: parameters,
-        } = translate_pipeline(snapshot.as_ref(), function_manager, query, source_query)?;
-        compile_profile.translation_finished();
+        } = pipeline;
         let arced_preamble = Arc::new(translated_preamble);
         let arced_given = translated_given.map(Arc::new);
         let arced_stages = Arc::new(translated_stages);
@@ -426,7 +466,7 @@ impl QueryManager {
     }
 }
 
-fn translate_pipeline<Snapshot: ReadableSnapshot>(
+pub fn translate_pipeline<Snapshot: ReadableSnapshot>(
     snapshot: &Snapshot,
     function_manager: &FunctionManager,
     query: &typeql::query::Pipeline,
@@ -455,7 +495,7 @@ fn annotate_and_compile_query(
     type_manager: &TypeManager,
     thing_manager: Arc<ThingManager>,
     function_manager: &FunctionManager,
-    compile_profile: &mut CompileProfile,
+    compile_profile: &mut CompileIRProfile,
     variable_registry: &mut VariableRegistry,
     arced_parameters: Arc<ParameterRegistry>,
     arced_preamble: Arc<Vec<Function>>,

--- a/query/redefine.rs
+++ b/query/redefine.rs
@@ -80,7 +80,7 @@ pub(crate) fn execute(
     type_manager: &TypeManager,
     thing_manager: &ThingManager,
     function_manager: &FunctionManager,
-    redefine: Redefine,
+    redefine: &Redefine,
     storage_counters: StorageCounters,
 ) -> Result<(), RedefineError> {
     if redefine.definables.is_empty() {

--- a/query/tests/BUILD
+++ b/query/tests/BUILD
@@ -65,6 +65,13 @@ rust_test(
     deps = deps,
 )
 
+rust_test(
+    name = "test_query_cache",
+    crate_root = "query_cache.rs",
+    srcs = ["query_cache.rs"],
+    deps = deps,
+)
+
 rustfmt_test(
     name = "rustfmt_test",
     targets = [

--- a/query/tests/define.rs
+++ b/query/tests/define.rs
@@ -30,7 +30,7 @@ fn basic() {
     "#;
     let schema_query = typeql::parse_query(query_str).unwrap().into_structure().into_schema();
     query_manager
-        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, schema_query, query_str)
+        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &schema_query, query_str)
         .unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 }

--- a/query/tests/fetch.rs
+++ b/query/tests/fetch.rs
@@ -34,7 +34,7 @@ fn define_schema(
     "#;
     let schema_query = typeql::parse_query(query_str).unwrap().into_structure().into_schema();
     query_manager
-        .execute_schema(&mut snapshot, type_manager, thing_manager, function_manager, schema_query, query_str)
+        .execute_schema(&mut snapshot, type_manager, thing_manager, function_manager, &schema_query, query_str)
         .unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 }

--- a/query/tests/pipeline_stages_limit.rs
+++ b/query/tests/pipeline_stages_limit.rs
@@ -8,7 +8,11 @@ use std::sync::Arc;
 
 use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
 use function::function_manager::FunctionManager;
-use query::{error::QueryError, given_rows::GivenRowsSimple, query_manager::QueryManager};
+use query::{
+    error::QueryError,
+    given_rows::GivenRowsSimple,
+    query_manager::{QueryManager, translate_pipeline},
+};
 use resource::{constants::query::MAX_PIPELINE_STAGES, profile::CommitProfile};
 use storage::snapshot::CommittableSnapshot;
 use test_utils_concept::{load_managers, setup_concept_storage};
@@ -40,7 +44,7 @@ fn setup() -> (
     let mut snapshot = storage.clone().open_snapshot_schema();
     let schema_query = typeql::parse_query(schema).unwrap().into_structure().into_schema();
     query_manager
-        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, schema_query, schema)
+        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &schema_query, schema)
         .unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 
@@ -72,23 +76,15 @@ fn pipeline_at_limit_is_accepted() {
 
 #[test]
 fn pipeline_over_limit_is_rejected() {
-    let (_tmp_dir, storage, type_manager, thing_manager, function_manager, query_manager) = setup();
+    let (_tmp_dir, storage, _type_manager, _thing_manager, function_manager, _query_manager) = setup();
 
     let over = MAX_PIPELINE_STAGES + 1;
     let query_str = build_pipeline_query(over);
     let pipeline = typeql::parse_query(&query_str).unwrap().into_structure().into_pipeline();
     assert_eq!(pipeline.stages.len(), over);
 
-    let snapshot = Arc::new(storage.clone().open_snapshot_read());
-    let result = query_manager.prepare_read_pipeline(
-        snapshot,
-        &type_manager,
-        thing_manager.clone(),
-        function_manager,
-        &pipeline,
-        None::<GivenRowsSimple>,
-        &query_str,
-    );
+    let snapshot = storage.clone().open_snapshot_read();
+    let result = translate_pipeline(&snapshot, &function_manager, &pipeline, &query_str);
     let err = match result {
         Ok(_) => panic!("query with too many stages should fail"),
         Err(err) => err,

--- a/query/tests/query_cache.rs
+++ b/query/tests/query_cache.rs
@@ -1,0 +1,125 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::sync::Arc;
+
+use concept::{
+    thing::{statistics::Statistics, thing_manager::ThingManager},
+    type_::type_manager::TypeManager,
+};
+use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
+use function::function_manager::FunctionManager;
+use query::{
+    given_rows::GivenRowsSimple,
+    query_cache::{ParsedQuery, QueryCache},
+    query_manager::QueryManager,
+};
+use resource::profile::CommitProfile;
+use storage::{
+    MVCCStorage, durability_client::WALClient, sequence_number::SequenceNumber, snapshot::CommittableSnapshot,
+};
+use test_utils::TempDir;
+use test_utils_concept::{load_managers, setup_concept_storage};
+use test_utils_encoding::create_core_storage;
+
+const SCHEMA: &str = r#"define
+    attribute name, value string;
+    entity person, owns name;
+"#;
+const QUERY: &str = "match $p isa person, has name $n;";
+
+struct Context {
+    storage: Arc<MVCCStorage<WALClient>>,
+    type_manager: Arc<TypeManager>,
+    thing_manager: Arc<ThingManager>,
+    function_manager: Arc<FunctionManager>,
+    query_manager: QueryManager,
+    cache: Arc<QueryCache>,
+    _tmp_dir: TempDir,
+}
+
+fn setup() -> Context {
+    let (_tmp_dir, mut storage) = create_core_storage();
+    setup_concept_storage(&mut storage);
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+    let function_manager = Arc::new(FunctionManager::new(Arc::new(DefinitionKeyGenerator::new()), None));
+
+    let mut snapshot = storage.clone().open_snapshot_schema();
+    let define = typeql::parse_query(SCHEMA).unwrap().into_structure().into_schema();
+    QueryManager::new(None)
+        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &define, SCHEMA)
+        .unwrap();
+    snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
+
+    let cache = Arc::new(QueryCache::new());
+    let query_manager = QueryManager::new(Some(cache.clone()));
+    // reload to obtain latest vertex generators and statistics entries
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+    Context { _tmp_dir, storage, type_manager, thing_manager, function_manager, query_manager, cache }
+}
+
+fn prepare(context: &Context) {
+    let snapshot = Arc::new(context.storage.clone().open_snapshot_read());
+    let ParsedQuery::Pipeline(pipeline) = context.query_manager.parse(QUERY).unwrap() else {
+        panic!("expected a data pipeline");
+    };
+    context
+        .query_manager
+        .prepare_read_pipeline(
+            snapshot,
+            &context.type_manager,
+            context.thing_manager.clone(),
+            context.function_manager.clone(),
+            &pipeline,
+            None::<GivenRowsSimple>,
+            QUERY,
+        )
+        .unwrap();
+}
+
+#[test]
+fn identical_query_string_hits_parse_cache() {
+    let context = setup();
+
+    // Cold: the parse cache has no entry for this string.
+    assert!(context.cache.get_parsed(QUERY).is_none());
+
+    assert!(matches!(context.query_manager.parse(QUERY).unwrap(), ParsedQuery::Pipeline(_)));
+
+    // Warm: the identical query string now resolves straight from the parse cache.
+    assert!(context.cache.get_parsed(QUERY).is_some(), "an identical query string should hit the parse cache");
+}
+
+#[test]
+fn identical_query_string_hits_translation_cache() {
+    let context = setup();
+
+    // Cold: the translation cache has no entry for this string.
+    assert!(context.cache.get_translated(QUERY).is_none());
+
+    prepare(&context);
+
+    // Warm: the identical query string now resolves straight to translated IR.
+    assert!(
+        context.cache.get_translated(QUERY).is_some(),
+        "an identical query string should hit the translation cache"
+    );
+}
+
+#[test]
+fn schema_reset_invalidates_translation_but_keeps_parse_cache() {
+    let context = setup();
+
+    prepare(&context);
+    assert!(context.cache.get_parsed(QUERY).is_some());
+    assert!(context.cache.get_translated(QUERY).is_some());
+
+    // A schema commit can change function resolution, so it flushes the translation cache. Parsing
+    // is purely syntactic, so the parse cache must survive.
+    context.cache.force_reset(&Statistics::new(SequenceNumber::MIN));
+    assert!(context.cache.get_translated(QUERY).is_none(), "a schema reset should invalidate the translation cache");
+    assert!(context.cache.get_parsed(QUERY).is_some(), "a schema reset must not invalidate the parse cache");
+}

--- a/query/tests/query_profile.rs
+++ b/query/tests/query_profile.rs
@@ -41,7 +41,7 @@ fn define_schema(
     "#;
     let schema_query = typeql::parse_query(query_str).unwrap().into_structure().into_schema();
     query_manager
-        .execute_schema(&mut snapshot, type_manager, thing_manager, function_manager, schema_query, query_str)
+        .execute_schema(&mut snapshot, type_manager, thing_manager, function_manager, &schema_query, query_str)
         .unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 }

--- a/query/tests/unimplemented.rs
+++ b/query/tests/unimplemented.rs
@@ -46,7 +46,7 @@ fn setup_common(schema: &str) -> Context {
     let mut snapshot = storage.clone().open_snapshot_schema();
     let define = typeql::parse_query(schema).unwrap().into_structure().into_schema();
     query_manager
-        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, define, schema)
+        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &define, schema)
         .unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 

--- a/query/undefine.rs
+++ b/query/undefine.rs
@@ -70,7 +70,7 @@ pub(crate) fn execute(
     type_manager: &TypeManager,
     thing_manager: &ThingManager,
     function_manager: &FunctionManager,
-    undefine: Undefine,
+    undefine: &Undefine,
 ) -> Result<(), UndefineError> {
     process_function_undefinitions(snapshot, function_manager, &undefine.undefinables)?;
     process_specialise_undefinitions(snapshot, type_manager, thing_manager, &undefine.undefinables)?;

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -114,6 +114,8 @@ pub mod database {
     // anything over 8.0 often does not plan frequently enough, as the data scales
     pub const QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION: f64 = 3.0;
     pub const QUERY_PLAN_CACHE_SIZE: u64 = 100;
+    pub const QUERY_PARSE_CACHE_SIZE: u64 = 200;
+    pub const QUERY_TRANSLATION_CACHE_SIZE: u64 = 200;
     pub const STATISTICS_DURABLE_WRITE_CHANGE_COUNT: u64 = 10_000;
     pub const STATISTICS_DURABLE_WRITE_SEQ_NUMBERS: usize = 1_000;
     pub const STATISTICS_UPDATE_INTERVAL: Duration = Duration::from_millis(50);

--- a/resource/perf_counters.rs
+++ b/resource/perf_counters.rs
@@ -30,3 +30,7 @@ impl Counter {
 pub static QUERY_CACHE_HITS: Counter = Counter::new(PERF_COUNTERS_ENABLED);
 pub static QUERY_CACHE_MISSES: Counter = Counter::new(PERF_COUNTERS_ENABLED);
 pub static QUERY_CACHE_FLUSH: Counter = Counter::new(PERF_COUNTERS_ENABLED);
+pub static QUERY_PARSE_CACHE_HITS: Counter = Counter::new(PERF_COUNTERS_ENABLED);
+pub static QUERY_PARSE_CACHE_MISSES: Counter = Counter::new(PERF_COUNTERS_ENABLED);
+pub static QUERY_TRANSLATION_CACHE_HITS: Counter = Counter::new(PERF_COUNTERS_ENABLED);
+pub static QUERY_TRANSLATION_CACHE_MISSES: Counter = Counter::new(PERF_COUNTERS_ENABLED);

--- a/resource/profile.rs
+++ b/resource/profile.rs
@@ -434,21 +434,21 @@ impl CommitProfileData {
 
 #[derive(Debug)]
 pub struct QueryProfile {
-    compile_profile: CompileProfile,
+    compile_profile: CompileIRProfile,
     stage_profiles: RwLock<HashMap<u64, Arc<StageProfile>>>,
     enabled: bool,
 }
 
 impl QueryProfile {
     pub fn new(enabled: bool) -> Self {
-        Self { compile_profile: CompileProfile::new(enabled), stage_profiles: RwLock::new(HashMap::new()), enabled }
+        Self { compile_profile: CompileIRProfile::new(enabled), stage_profiles: RwLock::new(HashMap::new()), enabled }
     }
 
     pub fn is_enabled(&self) -> bool {
         self.enabled
     }
 
-    pub fn compilation_profile(&mut self) -> &mut CompileProfile {
+    pub fn compilation_profile(&mut self) -> &mut CompileIRProfile {
         &mut self.compile_profile
     }
 
@@ -507,17 +507,16 @@ impl IndentDisplay for QueryProfile {
 }
 
 #[derive(Debug)]
-pub struct CompileProfile {
-    data: Option<CompileProfileData>,
+pub struct CompileIRProfile {
+    data: Option<CompileIRProfileData>,
 }
 
-impl CompileProfile {
+impl CompileIRProfile {
     fn new(enabled: bool) -> Self {
         if enabled {
             Self {
-                data: Some(CompileProfileData {
+                data: Some(CompileIRProfileData {
                     stage_start: Instant::now(), // irrelevant
-                    translation: Duration::ZERO,
                     validation: Duration::ZERO,
                     annotation: Duration::ZERO,
                     compilation: Duration::ZERO,
@@ -531,13 +530,6 @@ impl CompileProfile {
     pub fn start(&mut self) {
         if let Some(data) = &mut self.data {
             data.stage_start = Instant::now()
-        }
-    }
-
-    pub fn translation_finished(&mut self) {
-        if let Some(data) = &mut self.data {
-            data.translation = data.stage_start.elapsed();
-            data.stage_start = Instant::now();
         }
     }
 
@@ -565,20 +557,18 @@ impl CompileProfile {
     fn total_nanos(&self) -> u64 {
         match &self.data {
             None => 0,
-            Some(data) => (data.translation + data.validation + data.annotation + data.compilation).as_nanos() as u64,
+            Some(data) => (data.validation + data.annotation + data.compilation).as_nanos() as u64,
         }
     }
 }
 
-impl IndentDisplay for CompileProfile {
+impl IndentDisplay for CompileIRProfile {
     fn indent_fmt(&self, f: &mut Formatter<'_>, indent: usize) -> fmt::Result {
         write_indent(f, indent)?;
         match &self.data {
-            None => writeln!(f, "Compile[enabled=false]"),
+            None => writeln!(f, "CompileIR[enabled=false]"),
             Some(data) => {
-                writeln!(f, "Compile[enabled=true, total micros={}]", self.total_nanos() as f64 / 1000.0)?;
-                write_indent(f, indent + 1)?;
-                writeln!(f, "translation micros: {}", data.translation.as_nanos() as f64 / 1000.0)?;
+                writeln!(f, "CompileIR[enabled=true, total micros={}]", self.total_nanos() as f64 / 1000.0)?;
                 write_indent(f, indent + 1)?;
                 writeln!(f, "validation micros: {}", data.validation.as_nanos() as f64 / 1000.0)?;
                 write_indent(f, indent + 1)?;
@@ -593,9 +583,8 @@ impl IndentDisplay for CompileProfile {
 /// Record the time different stages of a query compilation take.
 /// This struct is simplified to expect that we execute exactly these steps in a fixed order with no other (significant) operations.
 #[derive(Debug)]
-struct CompileProfileData {
+struct CompileIRProfileData {
     stage_start: Instant,
-    translation: Duration,
     validation: Duration,
     annotation: Duration,
     compilation: Duration,

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -44,6 +44,8 @@ use options::QueryOptions;
 use query::{
     error::QueryError,
     given_rows::{GivenRowDecodeError, GivenRowEntry, GivenRows},
+    query_cache::ParsedQuery,
+    query_manager::QueryManager,
 };
 use resource::profile::{EncodingProfile, QueryProfile, StorageCounters};
 use storage::snapshot::ReadableSnapshot;
@@ -63,7 +65,7 @@ use typedb_protocol::{
     query::Type::{Read, Write},
     transaction::{Server as ProtocolServer, stream_signal::Req},
 };
-use typeql::{parse_query, query::SchemaQuery};
+use typeql::query::{Pipeline as TypeQLPipeline, SchemaQuery};
 use uuid::Uuid;
 
 use crate::{
@@ -145,7 +147,8 @@ pub(crate) struct TransactionService {
 
     is_open: bool,
     transaction: Option<Transaction>,
-    query_queue: VecDeque<(Uuid, QueueOptions, typeql::query::Pipeline, Option<GivenRowsGrpc>, String)>,
+    query_manager: Option<Arc<QueryManager>>,
+    query_queue: VecDeque<(Uuid, QueueOptions, Arc<TypeQLPipeline>, Option<GivenRowsGrpc>, String)>,
     query_responders: HashMap<Uuid, (JoinHandle<()>, QueryStreamTransmitter)>,
     running_write_query: Option<(Uuid, JoinHandle<(Transaction, WriteQueryResult)>)>,
 
@@ -180,6 +183,7 @@ impl TransactionService {
 
             is_open: false,
             transaction: None,
+            query_manager: None,
             query_queue: VecDeque::with_capacity(20),
             query_responders: HashMap::new(),
             running_write_query: None,
@@ -480,6 +484,7 @@ impl TransactionService {
             transaction.load_kind(),
             ClientEndpoint::Grpc,
         ));
+        self.query_manager = Some(transaction.query_manager());
         self.transaction = Some(transaction);
         self.timeout_at = init_transaction_timeout(Some(transaction_timeout_millis));
         self.is_open = true;
@@ -741,25 +746,18 @@ impl TransactionService {
     async fn may_accept_from_queue(&mut self) {
         debug_assert!(self.running_write_query.is_none());
         // unblock requests until the first write request, which we begin executing if it exists
-        while let Some((req_id, queue_options, query_pipeline, given_rows, source_query)) = self.query_queue.pop_front()
-        {
-            match (queue_options, is_write_pipeline(&query_pipeline)) {
+        while let Some((req_id, queue_options, pipeline, given_rows, source_query)) = self.query_queue.pop_front() {
+            match (queue_options, is_write_pipeline(&pipeline)) {
                 (QueueOptions::Analyze, _) => {
                     debug_assert!(given_rows.is_none());
-                    self.run_analyse_query(req_id, query_pipeline, source_query).await;
+                    self.run_analyse_query(req_id, pipeline, source_query).await;
                 }
                 (QueueOptions::Query(query_options), true) => {
-                    self.run_write_query(req_id, query_options, query_pipeline, given_rows, source_query).await;
+                    self.run_write_query(req_id, query_options, pipeline, given_rows, source_query).await;
                     return;
                 }
                 (QueueOptions::Query(query_options), false) => {
-                    self.run_and_activate_read_transmitter(
-                        req_id,
-                        query_options,
-                        query_pipeline,
-                        given_rows,
-                        source_query,
-                    );
+                    self.run_and_activate_read_transmitter(req_id, query_options, pipeline, given_rows, source_query);
                 }
             }
         }
@@ -771,19 +769,18 @@ impl TransactionService {
         analyse_req: typedb_protocol::analyze::Req,
     ) -> Result<ControlFlow<(), ()>, Status> {
         let query = analyse_req.query;
-        let parsed = match parse_query(&query) {
-            Ok(parsed) => parsed,
-            Err(err) => {
-                let response = ImmediateAnalyzeResponse::non_fatal_err(TransactionServiceError::QueryParseFailed {
-                    typedb_source: err,
-                });
+        let pipeline = match self.query_manager.as_ref().expect("transaction is open").parse(&query) {
+            Ok(ParsedQuery::Pipeline(pipeline)) => pipeline,
+            Ok(ParsedQuery::Schema(_)) => {
+                let response =
+                    ImmediateAnalyzeResponse::non_fatal_err(TransactionServiceError::AnalyseQueryExpectsPipeline {});
                 return Ok(Self::respond_analyze_response(&self.response_sender, req_id, response).await);
             }
-        };
-        let typeql::query::QueryStructure::Pipeline(pipeline) = parsed.into_structure() else {
-            let response =
-                ImmediateAnalyzeResponse::non_fatal_err(TransactionServiceError::AnalyseQueryExpectsPipeline {});
-            return Ok(Self::respond_analyze_response(&self.response_sender, req_id, response).await);
+            Err(typedb_source) => {
+                let response =
+                    ImmediateAnalyzeResponse::non_fatal_err(TransactionServiceError::QueryFailed { typedb_source });
+                return Ok(Self::respond_analyze_response(&self.response_sender, req_id, response).await);
+            }
         };
         if !self.query_queue.is_empty() || self.running_write_query.is_some() {
             self.query_queue.push_back((req_id, QueueOptions::Analyze, pipeline, None, query));
@@ -815,56 +812,31 @@ impl TransactionService {
         }
 
         let query = query_req.query;
-        let parsed = match parse_query(&query) {
-            Ok(parsed) => parsed,
+        let given_rows = query_req.given.map(GivenRowsGrpc);
+        let pipeline = match self.query_manager.as_ref().expect("transaction is open").parse(&query) {
+            Ok(ParsedQuery::Pipeline(pipeline)) => pipeline,
+            Ok(ParsedQuery::Schema(schema_query)) => {
+                // schema queries are handled immediately so there is a query response or a fatal Status
+                let response = self.handle_query_schema(schema_query, query).await?;
+                return Ok(Self::respond_query_response(&self.response_sender, req_id, response).await);
+            }
             Err(typedb_source) => {
                 let response =
-                    ImmediateQueryResponse::non_fatal_err(TransactionServiceError::QueryParseFailed { typedb_source });
+                    ImmediateQueryResponse::non_fatal_err(TransactionServiceError::QueryFailed { typedb_source });
                 return Ok(Self::respond_query_response(&self.response_sender, req_id, response).await);
             }
         };
-        match parsed.into_structure() {
-            typeql::query::QueryStructure::Schema(schema_query) => {
-                // schema queries are handled immediately so there is a query response or a fatal Status
-                let response = self.handle_query_schema(schema_query, query).await?;
-                Ok(Self::respond_query_response(&self.response_sender, req_id, response).await)
-            }
-            typeql::query::QueryStructure::Pipeline(pipeline) => {
-                let given_rows = query_req.given.map(GivenRowsGrpc);
-                #[allow(clippy::collapsible_else_if)]
-                if is_write_pipeline(&pipeline) {
-                    if !self.query_queue.is_empty() || self.running_write_query.is_some() {
-                        self.query_queue.push_back((
-                            req_id,
-                            QueueOptions::Query(query_options),
-                            pipeline,
-                            given_rows,
-                            query,
-                        ));
-                        // queued queries are not handled yet so there will be no query response yet
-                        Ok(Continue(()))
-                    } else {
-                        self.run_write_query(req_id, query_options, pipeline, given_rows, query).await;
-                        Ok(Continue(()))
-                    }
-                } else {
-                    if !self.query_queue.is_empty() || self.running_write_query.is_some() {
-                        self.query_queue.push_back((
-                            req_id,
-                            QueueOptions::Query(query_options),
-                            pipeline,
-                            given_rows,
-                            query,
-                        ));
-                        // queued queries are not handled yet so there will be no query response yet
-                        Ok(Continue(()))
-                    } else {
-                        self.run_and_activate_read_transmitter(req_id, query_options, pipeline, given_rows, query);
-                        // running read queries have no response on the main loop and will respond asynchronously
-                        Ok(Continue(()))
-                    }
-                }
-            }
+        if !self.query_queue.is_empty() || self.running_write_query.is_some() {
+            self.query_queue.push_back((req_id, QueueOptions::Query(query_options), pipeline, given_rows, query));
+            // queued queries are not handled yet so there will be no query response yet
+            Ok(Continue(()))
+        } else if is_write_pipeline(&pipeline) {
+            self.run_write_query(req_id, query_options, pipeline, given_rows, query).await;
+            Ok(Continue(()))
+        } else {
+            self.run_and_activate_read_transmitter(req_id, query_options, pipeline, given_rows, query);
+            // running read queries have no response on the main loop and will respond asynchronously
+            Ok(Continue(()))
         }
     }
 
@@ -905,7 +877,7 @@ impl TransactionService {
         Ok(ImmediateQueryResponse::non_fatal_err(TransactionServiceError::SchemaQueryRequiresSchemaTransaction {}))
     }
 
-    async fn run_analyse_query(&mut self, req_id: Uuid, pipeline: typeql::query::Pipeline, source_query: String) {
+    async fn run_analyse_query(&mut self, req_id: Uuid, pipeline: Arc<TypeQLPipeline>, source_query: String) {
         with_readable_transaction!(self.transaction.as_ref().unwrap(), |transaction| {
             let snapshot = transaction.snapshot.clone();
             let type_manager = transaction.type_manager.clone();
@@ -917,14 +889,14 @@ impl TransactionService {
                 query_manager.analyse(
                     snapshot,
                     &type_manager,
-                    thing_manager,
                     &function_manager,
+                    &thing_manager,
                     &pipeline,
                     &source_query,
                 )
             })
             .await
-            .expect("Expected schema query execution finishing");
+            .expect("Expected analyse query execution finishing");
             let resp = match result {
                 Ok(analyzed) => {
                     match encode_analyzed_query(&*transaction.snapshot, &*transaction.type_manager, analyzed) {
@@ -942,7 +914,7 @@ impl TransactionService {
         &mut self,
         req_id: Uuid,
         query_options: QueryOptions,
-        pipeline: typeql::query::Pipeline,
+        pipeline: Arc<TypeQLPipeline>,
         given_rows: Option<GivenRowsGrpc>,
         source_query: String,
     ) {
@@ -988,7 +960,7 @@ impl TransactionService {
         &mut self,
         req_id: Uuid,
         query_options: QueryOptions,
-        pipeline: typeql::query::Pipeline,
+        pipeline: Arc<TypeQLPipeline>,
         given_rows: Option<GivenRowsGrpc>,
         source_query: String,
     ) {
@@ -1008,7 +980,7 @@ impl TransactionService {
     fn spawn_blocking_execute_write_query(
         &mut self,
         query_options: QueryOptions,
-        pipeline: typeql::query::Pipeline,
+        pipeline: Arc<TypeQLPipeline>,
         given_rows: Option<GivenRowsGrpc>,
         source_query: String,
     ) -> Result<JoinHandle<(Transaction, WriteQueryResult)>, TransactionServiceError> {
@@ -1230,7 +1202,7 @@ impl TransactionService {
         &self,
         sender: Sender<StreamQueryResponse>,
         query_options: QueryOptions,
-        pipeline: typeql::query::Pipeline,
+        pipeline: Arc<TypeQLPipeline>,
         given_rows: Option<GivenRowsGrpc>,
         source_query: String,
     ) -> JoinHandle<()> {

--- a/server/service/http/transaction_service.rs
+++ b/server/service/http/transaction_service.rs
@@ -34,7 +34,7 @@ use ir::pipeline::ParameterRegistry;
 use itertools::{Either, Itertools};
 use lending_iterator::LendingIterator;
 use options::{QueryOptions, TransactionOptions};
-use query::error::QueryError;
+use query::{error::QueryError, query_cache::ParsedQuery, query_manager::QueryManager};
 use resource::profile::StorageCounters;
 use storage::snapshot::ReadableSnapshot;
 use tokio::{
@@ -48,7 +48,7 @@ use tokio::{
     time::Instant,
 };
 use tracing::{Level, event};
-use typeql::{parse_query, query::SchemaQuery};
+use typeql::query::{Pipeline as TypeQLPipeline, SchemaQuery};
 
 use crate::{
     service::{
@@ -156,7 +156,8 @@ pub(crate) struct TransactionService {
     timeout_at: Instant,
 
     transaction: Option<Transaction>,
-    query_queue: VecDeque<(TransactionResponder, QueueOptions, typeql::query::Pipeline, Option<GivenRowsHttp>, String)>,
+    query_manager: Option<QueryManager>,
+    query_queue: VecDeque<(TransactionResponder, QueueOptions, Arc<TypeQLPipeline>, Option<GivenRowsHttp>, String)>,
     running_write_query: Option<(TransactionResponder, JoinHandle<(Transaction, WriteQueryResult)>)>,
 
     close_sender: Sender<()>,
@@ -251,6 +252,7 @@ impl TransactionService {
             timeout_at: init_transaction_timeout(None),
 
             transaction: None,
+            query_manager: None,
             query_queue: VecDeque::with_capacity(20),
             running_write_query: None,
 
@@ -285,6 +287,7 @@ impl TransactionService {
             transaction.load_kind(),
             ClientEndpoint::Http,
         ));
+        self.query_manager = Some(with_readable_transaction!(&transaction, |txn| { (*txn.query_manager).clone() }));
         self.transaction = Some(transaction);
         self.timeout_at = init_transaction_timeout(Some(transaction_timeout_millis));
 
@@ -598,26 +601,23 @@ impl TransactionService {
         debug_assert!(self.running_write_query.is_none());
 
         // unblock requests until the first write request, which we begin executing if it exists
-        while let Some((responder, queue_options, query_pipeline, given_rows, source_query)) =
-            self.query_queue.pop_front()
-        {
-            match (queue_options, is_write_pipeline(&query_pipeline)) {
+        while let Some((responder, queue_options, pipeline, given_rows, source_query)) = self.query_queue.pop_front() {
+            let is_write = is_write_pipeline(&pipeline);
+            match (queue_options, is_write) {
                 (QueueOptions::Analyze, _) => {
                     debug_assert!(given_rows.is_none());
-                    if let Break(()) = self.run_analyse_query(responder, query_pipeline, source_query).await {
+                    if let Break(()) = self.run_analyse_query(responder, pipeline, source_query).await {
                         return Break(());
                     }
                 }
                 (QueueOptions::Query(query_options), true) => {
-                    return self
-                        .run_write_query(responder, query_options, query_pipeline, given_rows, source_query)
-                        .await;
+                    return self.run_write_query(responder, query_options, pipeline, given_rows, source_query).await;
                 }
                 (QueueOptions::Query(query_options), false) => {
                     self.blocking_read_query_worker(
                         responder,
                         query_options,
-                        query_pipeline,
+                        pipeline,
                         given_rows,
                         source_query,
                         StorageCounters::DISABLED,
@@ -641,68 +641,45 @@ impl TransactionService {
             m.record_query();
         }
 
-        let parsed = match parse_query(&query) {
-            Ok(parsed) => parsed,
-            Err(err) => {
-                let _ = respond_transaction_response(
-                    responder,
-                    TransactionServiceResponse::Err(TransactionServiceError::QueryParseFailed { typedb_source: err }),
-                );
-                return Continue(());
-            }
-        };
-        match parsed.into_structure() {
-            typeql::query::QueryStructure::Schema(schema_query) => {
-                // schema queries are handled immediately so there is a query response or a fatal Status
-                match self.handle_query_schema(schema_query, query).await {
+        // Step 1 (parse) needs no transaction, so this is safe even while a write holds it.
+        let pipeline = match self.query_manager.as_ref().expect("transaction is open").parse(&query) {
+            Ok(ParsedQuery::Pipeline(pipeline)) => pipeline,
+            Ok(ParsedQuery::Schema(schema_query)) => {
+                // schema queries are handled immediately so there is a query response or a fatal error
+                return match self.handle_query_schema(schema_query, query).await {
                     Ok(response) => {
                         respond_else_return_break!(responder, response);
                         Continue(())
                     }
                     Err(err) => respond_error_and_return_break!(responder, err),
-                }
+                };
             }
-            typeql::query::QueryStructure::Pipeline(pipeline) => {
-                #[allow(clippy::collapsible_else_if)]
-                if is_write_pipeline(&pipeline) {
-                    if !self.query_queue.is_empty() || self.running_write_query.is_some() {
-                        self.query_queue.push_back((
-                            responder,
-                            QueueOptions::Query(query_options),
-                            pipeline,
-                            given_rows,
-                            query,
-                        ));
-                        // queued queries are not handled yet so there will be no query response yet
-                        Continue(())
-                    } else {
-                        self.run_write_query(responder, query_options, pipeline, given_rows, query).await
-                    }
-                } else {
-                    if !self.query_queue.is_empty() || self.running_write_query.is_some() {
-                        self.query_queue.push_back((
-                            responder,
-                            QueueOptions::Query(query_options),
-                            pipeline,
-                            given_rows,
-                            query,
-                        ));
-                        // queued queries are not handled yet so there will be no query response yet
-                        Continue(())
-                    } else {
-                        self.blocking_read_query_worker(
-                            responder,
-                            query_options,
-                            pipeline,
-                            given_rows,
-                            query,
-                            StorageCounters::DISABLED,
-                        )
-                        .await
-                        .expect("Expected read query completion")
-                    }
-                }
+            Err(typedb_source) => {
+                let _ = respond_transaction_response(
+                    responder,
+                    TransactionServiceResponse::Err(TransactionServiceError::QueryFailed { typedb_source }),
+                );
+                return Continue(());
             }
+        };
+
+        if !self.query_queue.is_empty() || self.running_write_query.is_some() {
+            self.query_queue.push_back((responder, QueueOptions::Query(query_options), pipeline, given_rows, query));
+            // queued queries are not handled yet so there will be no query response yet
+            Continue(())
+        } else if is_write_pipeline(&pipeline) {
+            self.run_write_query(responder, query_options, pipeline, given_rows, query).await
+        } else {
+            self.blocking_read_query_worker(
+                responder,
+                query_options,
+                pipeline,
+                given_rows,
+                query,
+                StorageCounters::DISABLED,
+            )
+            .await
+            .expect("Expected read query completion")
         }
     }
 
@@ -752,7 +729,7 @@ impl TransactionService {
         &mut self,
         responder: TransactionResponder,
         query_options: QueryOptions,
-        pipeline: typeql::query::Pipeline,
+        pipeline: Arc<TypeQLPipeline>,
         given_rows: Option<GivenRowsHttp>,
         source_query: String,
     ) -> ControlFlow<(), ()> {
@@ -829,7 +806,7 @@ impl TransactionService {
     fn spawn_blocking_execute_write_query(
         &mut self,
         query_options: QueryOptions,
-        pipeline: typeql::query::Pipeline,
+        pipeline: Arc<TypeQLPipeline>,
         given_rows: Option<GivenRowsHttp>,
         source_query: String,
     ) -> Result<JoinHandle<(Transaction, WriteQueryResult)>, TransactionServiceError> {
@@ -991,7 +968,7 @@ impl TransactionService {
         &self,
         responder: TransactionResponder,
         query_options: QueryOptions,
-        pipeline: typeql::query::Pipeline,
+        pipeline: Arc<TypeQLPipeline>,
         given_rows: Option<GivenRowsHttp>,
         source_query: String,
         storage_counters: StorageCounters,
@@ -1201,18 +1178,19 @@ impl TransactionService {
     }
 
     async fn handle_analyse_query(&mut self, query: String, responder: TransactionResponder) -> ControlFlow<(), ()> {
-        let parsed = match parse_query(&query) {
-            Ok(parsed) => parsed,
-            Err(err) => {
+        // Step 1 (parse) needs no transaction, so this is safe even while a write holds it.
+        let pipeline = match self.query_manager.as_ref().expect("transaction is open").parse(&query) {
+            Ok(ParsedQuery::Pipeline(pipeline)) => pipeline,
+            Ok(ParsedQuery::Schema(_)) => {
+                respond_error_and_return_break!(responder, TransactionServiceError::AnalyseQueryExpectsPipeline {});
+            }
+            Err(typedb_source) => {
                 let _ = respond_transaction_response(
                     responder,
-                    TransactionServiceResponse::Err(TransactionServiceError::QueryParseFailed { typedb_source: err }),
+                    TransactionServiceResponse::Err(TransactionServiceError::QueryFailed { typedb_source }),
                 );
                 return Continue(());
             }
-        };
-        let typeql::query::QueryStructure::Pipeline(pipeline) = parsed.into_structure() else {
-            respond_error_and_return_break!(responder, TransactionServiceError::AnalyseQueryExpectsPipeline {});
         };
         if !self.query_queue.is_empty() || self.running_write_query.is_some() {
             // queued queries are not handled yet so there will be no query response yet
@@ -1226,7 +1204,7 @@ impl TransactionService {
     async fn run_analyse_query(
         &mut self,
         responder: TransactionResponder,
-        pipeline: typeql::query::Pipeline,
+        pipeline: Arc<TypeQLPipeline>,
         source_query: String,
     ) -> ControlFlow<(), ()> {
         debug_assert!(self.query_queue.is_empty() && self.running_write_query.is_none() && self.transaction.is_some());
@@ -1240,8 +1218,8 @@ impl TransactionService {
                 let analyse_result = query_manager.analyse(
                     snapshot.clone(),
                     &type_manager,
-                    thing_manager.clone(),
                     &function_manager,
+                    &thing_manager,
                     &pipeline,
                     &source_query,
                 );

--- a/server/system_init.rs
+++ b/server/system_init.rs
@@ -86,7 +86,7 @@ pub fn get_system_database_schema_commit_intent(
                 })
                 .into_structure()
                 .into_schema();
-            query_mgr.execute_schema(snapshot, type_mgr, thing_mgr, fn_mgr, query, SCHEMA).unwrap_or_else(|error| {
+            query_mgr.execute_schema(snapshot, type_mgr, thing_mgr, fn_mgr, &query, SCHEMA).unwrap_or_else(|error| {
                 panic!("Unexpected error occurred when defining the schema for the {SYSTEM_DB} database: {error:?}")
             });
         });

--- a/server/transaction.rs
+++ b/server/transaction.rs
@@ -12,6 +12,7 @@ use database::{
 };
 use diagnostics::metrics::LoadKind;
 use options::TransactionOptions;
+use query::query_manager::QueryManager;
 use serde::{Deserialize, Serialize};
 use storage::durability_client::WALClient;
 use tokio::task::spawn_blocking;
@@ -69,6 +70,10 @@ impl Transaction {
 
     pub fn database_name(&self) -> Arc<str> {
         with_readable_transaction!(self, |transaction| { transaction.database.name_arc() })
+    }
+
+    pub fn query_manager(&self) -> Arc<QueryManager> {
+        with_readable_transaction!(self, |transaction| { transaction.query_manager.clone() })
     }
 
     pub fn close(self) {

--- a/tests/behaviour/steps/connection/transaction.rs
+++ b/tests/behaviour/steps/connection/transaction.rs
@@ -208,7 +208,7 @@ fn execute_schema_transaction(
             &transaction.type_manager,
             &transaction.thing_manager,
             &transaction.function_manager,
-            typeql::parse_query(&schema_define)
+            &typeql::parse_query(&schema_define)
                 .map_err(|err| Box::new(err) as Box<dyn TypeDBError>)?
                 .into_structure()
                 .into_schema(),

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -93,12 +93,13 @@ fn execute_read_query(
     source_query: &str,
 ) -> Result<QueryAnswer, Box<QueryError>> {
     with_read_tx!(context, |tx| {
+        let parsed_pipeline = query.into_structure().into_pipeline();
         let pipeline = tx.query_manager.prepare_read_pipeline(
             tx.snapshot.clone(),
             &tx.type_manager,
             tx.thing_manager.clone(),
             tx.function_manager.clone(),
-            &query.into_structure().into_pipeline(),
+            &parsed_pipeline,
             given_rows,
             source_query,
         )?;
@@ -155,12 +156,13 @@ fn execute_write_query(
                                            query_manager,
                                            _db,
                                            _opts| {
+        let parsed_pipeline = query.into_structure().into_pipeline();
         let pipeline_result = query_manager.prepare_write_pipeline(
             Arc::try_unwrap(snapshot).unwrap_or_else(|_| panic!("Expected unique ownership of snapshot")),
             &type_manager,
             thing_manager.clone(),
             function_manager.clone(),
-            &query.into_structure().into_pipeline(),
+            &parsed_pipeline,
             given_rows,
             source_query,
         );
@@ -229,13 +231,14 @@ fn execute_analyze(
     source_query: &str,
 ) -> Result<AnalysedQuery, BehaviourTestExecutionError> {
     with_read_tx!(context, |tx| {
+        let parsed_pipeline = query.into_structure().into_pipeline();
         tx.query_manager
             .analyse(
                 tx.snapshot.clone(),
                 &tx.type_manager,
-                tx.thing_manager.clone(),
                 &tx.function_manager,
-                &query.into_structure().into_pipeline(),
+                &tx.thing_manager,
+                &parsed_pipeline,
                 source_query,
             )
             .map_err(|source| BehaviourTestExecutionError::Query(*source))
@@ -282,7 +285,7 @@ async fn typeql_schema_query(context: &mut Context, may_error: params::TypeQLMay
             &tx.type_manager,
             &tx.thing_manager,
             &tx.function_manager,
-            typeql_schema,
+            &typeql_schema,
             query,
         );
         if let Either::Right(_err) = may_error.check_logic(result) {

--- a/tests/benchmarks/concurrent_ops/bench_concurrency.rs
+++ b/tests/benchmarks/concurrent_ops/bench_concurrency.rs
@@ -175,7 +175,7 @@ fn seed_persons(database: &Arc<Database<WALClient>>, count: usize) {
             let (returned_tx, result) = execute_write_query_in_write(
                 tx,
                 QueryOptions::default_grpc(),
-                pipeline,
+                Arc::new(pipeline),
                 None::<GivenRowsSimple>,
                 query_str,
                 ExecutionInterrupt::new_uninterruptible(),
@@ -210,7 +210,7 @@ fn execute_insert_batch(
         let (returned_tx, result) = execute_write_query_in_write(
             tx,
             QueryOptions::default_grpc(),
-            pipeline,
+            Arc::new(pipeline),
             None::<GivenRowsSimple>,
             query_str,
             ExecutionInterrupt::new_uninterruptible(),
@@ -247,7 +247,7 @@ fn execute_update_batch(
         let (returned_tx, result) = execute_write_query_in_write(
             tx,
             QueryOptions::default_grpc(),
-            pipeline,
+            Arc::new(pipeline),
             None::<GivenRowsSimple>,
             query_str,
             ExecutionInterrupt::new_uninterruptible(),
@@ -286,7 +286,7 @@ fn execute_relation_batch(
         let (returned_tx, result) = execute_write_query_in_write(
             tx,
             QueryOptions::default_grpc(),
-            pipeline,
+            Arc::new(pipeline),
             None::<GivenRowsSimple>,
             query_str,
             ExecutionInterrupt::new_uninterruptible(),

--- a/tests/benchmarks/iam/bench_iam.rs
+++ b/tests/benchmarks/iam/bench_iam.rs
@@ -49,7 +49,7 @@ fn load_schema_tql(database: Arc<Database<WALClient>>, schema_tql: &Path) {
             &type_manager,
             &thing_manager,
             &function_manager,
-            schema_query,
+            &schema_query,
             &schema_str,
         )
         .unwrap();


### PR DESCRIPTION
## Product change and motivation

With the introduction of #7812, there is now massive benefit in avoiding re-parsing and translating queries that are string-identical - parameters are now generally expected to be extracted out of the query.

We convert our old compilation query cache into a three-stage cache to take advantage of this fact.

1) parse cache: string -> parsed data pipeline. Purely syntactic, so it is never invalidated. Only data pipelines are cached; schema queries (define/redefine/undefine) are not included
2) translation cache: string -> translated IR. Translation resolves user-defined functions, so it is flushed on schema commits (but not on statistics-only changes). 
3) compile cache: translated IR -> executable pipeline. Flushed on schema commits, and when statistics drift far enough to change query plans.

Splitting parse from translate also lets a query be parsed with no transaction: queries arriving mid-write are parsed immediately and their translation deferred until the write completes. 

## Implementation

- Add new caches with invalidation logic
- QueryManager becomes the single entry point for parse/translate/ prepare, and all consumers (gRPC/HTTP transaction services, tests, benches) move to the staged flow.
