### PR TITLE
DefinitionKey holds Prefix & DefinitionID instead of raw bytes

### DIFF
--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -124,7 +124,7 @@ pub mod tests {
         let (with_no_cache, with_local_cache, _with_schema_cache) = [
             FunctionID::Preamble(0),
             FunctionID::Preamble(0),
-            FunctionID::Schema(DefinitionKey::build(Prefix::DefinitionFunction, DefinitionID::build(0))),
+            FunctionID::Schema(DefinitionKey::new(Prefix::DefinitionFunction, DefinitionID::new(0))),
         ]
         .iter()
         .map(|function_id| {

--- a/concept/type_/type_manager/type_reader.rs
+++ b/concept/type_/type_manager/type_reader.rs
@@ -109,7 +109,7 @@ impl TypeReader {
         let bytes = snapshot
             .get(index_key.into_storage_key().as_reference(), StorageCounters::DISABLED)
             .map_err(|source| Box::new(ConceptReadError::SnapshotGet { source }))?;
-        Ok(bytes.map(|value| DefinitionKey::new(Bytes::Array(value))))
+        Ok(bytes.map(|value| DefinitionKey::decode(Bytes::Array(value))))
     }
 
     pub(crate) fn get_struct_definition(
@@ -137,7 +137,7 @@ impl TypeReader {
                 StorageCounters::DISABLED,
             )
             .collect_cloned_hashmap(|key, value| {
-                (DefinitionKey::new(Bytes::Array(key.bytes().into())), StructDefinition::from_bytes(value))
+                (DefinitionKey::decode(Bytes::Array(key.bytes().into())), StructDefinition::from_bytes(value))
             })
             .map_err(|source| Box::new(ConceptReadError::SnapshotIterate { source }))
     }

--- a/concept/type_/type_manager/type_writer.rs
+++ b/concept/type_/type_manager/type_writer.rs
@@ -42,7 +42,7 @@ impl<Snapshot: WritableSnapshot> TypeWriter<Snapshot> {
         struct_definition: StructDefinition,
     ) {
         let index_key = NameToStructDefinitionIndex::build(struct_definition.name.as_str());
-        snapshot.put_val(index_key.into_storage_key().into_owned_array(), ByteArray::copy(definition_key.bytes()));
+        snapshot.put_val(index_key.into_storage_key().into_owned_array(), ByteArray::copy(&definition_key.bytes()));
         snapshot.insert_val(
             definition_key.into_storage_key().into_owned_array(),
             struct_definition.into_bytes().unwrap().into_array(),

--- a/encoding/graph/common/schema_id_allocator.rs
+++ b/encoding/graph/common/schema_id_allocator.rs
@@ -140,11 +140,11 @@ impl SchemaID for DefinitionKey {
 
     fn object_from_id(prefix: Prefix, id: u64) -> Self {
         debug_assert!((Self::MIN_ID..=Self::MAX_ID).contains(&id));
-        DefinitionKey::build(prefix, DefinitionID::build(id as DefinitionIDUInt))
+        DefinitionKey::new(prefix, DefinitionID::new(id as DefinitionIDUInt))
     }
 
     fn id_from_key(key: StorageKey<'_, BUFFER_KEY_INLINE>) -> u64 {
-        DefinitionKey::new(Bytes::reference(key.bytes())).definition_id().as_uint() as u64
+        DefinitionKey::decode(Bytes::reference(key.bytes())).definition_id().as_uint() as u64
     }
 
     fn ids_exhausted_error(prefix: Prefix) -> EncodingError {

--- a/encoding/graph/definition/definition_key.rs
+++ b/encoding/graph/definition/definition_key.rs
@@ -6,7 +6,7 @@
 
 use std::{fmt, ops::Range};
 
-use bytes::{Bytes, byte_array::ByteArray};
+use bytes::{Bytes, byte_array::ByteArray, util::HexBytesFormatter};
 use resource::constants::{encoding::DefinitionIDUInt, snapshot::BUFFER_KEY_INLINE};
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
@@ -21,7 +21,8 @@ use crate::{
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct DefinitionKey {
-    bytes: ByteArray<BUFFER_KEY_INLINE>,
+    prefix: Prefix,
+    definition_id: DefinitionID,
 }
 
 impl DefinitionKey {
@@ -33,20 +34,20 @@ impl DefinitionKey {
     pub(crate) const RANGE_DEFINITION_ID: Range<usize> =
         Self::INDEX_PREFIX + 1..Self::INDEX_PREFIX + 1 + DefinitionID::LENGTH;
 
-    pub fn new(bytes: Bytes<'_, BUFFER_KEY_INLINE>) -> Self {
+    pub fn new(prefix: Prefix, definition_id: DefinitionID) -> Self {
+        Self { prefix, definition_id }
+    }
+
+    pub fn decode(bytes: Bytes<'_, BUFFER_KEY_INLINE>) -> Self {
         debug_assert_eq!(bytes.length(), Self::LENGTH);
-        Self { bytes: ByteArray::copy(&bytes) }
+        Self {
+            prefix: Prefix::from_prefix_id(PrefixID::new(bytes[Self::INDEX_PREFIX])).unwrap(),
+            definition_id: DefinitionID::decode(bytes[Self::RANGE_DEFINITION_ID].try_into().unwrap()),
+        }
     }
 
     pub fn definition_id(&self) -> DefinitionID {
-        DefinitionID::new(self.bytes[Self::RANGE_DEFINITION_ID].try_into().unwrap())
-    }
-
-    pub fn build(prefix: Prefix, definition_id: DefinitionID) -> Self {
-        let mut array = ByteArray::zeros(Self::LENGTH);
-        array[Self::INDEX_PREFIX] = prefix.prefix_id().byte;
-        array[Self::RANGE_DEFINITION_ID].copy_from_slice(&definition_id.bytes());
-        Self { bytes: array }
+        self.definition_id
     }
 
     pub fn build_prefix(prefix: Prefix) -> StorageKey<'static, { DefinitionKey::LENGTH_PREFIX }> {
@@ -57,14 +58,17 @@ impl DefinitionKey {
         )
     }
 
-    pub fn bytes(&self) -> &[u8] {
-        &self.bytes
+    pub fn bytes(&self) -> [u8; Self::LENGTH] {
+        let mut array = [0; 3];
+        array[Self::INDEX_PREFIX] = self.prefix.prefix_id().byte;
+        array[Self::RANGE_DEFINITION_ID].copy_from_slice(&self.definition_id.bytes());
+        array
     }
 }
 
 impl AsBytes<BUFFER_KEY_INLINE> for DefinitionKey {
     fn to_bytes(self) -> Bytes<'static, BUFFER_KEY_INLINE> {
-        Bytes::Array(self.bytes)
+        Bytes::Array(ByteArray::copy(&self.bytes()))
     }
 }
 
@@ -78,38 +82,33 @@ impl Prefixed<BUFFER_KEY_INLINE> for DefinitionKey {}
 
 impl fmt::Display for DefinitionKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // we'll just arbitrarily write it out as an u64 in Big Endian
-        debug_assert!(self.bytes.len() < (u64::BITS / 8) as usize);
-        let mut bytes = [0u8; (u64::BITS / 8) as usize];
-        bytes[0..self.bytes.len()].copy_from_slice(&self.bytes);
-        let as_u64 = u64::from_be_bytes(bytes);
-        write!(f, "{}", as_u64)
+        write!(f, "{:?}", &HexBytesFormatter::borrowed(&self.bytes()))
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct DefinitionID {
-    bytes: [u8; DefinitionID::LENGTH],
+    id: u16,
 }
 
 impl DefinitionID {
     pub(crate) const LENGTH: usize = std::mem::size_of::<DefinitionIDUInt>();
 
-    pub fn new(bytes: [u8; DefinitionID::LENGTH]) -> DefinitionID {
-        DefinitionID { bytes }
+    pub fn decode(bytes: [u8; Self::LENGTH]) -> DefinitionID {
+        DefinitionID { id: DefinitionIDUInt::from_be_bytes(bytes) }
     }
 
-    pub fn build(id: DefinitionIDUInt) -> Self {
+    pub fn new(id: DefinitionIDUInt) -> Self {
         debug_assert_eq!(std::mem::size_of_val(&id), DefinitionID::LENGTH);
-        DefinitionID { bytes: id.to_be_bytes() }
+        DefinitionID { id }
     }
 
     pub fn as_uint(&self) -> DefinitionIDUInt {
-        DefinitionIDUInt::from_be_bytes(self.bytes)
+        self.id
     }
 
     pub fn bytes(&self) -> [u8; DefinitionID::LENGTH] {
-        self.bytes
+        self.id.to_be_bytes()
     }
 }
 
@@ -118,7 +117,7 @@ impl Serialize for DefinitionKey {
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(&self.bytes)
+        serializer.serialize_bytes(&self.bytes())
     }
 }
 
@@ -139,7 +138,7 @@ impl<'de> Deserialize<'de> for DefinitionKey {
             where
                 E: Error,
             {
-                Ok(DefinitionKey { bytes: ByteArray::copy(v) })
+                Ok(DefinitionKey::decode(Bytes::Reference(v)))
             }
         }
 

--- a/encoding/graph/type_/property.rs
+++ b/encoding/graph/type_/property.rs
@@ -276,7 +276,7 @@ impl FunctionProperty {
     pub fn decode(bytes: Bytes<'_, BUFFER_KEY_INLINE>) -> Self {
         debug_assert!(bytes.length() >= Self::LENGTH_NO_SUFFIX);
         debug_assert_eq!(bytes[Self::INDEX_PREFIX], Self::PREFIX.prefix_id().byte);
-        let function_id = DefinitionKey::new(bytes.clone().into_range(Self::range_function_id()));
+        let function_id = DefinitionKey::decode(bytes.clone().into_range(Self::range_function_id()));
         let infix = Infix::from_infix_id(InfixID::new((&bytes[Self::range_infix()]).try_into().unwrap()));
         let suffix = ByteArray::copy(&bytes[Self::LENGTH_NO_SUFFIX..]);
         Self { function_id, infix, suffix }

--- a/encoding/tests/test_definitions.rs
+++ b/encoding/tests/test_definitions.rs
@@ -45,7 +45,7 @@ fn define_struct<Snapshot: WritableSnapshot>(
 fn get_struct_key(snapshot: &impl ReadableSnapshot, name: String) -> Option<DefinitionKey> {
     let index_key = NameToStructDefinitionIndex::build(name.as_str());
     let bytes = snapshot.get(index_key.into_storage_key().as_reference(), StorageCounters::DISABLED).unwrap();
-    bytes.map(|value| DefinitionKey::new(Bytes::Array(value)))
+    bytes.map(|value| DefinitionKey::decode(Bytes::Array(value)))
 }
 
 fn get_struct_definition(snapshot: &impl ReadableSnapshot, definition_key: &DefinitionKey) -> StructDefinition {

--- a/encoding/value/struct_bytes.rs
+++ b/encoding/value/struct_bytes.rs
@@ -284,11 +284,11 @@ pub mod test {
             (Value::String(Cow::Owned(String::from_utf8(vec![b'X'; 512]).unwrap())), Value::Integer(0xf00d)), // Bigger than 256 characters
         ];
         for (string_value, integer_value) in test_values {
-            let nested_key = DefinitionKey::build(StructDefinition::PREFIX, DefinitionID::build(0));
+            let nested_key = DefinitionKey::new(StructDefinition::PREFIX, DefinitionID::new(0));
             let nested_fields = HashMap::from([(0, string_value), (1, integer_value)]);
             let nested_struct = StructValue::new(nested_key, nested_fields);
 
-            let struct_key = DefinitionKey::build(StructDefinition::PREFIX, DefinitionID::build(0));
+            let struct_key = DefinitionKey::new(StructDefinition::PREFIX, DefinitionID::new(0));
             let struct_fields = HashMap::from([(0, Value::Struct(Cow::Owned(nested_struct.clone())))]);
             let struct_value = StructValue::new(struct_key, struct_fields);
 

--- a/encoding/value/struct_bytes.rs
+++ b/encoding/value/struct_bytes.rs
@@ -130,9 +130,8 @@ fn append_length_as_vle(len: usize, buf: &mut Vec<u8>) -> Result<(), EncodingErr
 
 // Decode
 fn decode_struct_increment_offset(offset: &mut usize, buf: &[u8]) -> Result<StructValue<'static>, EncodingError> {
-    let definition_id_u16 =
-        DefinitionID::build(u16::from_be_bytes(read_bytes_increment_offset::<{ DefinitionID::LENGTH }>(offset, buf)?));
-    let definition_key = DefinitionKey::build(StructDefinition::PREFIX, definition_id_u16);
+    let definition_id = DefinitionID::decode(read_bytes_increment_offset::<{ DefinitionID::LENGTH }>(offset, buf)?);
+    let definition_key = DefinitionKey::new(StructDefinition::PREFIX, definition_id);
     let n_fields = read_vle_increment_offset(offset, buf)?;
     let mut fields: HashMap<StructFieldIDUInt, Value<'static>> = HashMap::new();
     for _ in 0..n_fields {

--- a/encoding/value/value_type.rs
+++ b/encoding/value/value_type.rs
@@ -81,7 +81,7 @@ impl ValueType {
             ValueTypeCategory::Duration => Self::Duration,
             ValueTypeCategory::String => Self::String,
             ValueTypeCategory::Struct => {
-                let definition_key = DefinitionKey::new(Bytes::Array(ByteArray::copy(&tail)));
+                let definition_key = DefinitionKey::decode(Bytes::Array(ByteArray::copy(&tail)));
                 Self::Struct(definition_key)
             }
         }

--- a/function/function_manager.rs
+++ b/function/function_manager.rs
@@ -660,7 +660,7 @@ pub mod tests {
         "];
         let expected_name = "cat_names";
 
-        let expected_function_id = DefinitionKey::build(Prefix::DefinitionFunction, DefinitionID::build(0));
+        let expected_function_id = DefinitionKey::new(Prefix::DefinitionFunction, DefinitionID::new(0));
         let expected_signature = FunctionSignature::new(
             FunctionID::Schema(expected_function_id.clone()),
             vec![VariableCategory::Object],

--- a/function/function_manager.rs
+++ b/function/function_manager.rs
@@ -146,7 +146,7 @@ impl FunctionManager {
         for (function, definition) in zip(functions.iter(), definitions) {
             let index_key = NameToFunctionDefinitionIndex::build(function.name().as_str()).into_storage_key();
             let definition_key = &function.function_id;
-            snapshot.put_val(index_key.into_owned_array(), ByteArray::copy(definition_key.bytes()));
+            snapshot.put_val(index_key.into_owned_array(), ByteArray::copy(&definition_key.bytes()));
             snapshot.put_val(
                 definition_key.clone().into_storage_key().into_owned_array(),
                 FunctionDefinition::build_ref(definition.unparsed.as_str()).into_bytes().into_array(),
@@ -220,7 +220,7 @@ impl FunctionManager {
         for (function, definition) in zip(functions.iter(), [definition].iter()) {
             let index_key = NameToFunctionDefinitionIndex::build(function.name().as_str()).into_storage_key();
             let definition_key = &function.function_id;
-            snapshot.put_val(index_key.into_owned_array(), ByteArray::copy(definition_key.bytes()));
+            snapshot.put_val(index_key.into_owned_array(), ByteArray::copy(&definition_key.bytes()));
             snapshot.put_val(
                 definition_key.clone().into_storage_key().into_owned_array(),
                 FunctionDefinition::build_ref(definition.unparsed.as_str()).into_bytes().into_array(),
@@ -354,7 +354,7 @@ impl FunctionReader {
             )
             .collect_cloned_vec(|key, value| {
                 SchemaFunction::build(
-                    DefinitionKey::new(Bytes::Reference(key.bytes()).into_owned()),
+                    DefinitionKey::decode(Bytes::Reference(key.bytes()).into_owned()),
                     FunctionDefinition::new(Bytes::Reference(value).into_owned()),
                 )
                 .unwrap()
@@ -370,7 +370,7 @@ impl FunctionReader {
         let bytes_opt = snapshot
             .get(index_key.into_storage_key().as_reference(), StorageCounters::DISABLED)
             .map_err(|source| FunctionReadError::FunctionRetrieval { source })?;
-        Ok(bytes_opt.map(|bytes| DefinitionKey::new(Bytes::Array(bytes))))
+        Ok(bytes_opt.map(|bytes| DefinitionKey::decode(Bytes::Array(bytes))))
     }
 
     pub(crate) fn get_function(

--- a/ir/tests/pipeline.rs
+++ b/ir/tests/pipeline.rs
@@ -65,7 +65,7 @@ fn build_with_functions() {
         (VariableCategory::Value, VariableOptionality::Optional),
     ];
     let function_signature = FunctionSignature::new(
-        FunctionID::Schema(DefinitionKey::build(Prefix::DefinitionStruct, DefinitionID::build(1000))),
+        FunctionID::Schema(DefinitionKey::new(Prefix::DefinitionStruct, DefinitionID::new(1000))),
         function_argument_categories,
         function_return_categories,
         false,


### PR DESCRIPTION
## Implementation
Refactor `DefinitionKey` struct to hold Prefix & DefinitionID instead of raw bytes, in line with other stored objects.